### PR TITLE
util: add analysis filter to log splitter

### DIFF
--- a/docs/TimelineGuide.md
+++ b/docs/TimelineGuide.md
@@ -695,28 +695,26 @@ The reason to build the ability table is:
 Personally, starting from the ability table and then working out from there
 is the best way to attack most new content.
 
-#### One Hacky Workflow Suggestion
+#### Using the log splitter to find useful/interesting ability lines
 
-This is a bit of a hacky workflow, but one way to build the ability table is to filter log lines
-down to the useful log lines.
+Cactbot's log-splitter utility includes an option to export a particular fight from a log
+and filter the included log lines so that only certain 'useful' lines are exported.
+This is primarily for analysis purposes while building timelines and triggers,
+and it can be useful in building the ability table.
 
-If you load the log into ACT, [view the logs](LogGuide.md#viewing-logs-after-a-fight), and then search by the following regex,
-you will get most of the "interesting" lines for a fight.
+Here, we can run the log splitter utility from the command line and pass the `-af` argument
+to turn on filtering.  From your cactbot directory, run the following command:
+`node --loader=ts-node/esm util/logtools/split_log.ts -f docs/logs/TheAbyssalFractureExtreme.log -lf 1 -af`
 
-![encounter logs screenshot](images/timelineguide_encounterlogs.png)
+Alternatively, you can use the web-based [log splitter](https://overlayplugin.github.io/cactbot/util/logtools/splitter.html) tool
+and check the option to filter the log for analysis.
 
-This includes boss abilities and casts, added combatants, tethers, map effects, head markers, and debuffs on players.
-It's not perfect, but it's a place to start.
+This filtering should limit the exported log lines to just boss abilities and casts, added combatants, tethers, 
+map effects, head markers, and debuffs applied to and removed from players. It's not perfect, but it's a place to start.
 
 You can then walk through a log with video, and look at which abilities hit players and do damage
 and which are castbars on the boss (not all `StartsUsing` are castbars) and then fill out the ability table
 and understand what everything is.
-
-```text
-( 1A:[^:]*:([^:]|: )*:[^:]*:[E4][^:]*:[^:]*:1| 1A:(B9A|808):| 03:| 23:| 101:| 1B:| 1[456]:4.......:(?!\w*-Egi|Liturgic Bell|Thancred|Moonstone Carbuncle|Zero(?!mus)|Alphinaud|Alisaie|Topaz Titan|Emerald Carbuncle|Eos|Rook Autoturret|Seraph|Bishop Autoturret|Ruby Carbuncle|Esteem|Demi-\w*|Earthly Star|Automaton Queen|Bunshin|Selene|Hien|Lyse|Pipin Of The Steel Heart|Yugiri Mistwalker|2B|Topaz Carbuncle|Y'shtola|Hythlodaeus|Emet-Selch|Venat|Krile|Estinien|Urianger|G'raha Tia|Carbuncle|Varshahn|Emerald Garuda|Ruby Ifrit|Bunshin|Earthly Star)[^:]*:(?!IGNOREIDSHERE)[^:]*:(?!Attack|attack))
-```
-
-TODO: This could be a lot better. We could add an option in the log splitter to output "interesting" lines.
 
 ### Using make_timeline.ts with fflogs
 
@@ -1214,7 +1212,6 @@ There's plenty of feature work and fixes for timelines if you are interested in 
 * `testsync` instead of comments (we use `#Ability { params }` to avoid sync issues, but it'd be nice to add a `testsync` command that verifies that the sync was hit in the window but does not resync for testing purposes)
 * handle multiple syncs at the same time: <https://github.com/quisquous/cactbot/issues/5479>
 * clean up old timelines to use `label` and `forcejump`
-* add some checkbox to the splitter code to only print out "interesting" lines (see: [hacky workflow](#one-hacky-workflow-suggestion))
 
 ### Ability Table
 

--- a/docs/TimelineGuide.md
+++ b/docs/TimelineGuide.md
@@ -709,7 +709,7 @@ to turn on filtering.  From your cactbot directory, run the following command:
 Alternatively, you can use the web-based [log splitter](https://overlayplugin.github.io/cactbot/util/logtools/splitter.html) tool
 and check the option to filter the log for analysis.
 
-This filtering should limit the exported log lines to just boss abilities and casts, added combatants, tethers, 
+This filtering should limit the exported log lines to just boss abilities and casts, added combatants, tethers,
 map effects, head markers, and debuffs applied to and removed from players. It's not perfect, but it's a place to start.
 
 You can then walk through a log with video, and look at which abilities hit players and do damage

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -30,6 +30,54 @@ type FightEncInfo = ZoneEncInfo & {
   inferredStartFromAbility?: boolean;
 };
 
+// Some NPCs can be picked up by our entry processor.
+// We list them out explicitly here so we can ignore them at will.
+export const ignoredCombatants = PetData['en'].concat([
+  '',
+  'Alisaie',
+  'Alisaie\'s Avatar',
+  'Alphinaud',
+  'Alphinaud\'s Avatar',
+  'Arenvald',
+  'Carbuncle',
+  'Carvallain',
+  'Crystal Exarch',
+  'Doman Liberator',
+  'Doman Shaman',
+  'Earthly Star',
+  'Emerald Carbuncle',
+  'Emerald Garuda',
+  'Estinien',
+  'Estinien\'s Avatar',
+  'G\'raha Tia',
+  'G\'raha Tia\'s Avatar',
+  'Gosetsu',
+  'Hien',
+  'Liturgic Bell',
+  'Lyse',
+  'Mikoto',
+  'Minfilia',
+  'Mol Youth',
+  'Moonstone Carbuncle',
+  'Obsidian Carbuncle',
+  'Raubahn',
+  'Resistance Fighter',
+  'Resistance Pikedancer',
+  'Ruby Carbuncle',
+  'Ruby Ifrit',
+  'Ryne',
+  'Thancred',
+  'Thancred\'s Avatar',
+  'Topaz Carbuncle',
+  'Topaz Titan',
+  'Urianger',
+  'Urianger\'s Avatar',
+  'Varshahn',
+  'Y\'shtola',
+  'Y\'shtola\'s Avatar',
+  'Yugiri',
+  'Zero',
+]);
 export class EncounterFinder {
   currentZone: ZoneEncInfo = {};
   currentFight: FightEncInfo = {};
@@ -54,55 +102,6 @@ export class EncounterFinder {
 
   sealRegexes: Array<CactbotBaseRegExp<'GameLog'>> = [];
   unsealRegexes: Array<CactbotBaseRegExp<'GameLog'>> = [];
-
-  // Some NPCs can be picked up by our entry processor.
-  // We list them out explicitly here so we can ignore them at will.
-  ignoredCombatants = PetData['en'].concat([
-    '',
-    'Alisaie',
-    'Alisaie\'s Avatar',
-    'Alphinaud',
-    'Alphinaud\'s Avatar',
-    'Arenvald',
-    'Carbuncle',
-    'Carvallain',
-    'Crystal Exarch',
-    'Doman Liberator',
-    'Doman Shaman',
-    'Earthly Star',
-    'Emerald Carbuncle',
-    'Emerald Garuda',
-    'Estinien',
-    'Estinien\'s Avatar',
-    'G\'raha Tia',
-    'G\'raha Tia\'s Avatar',
-    'Gosetsu',
-    'Hien',
-    'Liturgic Bell',
-    'Lyse',
-    'Mikoto',
-    'Minfilia',
-    'Mol Youth',
-    'Moonstone Carbuncle',
-    'Obsidian Carbuncle',
-    'Raubahn',
-    'Resistance Fighter',
-    'Resistance Pikedancer',
-    'Ruby Carbuncle',
-    'Ruby Ifrit',
-    'Ryne',
-    'Thancred',
-    'Thancred\'s Avatar',
-    'Topaz Carbuncle',
-    'Topaz Titan',
-    'Urianger',
-    'Urianger\'s Avatar',
-    'Varshahn',
-    'Y\'shtola',
-    'Y\'shtola\'s Avatar',
-    'Yugiri',
-    'Zero',
-  ]);
 
   initializeZone(): void {
     this.currentZone = {};
@@ -282,13 +281,13 @@ export class EncounterFinder {
         return;
       }
       const pAttack = this.regex.playerAttackingMob.exec(line);
-      if (pAttack?.groups && !this.ignoredCombatants.includes(pAttack.groups?.target)) {
+      if (pAttack?.groups && !ignoredCombatants.includes(pAttack.groups?.target)) {
         this.onStartFight(line, pAttack.groups, this.currentZone.zoneName);
         this.currentFight.inferredStartFromAbility = true;
         return;
       }
       const mAttack = this.regex.mobAttackingPlayer.exec(line);
-      if (mAttack?.groups && !this.ignoredCombatants.includes(mAttack.groups?.source)) {
+      if (mAttack?.groups && !ignoredCombatants.includes(mAttack.groups?.source)) {
         this.onStartFight(line, mAttack.groups, this.currentZone.zoneName);
         this.currentFight.inferredStartFromAbility = true;
         return;

--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -9,7 +9,7 @@ import { NetMatches } from '../../types/net_matches';
 
 import { LogUtilArgParse, TimelineArgs } from './arg_parser';
 import { printCollectedFights, printCollectedZones } from './encounter_printer';
-import { EncounterCollector, FightEncInfo, TLFuncs } from './encounter_tools';
+import { EncounterCollector, FightEncInfo, ignoredCombatants, TLFuncs } from './encounter_tools';
 import FFLogs from './fflogs';
 
 // TODO: Repeated abilities that need to be auto-commented may not get the comment marker
@@ -61,8 +61,6 @@ class ExtendedArgsRequired extends Namespace implements TimelineArgs {
 }
 
 type ExtendedArgs = Partial<ExtendedArgsRequired>;
-
-const ignoredCombatants = new EncounterCollector().ignoredCombatants;
 
 const timelineParse = new LogUtilArgParse();
 

--- a/util/logtools/splitter.html
+++ b/util/logtools/splitter.html
@@ -10,6 +10,10 @@
     <input id="anon" type="checkbox"></input>
     <span id="anon-label"></span>
   </label>
+  <label class="input-label" for="analysisFilter">
+    <input id="analysisFilter" type="checkbox"></input>
+    <span id="analysisFilter-label"></span>
+  </label>
 
   <button class="input-label" id="export" disabled></button>
 </div>

--- a/util/logtools/web_splitter.ts
+++ b/util/logtools/web_splitter.ts
@@ -26,6 +26,9 @@ const pageText = {
     de: 'Log Anonymisieren',
     cn: '对日志进行匿名化处理',
   },
+  analysisFilterInput: {
+    en: 'Filter Log for Analysis',
+  },
   exportInput: {
     en: 'Export',
     de: 'Export',
@@ -181,6 +184,7 @@ class PageState {
     public table: HTMLElement,
     public exportButton: HTMLButtonElement,
     public anonInput: HTMLInputElement,
+    public analysisFilterInput: HTMLInputElement,
     public errorDiv: HTMLElement,
   ) {}
 }
@@ -225,13 +229,20 @@ const doExport = (state: PageState): void => {
   const anonymizer = new Anonymizer();
 
   const anonymizeLogs = state.anonInput.checked;
+  const analysisFilter = state.analysisFilterInput.checked;
 
   for (const idx of selected) {
     const fight = idxToFight[idx];
     if (fight === undefined || fight.startLine === undefined || fight.endLine === undefined)
       continue;
 
-    const splitter = new Splitter(fight.startLine, fight.endLine, notifier, firstTime);
+    const splitter = new Splitter(
+      fight.startLine,
+      fight.endLine,
+      notifier,
+      firstTime,
+      analysisFilter,
+    );
     firstTime = false;
 
     // TODO: we could be smarter here and not loop every time through all lines
@@ -284,6 +295,7 @@ const onLoaded = () => {
   const exportOptions = getElement('export-options');
   const exportButton = getElement('export') as HTMLButtonElement;
   const anonCheckbox = getElement('anon') as HTMLInputElement;
+  const analysisFilterCheckbox = getElement('analysisFilter') as HTMLInputElement;
   const errorDiv = getElement('errors');
 
   const fileDropText: LocaleText = pageText.fileDropText;
@@ -298,6 +310,7 @@ const onLoaded = () => {
     table,
     exportButton,
     anonCheckbox,
+    analysisFilterCheckbox,
     errorDiv,
   );
   fileDrop.addEventListener('drop', (e) => {
@@ -306,6 +319,7 @@ const onLoaded = () => {
   });
 
   setLabelText('anon-label', 'anonInput', lang);
+  setLabelText('analysisFilter-label', 'analysisFilterInput', lang);
   setLabelText('export', 'exportInput', lang);
 
   exportButton.addEventListener('click', () => {


### PR DESCRIPTION
Adds a "Filter Log for Analysis" checkbox to the web splitter tool, and an `-af` | `--analysis-filter` argument to the `split_log` utility.  If this option is enabled, the log lines are run through a filter and only "useful"/"interesting" lines are emitted.

(I also added an `-na` | `--no-anonymize` argument to `split_log` to allow anonymization to be turned off -- it's on by default.  This was a TODO in the script already, and since I was already poking around, it made sense to kill two birds.)

The filter to determine whether a log line is useful/interesting should essentially mirror the regex that quisquous has previously shared and that's mentioned in the timeline guide, with one exception: I also added comparable LosesEffect (30) lines, since the loss of a debuff may also be interesting for timing reasons (particularly if it's removed by a mechanic before the duration expires).  However, I think reasonable minds can certainly differ on what log lines may be useful, so I'm open to feedback on adding to or pruning the list.  

Tested against a handful of logs and working as expected, but more testing always welcome.