### PR TITLE
docs: fix Log Guide typo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017-2023 https://github.com/OverlayPlugin/cactbot
+   Copyright 2017-2024 https://github.com/OverlayPlugin/cactbot
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docs/LogGuide.md
+++ b/docs/LogGuide.md
@@ -200,7 +200,7 @@ This guide was last updated for:
 
 ## Data Flow
 
-![Alt text](https://g.gravizo.com/source/data_flow?https%3A%2F%2Fraw.githubusercontent.com%OverlayPlugin%2Fcactbot%2Fmain%2Fdocs%2FLogGuide.md)
+![Alt text](https://g.gravizo.com/source/data_flow?https%3A%2F%2Fraw.githubusercontent.com%2FOverlayPlugin%2Fcactbot%2Fmain%2Fdocs%2FLogGuide.md)
 
 <details>
 <summary></summary>


### PR DESCRIPTION
fixes a URL typo introduced in #1 