### PR TITLE
docs: remove future work for highlight

### DIFF
--- a/docs/TimelineGuide.md
+++ b/docs/TimelineGuide.md
@@ -1213,7 +1213,6 @@ There's plenty of feature work and fixes for timelines if you are interested in 
 
 ### Smaller Fixes/Changes
 
-* update [Cactbot Highlight](https://marketplace.visualstudio.com/items?itemName=MaikoTan.cactbot-highlight) to include new `Ability { params }` style syncs
 * make it so you can pass multiple mob names to `-it`
 * `test_timeline.ts` could know which file to use without `-t` (it could use `ZoneChange` lines to look up the correct timeline)
 * `make_timeline.ts` has issues with empty names: <https://github.com/quisquous/cactbot/issues/5943>


### PR DESCRIPTION
Since it is implemented at https://github.com/MaikoTan/cactbot-highlight/pull/406 and released in version 0.6.0.

~~Please call me Sonic Maiko~~

Preview:
![image](https://github.com/OverlayPlugin/cactbot/assets/19927330/8ff773c3-2d5f-4fea-887d-8dffc6da8fa5)
