### PR TITLE
docs: update zh-cn customisation guide

### DIFF
--- a/docs/CactbotCustomization.md
+++ b/docs/CactbotCustomization.md
@@ -186,7 +186,7 @@ and they don't expose a lot of knobs to tune.
 If you have particular things you want to change about the timeline bars that you can't,
 please feel free to submit a [github issue](https://github.com/OverlayPlugin/cactbot/issues/new/choose).
 
-**Warning**: cactbot makes no guarantees about preserving CSS backwards compatability.
+**Warning**: cactbot makes no guarantees about preserving CSS backwards compatibility.
 Future changes to cactbot may rearrange elements,
 change element names and classes,
 or change styling entirely.
@@ -388,7 +388,7 @@ The steps to override a timeline are:
     [ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt](../ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt)
     to `user/the_epic_of_alexander.txt`.
 
-1) Add a section to your user/raidboss.js file to override this.
+1) Add a section to your `user/raidboss.js` file to override this.
 
     Like adding a trigger, you add a section with the `zoneId`,
     along with `overrideTimelineFile: true`,
@@ -458,7 +458,7 @@ provide access to.
 
 ## Global Trigger File Imports
 
-User files are `eval`'d in JavaScript,
+User files are [`eval`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval)'d in JavaScript,
 and thus cannot `import` in the same way that built-in trigger files do.
 User javascript files have access to the following globals:
 

--- a/docs/zh-CN/CactbotCustomization.md
+++ b/docs/zh-CN/CactbotCustomization.md
@@ -1,51 +1,52 @@
-# Cactbot自定义教程
+# Cactbot 自定义教程
 
 🌎 [[English](../CactbotCustomization.md)] [**简体中文**] [[繁體中文](./zh-TW/CactbotCustomization.md)] [[한국어](../ko-KR/CactbotCustomization.md)]
 
-- [使用cactbot配置界面](#使用cactbot配置界面)
-- [通过cactbot配置界面改变触发器文本](#通过cactbot配置界面改变触发器文本)
+- [使用cactbot配置界面](#使用-cactbot-配置界面)
+- [通过cactbot配置界面改变触发器文本](#通过-cactbot-配置界面改变触发器文本)
 - [用户文件夹概览](#用户文件夹概览)
-- [设置您自己的用户文件夹](#设置您自己的用户文件夹)
+- [设置你自己的用户文件夹](#设置你自己的用户文件夹)
 - [样式自定义](#样式自定义)
-- [Raidboss触发器自定义](#raidboss触发器自定义)
+- [Raidboss触发器自定义](#raidboss-触发器自定义)
   - [例1：改变输出文本](#例1改变输出文本)
   - [例2：使挑衅提示适用于全职业](#例2使挑衅提示适用于全职业)
   - [例3：添加自定义触发器](#例3添加自定义触发器)
-- [Raidboss时间轴自定义](#raidboss时间轴自定义)
+- [Raidboss时间轴自定义](#raidboss-时间轴自定义)
 - [行为自定义](#行为自定义)
 - [用户文件的调试](#用户文件的调试)
-  - [检查OverlayPlugin的错误日志](#检查OverlayPlugin的错误日志)
+  - [检查OverlayPlugin的错误日志](#检查-overlayplugin-的错误日志)
   - [检查文件是否加载](#检查文件是否加载)
   - [检查文件是否有错误](#检查文件是否有错误)
 
-## 使用cactbot配置界面
+## 使用 Cactbot 配置界面
 
-自定义cactbot时，推荐使用cactbot的配置界面进行操作。该界面位于 ACT -> Plugins -> OverlayPlugin.dll -> Cactbot。
+自定义 Cactbot 时，推荐使用 Cactbot 的配置界面进行操作。该界面位于 ACT -> Plugins -> OverlayPlugin.dll -> Cactbot。
 
 它可以提供如下功能：
 
-- 设置触发器输出TTS
+- 设置触发器输出 TTS
 - 禁用触发器
-- 改变触发器输出
-- 改变cactbot语言
+- 改变触发器输出内容
+- 切换触发器输出玩家职业而非名字
+- 改变 Cactbot 语言
 - 音量设置
 - 隐藏奶酪图标
 
-您可能无法通过cactbot配置界面以配置所有您想要的更改。但这是所有自定义方式中最简单的，适合作为您开启定制化的第一步。 以后此界面会添加更多的选项。
+你可能无法通过 Cactbot 配置界面以配置所有你想要的更改。但这是所有自定义方式中最简单的，适合作为你开启定制化的第一步。 以后此界面会添加更多的选项。
 
-此处的选项会存储于 `%APPDATA%\Advanced Combat Tracker\Config\RainbowMage.OverlayPlugin.config.json` 文件中。但您并不需要也不应当直接修改该文件。
+此处的选项会存储于 `%APPDATA%\Advanced Combat Tracker\Config\RainbowMage.OverlayPlugin.config.json` 文件中。但你并不需要也不应当直接修改该文件。
 
-## 通过cactbot配置界面改变触发器文本
+## 通过 Cactbot 配置界面改变触发器文本
 
-在位于 ACT -> 插件 -> OverlayPlugin.dll -> Cactbot -> Raidboss 的 cactbot 配置界面中，罗列着所有的触发器。这里的列表让您可以更改每个触发器支持外部更改的配置设置。
+在位于 ACT -> 插件 -> OverlayPlugin.dll -> Cactbot -> Raidboss 的 Cactbot 配置界面中，罗列着所有的触发器。这里的列表让你可以更改每个触发器支持外部更改的配置设置。
 
-名称旁边带有铃铛 (🔔) 的设置项的触发器输出文本是可以被覆盖的。举个例子，假设有一个🔔onTarget字段，其文本为 `死刑点${player}`。 当某人接到死刑技能时，这个字符串将出现在屏幕上（或通过tts播报）。 `${player}` 参数由触发器动态设置。任何类似于 `${param}` 的字符串都是动态参数。
+名称旁边带有铃铛 (🔔) 的设置项的触发器输出文本是可以被覆盖的。举个例子，假设有一个🔔onTarget 字段，其文本为 `死刑点${player}`。 当某人接到死刑技能时，这个字符串将出现在屏幕上（或通过 TTS 播报）。 `${player}` 参数由触发器动态设置。任何类似于 `${param}` 的字符串都是动态参数。
 
-比如，您可以将这个文本更改为 `${player} 即将死亡！`。或者，也许您不关心谁是目标，那么您可以将其改为 `死刑` 以使文本更加简短。如果您想撤消自己的更改，只需清空文本框即可。
+比如，你可以将这个文本更改为 `${player} 即将死亡！`。或者，也许你不关心谁是目标，那么你可以将其改为 `死刑` 使文本更加简短。如果你想撤消自己的更改，只需清空文本框即可。
 
-但这个方式有一定的限制。例如，您无法更改逻辑；而且在大多数情况下，您无法使 `tts` 的播报内容与 `alarmText` 相区别、无法添加更多的参数。如果您想要对触发器做出更加复杂的覆盖操作，那么您需要查看 [Raidboss触发器自定义](#raidboss触发器自定义) 小节。
+但这个方式有一定的限制。例如，你无法更改逻辑；而且在大多数情况下，你无法使 `tts` 的播报内容与 `alarmText` 相区别、无法添加更多的参数。如果你想要对触发器做出更加复杂的覆盖操作，那么你需要查看 [Raidboss 触发器自定义](#raidboss-触发器自定义) 小节。
 
-每一个引用玩家的参数（通常称为 ${player} ，但不总是），都可以进一步修改输出文本：
+每一个引用玩家的参数（通常称为 `${player}` ，但不总是），都可以进一步修改输出文本：
 
 - `${player.job}`：职业缩写，例如 白魔
 - `${player.jobFull}`：职业全名，例如 白魔法师
@@ -54,45 +55,45 @@
 - `${player.nick}`：玩家的昵称/名，例如 吉田直树 （注：国服对于昵称和全名不做区分；国际服的昵称指代“first name”）
 - `${player.id}`：玩家的ID（用于测试），例如 1000485F
 
-当发生错误，或者玩家不在你的队伍中，或者使用了无效的后缀时，系统可能会退而使用默认昵称，以确保能够打印出相应的信息。
+当发生错误，或者玩家不在你的队伍中，或者使用了无效的后缀时，系统可能会回退至使用默认昵称，以确保能够打印出相应的信息。
 
-默认设置下，`${player}` 等同于 `${player.nick}`，但是你可以在 cactbot 配置界面的 raidboss 部分下的 “默认玩家代称” 选项来设置此默认值。
+默认设置下，`${player}` 等同于 `${player.nick}`，但是你可以在 Cactbot 配置界面的 Raidboss 部分下的 「默认玩家代称」 选项来设置此默认值。
 
 ## 用户文件夹概览
 
-若cactbot配置界面不存在您所需的选项，您可能需要考虑以用户文件覆盖的方式进行自定义。您需要编写JavaScript代码和CSS样式表，这意味着您可能需要掌握一点点编程知识。
+若 Cactbot 配置界面不存在你所需的选项，你可能需要考虑以用户文件覆盖的方式进行自定义。使用这种方法，你需要编写 JavaScript 代码和 CSS 样式表，这意味着你可能需要掌握一点点编程知识。
 
-Cactbot的设计哲学要求用户的任何自定义配置都应当存放于用户文件夹中。同时这也能防止您所做的更改在今后cactbot的更新中被覆盖失效。另外，目前您无法通过直接修改cactbot的文件应用您的更改，除非您了解如何构建您自己的项目。
+Cactbot 的设计哲学要求用户的任何自定义配置都应当存放于用户文件夹中。同时这也能防止你所做的更改在今后 Cactbot 的更新中被覆盖失效。另外，目前你无法通过直接修改 Cactbot 的文件应用你的更改，除非你了解如何构建你自己的项目。
 
-所有的cactbot模块都会从 [user/](../../user/) 文件夹加载用户设置。 `raidboss` 模块会加载 `user/raidboss.js` 与 `user/raidboss.css`，以及所有 `user/raidboss/` 目录及子目录下的任意 `.js` 和 `.css` 文件。(时间轴`.txt` 文件必须与引用它们的 `.js`文件放在同一个文件夹中。) 这些用户自定义文件将在cactbot自身加载完毕后加载，并可以覆盖对应的模块的设置。
+所有的 Cactbot 模块都会从 [user/](../../user/) 文件夹加载用户设置。 `raidboss` 模块会加载 `user/raidboss.js` 与 `user/raidboss.css`，以及所有 `user/raidboss/` 目录及子目录下的任意 `.js` 和 `.css` 文件。(时间轴`.txt` 文件必须与引用它们的 `.js`文件放在同一个文件夹中。) 这些用户自定义文件将在cactbot自身加载完毕后加载，并可以覆盖对应的模块的设置。
 
 与之类似，`oopsyraidsy` 模块会加载 `user/oopsyraidsy.js` 与 `user/oopsyraidsy.css`，以及 `user/oopsyraidsy/` 目录及子目录下的所有 `.js` 和 `.css` 文件。依此类推，每个模块都支持以此方式加载对应名称的自定义文件。
 
-cactbot将按照字母顺序优先加载user文件夹中的子文件夹里的文件，其次加载子文件夹外的文件。这就是为什么 `user/raidboss.js` 文件总是最后被加载并可以覆盖 `user/raidboss/` 文件夹中任何文件中的配置。例如，`user/alphascape/some_file.js` 先加载， `user/mystatic/some_file.js` 再加载，最后是 `user/raidboss.js` 加载。`.css` 文件自然也遵循同样的顺序。
+Cactbot 将按照字母顺序优先加载用户文件夹中的子文件夹里的文件，其次加载子文件夹外的文件。因此 `user/raidboss.js` 文件迟于 `user/raidboss/` 文件夹中任何文件加载，并可以覆盖后者中的配置。例如，`user/alphascape/some_file.js` 先加载， `user/mystatic/some_file.js` 再加载，最后是 `user/raidboss.js` 加载。`.css` 文件自然也遵循同样的顺序。
 
-在本文档中，“用户自定义js文件”指代以上两者。除了加载顺序以外，`user/raidboss.js` 和 `user/raidboss/some_file.js` 没有任何区别。同样地，“用户自定义css文件”同时指代 `user/radar.css` 和 `user/radar/some_file.css` 二者。用户文件夹中分出子目录是为了让触发器的分享和自定义配置更容易。
+在本文档中，「用户自定义 JS 文件」指代以上两者。除了加载顺序以外，`user/raidboss.js` 和 `user/raidboss/some_file.js` 没有任何区别。同样地，「用户自定义 CSS 文件」同时指代 `user/radar.css` 和 `user/radar/some_file.css` 二者。用户文件夹中分出子目录是为了让触发器的分享和自定义配置更容易。
 
 当开发者模式开启时，你可以从[调试信息](#检查文件是否加载)中得到更多关于加载顺序的信息。
 
-`user/` 文件夹中包含了一部分示例配置文件，您可以对其重命名并直接使用。如 [user/raidboss-example.js](../../user/raidboss-example.js) 文件可重命名为 `user/raidboss.js`，对其所做的更改将应用于 `raidboss` 模块。
+`user/` 文件夹中包含了一部分示例配置文件，你可以对其重命名并直接使用。如 [user/raidboss-example.js](../../user/raidboss-example.js) 文件可重命名为 `user/raidboss.js`，对其所做的更改将应用于 `raidboss` 模块。
 
-在修改了这些文件之后，单击ACT中OverlayPlugin插件页面对应悬浮窗设置中的“重载悬浮窗”按钮，即可应用更改。
+在修改了这些文件之后，单击 ACT 中 OverlayPlugin 插件页面对应悬浮窗设置中的「重载悬浮窗」按钮，即可应用更改。
 
-## 设置您自己的用户文件夹
+## 设置你自己的用户文件夹
 
-您可以通过cactbot配置界面设置用户文件夹：ACT -> Plugins -> OverlayPlugin.dll -> Cactbot -> cactbot用户文件夹。单击 `选择文件夹` 按钮，选择磁盘上的任意文件夹。
+你可以通过 Cactbot 配置界面设置用户文件夹：ACT -> Plugins -> OverlayPlugin.dll -> Cactbot -> Cactbot 用户文件夹。单击「选择文件夹」按钮，选择磁盘上的任意文件夹。
 
-如果没有选择，cactbot将自动选择其安装目录下的默认文件夹。
+如果没有选择，Cactbot 将自动选择其安装目录下的默认文件夹。
 
-建议您选择cactbot安装目录下的 `cactbot/user` 文件夹。 该文件夹通常为位于 `%APPDATA%\Advanced Combat Tracker\Plugins\cactbot-version\cactbot\user`。 有部分示例配置文件位于 [此文件夹](../../user) 下。
+建议你选择 Cactbot 安装目录下的 `cactbot/user` 文件夹。该文件夹通常为位于 `%APPDATA%\Advanced Combat Tracker\Plugins\cactbot-version\cactbot\user`。 有部分示例配置文件位于 [此文件夹](../../user) 下。
 
 ## 样式自定义
 
-用户自定义css文件可以对UI模块的位置、尺寸、颜色等进行自定义。可用的选择器可以通过阅览 `ui/<name>/<name>.css` 文件找到。
+用户自定义 CSS 文件可以对 UI 模块的位置、尺寸、颜色等进行自定义。可用的选择器可以通过阅览 `ui/<name>/<name>.css` 文件找到。
 
-例如您在 [ui/raidboss/raidboss.css](../../ui/raidboss/raidboss.css) 中，可发现诸如 `#popup-text-container` 与 `#timeline-container` 等选择器， 则您可以在 `user/raidboss.css` 中对其位置进行自定义。您可以在 `user/raidboss.css` 中或其他 `user/raidboss/` 下的 `.css` 中添加更多的样式。
+例如你在 [ui/raidboss/raidboss.css](../../ui/raidboss/raidboss.css) 中，可发现诸如 `#popup-text-container` 与 `#timeline-container` 等选择器，则你可以在 `user/raidboss.css` 中对其位置进行自定义。你可以在 `user/raidboss.css` 中或其他 `user/raidboss/` 下的 `.css` 中添加更多的样式。
 
-同样地，您可以在 `.info-text` 类中添加新的CSS规则，对信息文字的尺寸和颜色进行自定义。例如：
+同样地，你可以在 `.info-text` 类中添加新的CSS规则，对信息文字的尺寸和颜色进行自定义。例如：
 
 ```css
 .info-text {
@@ -101,25 +102,25 @@ cactbot将按照字母顺序优先加载user文件夹中的子文件夹里的文
 }
 ```
 
-简单地说，您可以认为cactbot会将用户文件中的CSS规则添加至内置CSS文件的末尾。因此，您需要注意 [CSS优先级规则](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity)，有时需要添加 `!important` 让您的规则可以强制覆盖。另一方面，您可能需要重置某些属性为默认的 `auto` 值。
+简单地说，你可以认为 Cactbot 会将用户文件中的 CSS 规则添加至内置 CSS 文件的末尾。因此，你需要注意 [CSS优先级规则](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity)，有时需要添加 `!important` 让你的规则可以强制覆盖。另一方面，你可能需要重置某些属性为默认的 `auto` 值。
 
-我们推荐使用 [Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools) 以调试CSS。您可以通过 ACT -> Plugins -> OverlayPlugin.dll -> 您的悬浮窗名字 -> 启动Debug工具 按钮以开启DevTools。
+我们推荐使用 [Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools) 以调试 CSS。你可以通过 ACT -> Plugins -> OverlayPlugin.dll -> 你的悬浮窗名字 -> 启动Debug工具 按钮以开启DevTools。
 
-**注意**：某些组件的自定义较为困难，甚至无法进行自定义，如时间轴的进度条等。原因是，这些组件属于自定义HTML元素，且没有开放外部配置的接口。如果您有特别的需求，但是不知道如何修改，您可以提出一个 [github issue](https://github.com/OverlayPlugin/cactbot/issues/new/choose)。
+**注意**：某些组件的自定义较为困难，甚至无法进行自定义，如时间轴的进度条等。原因是，这些组件属于自定义HTML元素，且没有开放外部配置的接口。如果你有特别的需求，但是不知道如何修改，你可以提出一个 [GitHub Issue](https://github.com/OverlayPlugin/cactbot/issues/new/choose)。
 
-**警告**：cactbot不保证CSS的向后兼容性。在以后的更改中，cactbot可能会重新组织网页结构，改变元素名称和类名称，甚至重构所有样式。因此，您需知晓您的自定义CSS有在将来出现问题的风险。
+**警告**：Cactbot 不保证 CSS 的向后兼容性。在以后的更改中，Cactbot 可能会重新组织网页结构，改变元素名称和类名称，甚至重构所有样式。因此，你需知晓你的自定义 CSS 有在将来出现问题的风险。
 
-## Raidboss触发器自定义
+## Raidboss 触发器自定义
 
-您可以通过用户自定义js文件(例如 `user/raidboss.js` 或 `user/raidboss/` 目录下的任意 `.js` 文件)自定义触发器行为。您可以修改输出文本、适用职业、文本显示的时间等等。
+你可以通过用户自定义 JS 文件 (例如 `user/raidboss.js` 或 `user/raidboss/` 目录下的任意 `.js` 文件) 自定义触发器行为。你可以修改输出文本、适用职业、文本显示的时间等等。
 
-您可以在[这个分支](https://github.com/OverlayPlugin/cactbot/tree/triggers)查看所有触发器的 JavaScript 版本。我们推荐您查看、拷贝并粘贴这个分支中的代码实现您自己的触发器。主分支（main）中的触发器代码基于 TypeScript 写成，无法直接在ACT或浏览器中运行；而发行版本中的代码经过了编译与混淆，对于人类来说难以阅读，因此不作推荐。
+你可以在 [这个分支](https://github.com/OverlayPlugin/cactbot/tree/triggers) 查看所有触发器的 JavaScript 版本。我们推荐你查看、拷贝并粘贴这个分支中的代码实现你自己的触发器。主分支（main）中的触发器代码基于 TypeScript 写成，无法直接在 ACT 或浏览器中运行；而发行版本中的代码经过了编译与混淆，对于人类来说难以阅读，因此不作推荐。
 
-在您的raidboss模块用户自定义js文件中，`Options.Triggers` 是一个存放了触发器集合的列表。您可以通过此变量添加新触发器，或修改已有的触发器。若用户文件中存在与现有触发器 (cactbot官方提供的) 相同id的触发器，则会将后者完全覆盖。
+在你的 Raidboss 模块用户自定义 JS 文件中，`Options.Triggers` 是一个存放了触发器集合的列表。你可以通过此变量添加新触发器，或修改已有的触发器。若用户文件中存在与现有触发器 (Cactbot 官方提供的) 相同id的触发器，则会将后者完全覆盖。
 
-在您修改触发器前，我们推荐您阅读[触发器指南](RaidbossGuide.md)以了解各触发器的诸多属性的含义。
+在你修改触发器前，我们推荐你阅读[触发器指南](RaidbossGuide.md)以了解各触发器的诸多属性的含义。
 
-一般来说，你需要将形如以下的代码块加入到你的用户自定义js文件(例如 `user/raidboss.js`)中：
+一般来说，你需要将形如以下的代码块加入到你的用户自定义 JS 文件(例如 `user/raidboss.js`)中：
 
 ```javascript
 Options.Triggers.push({
@@ -135,19 +136,19 @@ Options.Triggers.push({
 });
 ```
 
-最简单的定制触发器的方式是直接复制上面那一大块代码粘贴到此文件再进行修改。您可以修改 `zoneId` 一行为您想要触发器响应的区域id，通常位于cactbot触发器文件的顶部。[该文件](../../resources/zone_id.ts)中列出了所有可用的区域id。若您定义了错误的id，OverlayPlugin的日志窗口将会输出警告信息。然后[复制触发器文本](https://github.com/OverlayPlugin/cactbot/tree/triggers)并粘贴至此，按您的喜好进行修改。当你修改完成后，重载raidboss悬浮窗以应用更改。
+最简单的定制触发器的方式是直接复制上面那一大块代码粘贴到此文件再进行修改。你可以修改 `zoneId` 一行为你想要触发器响应的区域 ID，通常位于 Cactbot 触发器文件的顶部。[该文件](../../resources/zone_id.ts)中列出了所有可用的区域 ID。若你定义了错误的 ID，OverlayPlugin 的日志窗口将会输出警告信息。然后[复制触发器文本](https://github.com/OverlayPlugin/cactbot/tree/triggers)并粘贴至此，按你的喜好进行修改。当你修改完成后，重载Raidboss 悬浮窗以应用更改。
 
-**注意**：此方式会将原触发器完全移除，因此请在修改时不要删除任何逻辑代码。触发器均采用JavaScript编写，因此必须采用标准JavaScript语法。若您不是字面意义上的程序员，您需要格外注意这点。
+**注意**：此方式会将原触发器完全移除，因此请在修改时不要删除任何逻辑代码。触发器均采用 JavaScript 编写，因此必须采用标准 JavaScript 语法。若你不是字面意义上的程序员，你需要格外注意这点。
 
 ### 例1：改变输出文本
 
-假定您正在攻略巴哈姆特绝境战(UCOB)，但您的固定队采用的不是cactbot中默认的火1集合吃的打法，而是先单吃火1。此外，您*同时*还想让触发器通过tts播报与显示文本不同的内容。比如，您总是忘记出人群，因此您想让它重复播报数次。
+假定你正在攻略巴哈姆特绝境战(英语: The Unending Coil of Bahamut Ultimate 或简称 UCOB)，但你的固定队采用的不是 Cactbot 中默认的火 1 集合吃的打法，而是先单吃火 1 。此外，你*同时*还想让触发器通过 TTS 播报与显示文本不同的内容。比如，你总是忘记出人群，因此你想让它重复播报数次。
 
-若您只是想修改 `信息文本`，你可以 [通过cactbot配置界面改变触发器文本](#通过cactbot配置界面改变触发器文本) 实现。
+若你只是想修改 `信息文本`，你可以 [通过 Cactbot 配置界面改变触发器文本](#通过-cactbot-配置界面改变触发器文本) 实现。
 
-其中一种调整方式是编辑触发器的输出。您可以在 [ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js](https://github.com/OverlayPlugin/cactbot/blob/triggers/04-sb/ultimate/unending_coil_ultimate.js#:~:text=UCU%20Nael%20Fireball%201) 中找到原本的 fireball #1 触发器。
+其中一种调整方式是编辑触发器的输出。你可以在 [ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js](https://github.com/OverlayPlugin/cactbot/blob/triggers/04-sb/ultimate/unending_coil_ultimate.js#:~:text=UCU%20Nael%20Fireball%201) 中找到原本的 `fireball #1` 触发器。
 
-您需要将以下的代码粘贴至您的用户自定义js文件底部。
+你需要将以下的代码粘贴至你的用户自定义 JS 文件底部。
 
 ```javascript
 Options.Triggers.push({
@@ -179,11 +180,11 @@ Options.Triggers.push({
 
 ### 例2：使挑衅提示适用于全职业
 
-目前，只有团队成员的挑衅会触发提示，并且不是所有职业都能收到提示。该例子展示了如何使其适用于所有职业。挑衅触发器可以在 [ui/raidboss/data/00-misc/general.js](https://github.com/OverlayPlugin/cactbot/blob/triggers/00-misc/general.js#:~:text=General%20Provoke) 中找到。
+目前，只有同一队的成员的挑衅会触发提示，并且不是所有职业都能收到提示。该例子展示了如何使其适用于所有职业。挑衅触发器可以在 [ui/raidboss/data/00-misc/general.js](https://github.com/OverlayPlugin/cactbot/blob/triggers/00-misc/general.js#:~:text=General%20Provoke) 中找到。
 
-我们需要修改 `condition` 函数(function)。此处的id应当与内置的 `General Provoke` 触发器一致，才能正确覆盖同名的内置触发器。
+我们需要修改 `condition` 函数。此处的 `id` 应当与内置的 `General Provoke` 触发器一致，才能保证覆盖该内置触发器。
 
-您需要将以下的代码粘贴至您的用户自定义js文件底部。
+你需要将以下的代码粘贴至你的用户自定义 JS 文件底部。
 
 ```javascript
 Options.Triggers.push({
@@ -215,13 +216,13 @@ Options.Triggers.push({
 });
 ```
 
-当然，您也可以直接删除整个 `condition` 函数，毕竟没有condition的触发器在匹配到正则时永远会运行。
+当然，你也可以直接删除整个 `condition` 函数，毕竟没有条件判断的触发器在匹配到正则时永远会运行。
 
 ### 例3：添加自定义触发器
 
-您也可以用同样的办法添加您的自定义触发器。
+你也可以用同样的办法添加你的自定义触发器。
 
-这是一个示例触发器，当您中了“叉形闪电”效果时，会在1秒后显示“快出去!!!”。
+这是一个示例触发器，当你中了「叉形闪电」效果时，会在1秒后显示「快出去!!!」。
 
 ```javascript
 Options.Triggers.push([
@@ -237,7 +238,7 @@ Options.Triggers.push([
         alertText: '快出去!!!',
       },
 
-      // 您的其他触发器……
+      // 你的其他触发器……
     ],
   },
 
@@ -245,25 +246,25 @@ Options.Triggers.push([
 ]);
 ```
 
-我们推荐阅读 [触发器指南](RaidbossGuide.md) 以了解如何撰写cactbot的触发器，当然您也可以直接看 [ui/raidboss/data](../../ui/raidboss/data) 中现有的触发器代码。
+我们推荐阅读 [触发器指南](RaidbossGuide.md) 以了解如何撰写 Cactbot 的触发器，当然你也可以直接看 [ui/raidboss/data](../../ui/raidboss/data) 中现有的触发器代码。
 
-## Raidboss时间轴自定义
+## Raidboss 时间轴自定义
 
-一些自定义操作可以通过 [cactbot 配置界面](#使用cactbot配置界面) 实现。你可以在这个界面隐藏或重命名现有的时间轴条目，也可以添加自定义时间轴条目等。
+一些自定义操作可以通过 [Cactbot 配置界面](#使用-cactbot-配置界面) 实现。你可以在这个界面隐藏或重命名现有的时间轴条目，也可以添加自定义时间轴条目等。
 
-仅当你需要做的操作超出了配置界面所能提供的范围时才考虑使用本章节的操作，比如完全替换整个时间轴。替换时间轴的操作与 [替换触发器](#替换raidboss触发器) 类似。
+仅当你需要做的操作超出了配置界面所能提供的范围时才考虑使用本章节的操作，比如完全替换整个时间轴。替换时间轴的操作与 [替换触发器](#替换-raidboss-触发器) 类似。
 
 自定义时间轴的步骤如下：
 
-1) 复制原有的时间轴文本文件内容至您的用户文件夹
+1) 复制原有的时间轴文本文件内容至你的用户文件夹
 
-    例如，您可以复制
+    例如，你可以复制
     [ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt](../ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt)
     至 `user/the_epic_of_alexander.txt`。
 
-1) 在 user/raidboss.js 中添加代码
+1) 在 `user/raidboss.js` 中添加代码
 
-    如同我们添加触发器一样，您依旧需要定义 `zoneId`、 `overrideTimelineFile: true`，
+    如同我们添加触发器一样，你依旧需要定义 `zoneId`、 `overrideTimelineFile: true`，
     以及定义文本文件名称的 `timelineFile` 属性。
 
     ```javascript
@@ -274,11 +275,11 @@ Options.Triggers.push([
     });
     ```
 
-    （假设您已经做完了第一步，并且该文本文件的名称为 `user/the_epic_of_alexander.txt` ）
+    这里假设了你已经做完了第一步，并且该文本文件的名称为 `user/the_epic_of_alexander.txt`。
 
-    设置 `overrideTimelineFile: true` 是为了告诉cactbot将内置的时间轴完全替换为您添加的文件。
+    设置 `overrideTimelineFile: true` 是为了告诉cactbot将内置的时间轴完全替换为你添加的文件。
 
-1) 按您的喜好编辑您自己的时间轴文件
+1) 按你的喜好编辑你自己的时间轴文件
 
     阅读 [时间轴指南](TimelineGuide.md) 学习更多关于时间轴的知识。
 
@@ -286,11 +287,11 @@ Options.Triggers.push([
 
 ## 行为自定义
 
-这一文段将讨论自定义cactbot的其他方式。Cactbot中有一些不在配置界面显示，也不是触发器的变量。
+这一文段将讨论自定义 Cactbot 的其他方式。Cactbot中有一些不在配置界面显示，也不是触发器的变量。
 
-每个cactbot模块都有一个名为 `Options` 的变量，它包含了若干控制选项。可用的 `Options` 变量会在每个 `ui/<name>/<name>.js` 文件的顶部列出。
+每个 Cactbot 模块都有一个名为 `Options` 的变量，它包含了若干控制选项。可用的 `Options` 变量会在每个 `ui/<name>/<name>.js` 文件的顶部列出。
 
-例如在 [ui/raidboss/raidboss.js](../../ui/raidboss/raidboss.js) 文件中，您可以通过 `PlayerNicks` 选项定义玩家的昵称。
+例如在 [ui/raidboss/raidboss.js](../../ui/raidboss/raidboss.js) 文件中，你可以通过 `PlayerNicks` 选项定义玩家的昵称。
 
 ```javascript
 Options.PlayerNicks = {
@@ -311,12 +312,11 @@ Options.TransformTts = (text) => {
 };
 ```
 
-**警告**：用户文件夹中的文件会静默覆盖cactbot配置窗口的同名选项。 该行为可能会造成一些困惑，因此您应当直接通过配置窗口设置这些变量，当且仅当配置窗口不提供设置方法时可以采用此方式覆盖默认行为。
+**警告**：用户文件夹中的文件会静默覆盖cactbot配置窗口的同名选项。 该行为可能会造成一些困惑，因此你应当直接通过配置窗口设置这些变量，当且仅当配置窗口不提供设置方法时可以采用此方式覆盖默认行为。
 
 ## 触发器全局可用变量
 
-用户文件以 `eval` 的方式加载，因此无法像内置的触发器文件那样使用 import 语句。
-用户文件可以访问如下的变量：
+用户文件以 [`eval`](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/eval) 的方式加载，因此无法像内置的触发器文件那样使用 `import` 语句。但是在用户文件可以使用如下的全局变量：
 
 - [Conditions](../../resources/conditions.ts)
 - [ContentType](../../resources/content_type.ts)
@@ -330,25 +330,25 @@ Options.TransformTts = (text) => {
 
 ## 用户文件的调试
 
-### 检查OverlayPlugin的错误日志
+### 检查 OverlayPlugin 的错误日志
 
-您可以在 ACT -> Plugins -> OverlayPlugin.dll 找到位于该窗口的底部的OverlayPlugin日志窗口，它是一个自动滚动的文本窗口。
+你可以在 ACT -> Plugins -> OverlayPlugin.dll 找到位于该窗口的底部的 OverlayPlugin 日志窗口，它是一个自动滚动的文本窗口。
 
 当运行错误时，错误信息会显示在此处。
 
 ### 检查文件是否加载
 
-首先，您需要开启raidboss模块的调试模式。 打开cactbot配置窗口，启用 `显示开发者选项` ，然后重新加载悬浮窗。 然后，勾选raidboss模块下的 `启用调试模式`，再次重载悬浮窗。
+首先，你需要开启 Raidboss 模块的调试模式。打开 Cactbot 配置窗口，启用 `显示开发者选项` ，然后重新加载悬浮窗。然后，勾选 Raidboss 模块下的 `启用调试模式`，再次重载悬浮窗。
 
-当raidboss模块的调试模式启用时，OverlayPlugin的日志窗口中会打印更多信息。 每次本地的用户文件加载时都会输出类似于这样的信息： `[10/19/2020 6:18:27 PM] Info: raidbossy: BrowserConsole: local user file: C:\Users\tinipoutini\cactbot\user\raidboss.js`
+当 Raidboss 模块的调试模式启用时，OverlayPlugin 的日志窗口中会打印更多信息。每次本地的用户文件加载时都会输出类似于这样的信息：`[10/19/2020 6:18:27 PM] Info: raidbossy: BrowserConsole: local user file: C:\Users\tinipoutini\cactbot\user\raidboss.js`
 
-确认您的用户文件是否正常加载。
+确认你的用户文件是否正常加载。
 
 文件名的打印顺序就是它们的加载顺序。
 
 ### 检查文件是否有错误
 
-用户文件采用JavaScript编写，若代码语法本身有错误，日志窗口会输出错误，您的用户文件也会被跳过而不会被加载。 在文件加载时检查OverlayPlugin的错误日志。
+用户文件采用 JavaScript 编写，若代码语法本身有错误，日志窗口会输出错误，你的用户文件也会被跳过而不会被加载。在文件加载时检查 OverlayPlugin 的错误日志。
 
 此处有一个例子：
 


### PR DESCRIPTION
This is re-PR'ed from quisquous/cactbot#6052

------

This is the following up for quisquous/cactbot#6047 , also fix several typos in English version.


According to [Microsoft's localisation guide](https://learn.microsoft.com/en-us/globalization/localization/ministyleguides/mini-style-guide-sim-chinese) and [vinta's 盤古之白 convince](https://github.com/vinta/pangu.js), this PR do the following:

- Add missing lines in the previous PR.
- Replace all polite `您` to a normal `你`.
- Insert spaces between Chinese characters and western characters or symbols (the `Pangu`-ism).
- Captalize all English words, unless it has a special spell rule.

------

cc @Echoring @ShadyWhite 