### PR TITLE
ci: add npm compiler test to mocha

### DIFF
--- a/test/unittests/compile_test.ts
+++ b/test/unittests/compile_test.ts
@@ -1,0 +1,38 @@
+import assert from 'assert';
+import fs from 'fs';
+import path from 'path';
+
+import { exec } from '@actions/exec';
+
+const projectRoot = path.resolve('.');
+
+describe('compile test', () => {
+  afterEach(() => {
+    process.chdir(projectRoot);
+    fs.rmSync('dist', { recursive: true, force: true });
+  });
+
+  it('npm package should compile successfully', async function() {
+    // eslint-disable-next-line @typescript-eslint/no-invalid-this
+    this.timeout(30000); // allow a 30s timeout
+    let execError;
+    try {
+      process.chdir(projectRoot);
+      fs.rmSync('dist', { recursive: true, force: true });
+      let stdout = '';
+      let stderr = '';
+      await exec('npx ttsc --declaration', [], {
+        listeners: {
+          stdout: (data) => stdout += data.toString(), // suppress
+          stderr: (data) => stderr += data.toString(),
+        },
+      });
+      if (stderr.length > 0)
+        throw stderr;
+    } catch (err) {
+      console.error(err);
+      execError = err;
+    }
+    assert.ifError(execError);
+  });
+});

--- a/test/unittests/compile_test.ts
+++ b/test/unittests/compile_test.ts
@@ -15,24 +15,26 @@ describe('compile test', () => {
   it('npm package should compile successfully', async function() {
     // eslint-disable-next-line @typescript-eslint/no-invalid-this
     this.timeout(30000); // allow a 30s timeout
-    let execError;
+    let execError = false;
+    let output = '';
     try {
       process.chdir(projectRoot);
       fs.rmSync('dist', { recursive: true, force: true });
-      let stdout = '';
-      let stderr = '';
       await exec('npx ttsc --declaration', [], {
         listeners: {
-          stdout: (data) => stdout += data.toString(), // suppress
-          stderr: (data) => stderr += data.toString(),
+          stdout: (data) => output += data.toString(),
+          stderr: (data) => {
+            execError = true;
+            output += data.toString();
+          },
         },
       });
-      if (stderr.length > 0)
-        throw stderr;
+      if (execError)
+        throw output;
     } catch (err) {
       console.error(err);
-      execError = err;
+      execError = true;
     }
-    assert.ifError(execError);
+    assert(execError === false, output);
   });
 });


### PR DESCRIPTION
This adds a new unit test to mocha to run the `ttsc` compiler and check for compile errors.

This will resolve the issue that came up during the last version bump (see [here](https://github.com/OverlayPlugin/cactbot/actions/runs/7565591888/job/20621874132)), where an earlier PR was successfully merged without any workflow errors during PR checks or merging, but a new TS error appeared in the `release.yml` workflow when `ttsc` attempted to compile and publish the npm package.

Tested locally with `npm test` and also in my fork against both routine and breaking PRs, and confirmed that the `test.yml` workflow is working as expected.


