### PR TITLE
raidboss: fix shrinking timeline issue

### DIFF
--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -369,6 +369,7 @@ export class Timeline {
       window.clearTimeout(keepAlive.timeout);
       this.ui?.OnRemoveTimer(keepAlive.event, false);
     }
+    this.keepAliveEvents = [];
   }
 
   private _ClearExceptRunningDurationTimers(fightNow: number): void {


### PR DESCRIPTION
Closes #58.

Behavior/repro is described in the linked issue, but the cause appears to be that `keepAliveEvents[]` (which contains only those entries which are passed their sync time but have an extended `duration` and are still being shown) is not emptied when `_Stop()` -> `_ClearTimers()` is called after a wipe or jump 0.  As a result, a timeline slot is "reserved" for the defunct keepAlive event on the next timeline start, even though it shouldn't be (and even though nothing is displayed in the ui).  Repeating the repro steps causes `keepAliveEvents[]` to accumulate multiple ghost entries, which is why the timeline continues to shrink each time the bug conditions are satisfied.

`_ClearTimers()` is only called by `_Stop()`, so this shouldn't have any unanticipated side effects. 
