### PR TITLE
util: fix collision handling in gen_zone script

### DIFF
--- a/util/gen_zone_id_and_info.ts
+++ b/util/gen_zone_id_and_info.ts
@@ -481,6 +481,10 @@ const generateZoneIdMap = (
             nameMap[zoneName] ?? ''
           }). Please investigate.`,
         );
+        // remove any ttid->cfcid mapping previously stored, as it's now an unknown collision
+        const firstTtId = nameMap[zoneName];
+        if (typeof firstTtId === 'number')
+          delete finalTtIdToCfcId[firstTtId];
       } else {
         log.debug(`Found expected/known collision for ${zoneName} (ID: $[ttId})`);
       }


### PR DESCRIPTION
Closes #47.

I opted for the safer approach of not writing any zone info for an unknown conflict rather than trying to resolve the collision using CFC.  It's strange that this type of conflict (duplicate TTs, tied to the same CFC entry that points back to just one TT) does not show up anywhere else in these data sets, but I don't think it's wise to infer a resolution if this happens again, at least not without investigating it first.  So going forward, no zone id or zone info will be written, but the alert will still appear in the console advising that investigation is needed.

Tested against the 6.55 pre-override data to confirm this will handle this sort of collision correctly, and re-ran the script to make sure there's no impact to existing data.