### PR TITLE
ci: add workflow linter

### DIFF
--- a/.github/scripts/lint-workflow.cjs
+++ b/.github/scripts/lint-workflow.cjs
@@ -1,0 +1,269 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+// This linter script checks the format of a given GitHub workflow file
+// to ensure it conforms to the format below (esp. newlines and spacing).
+// --- WORKFLOW FILE FORMAT: ---
+// name: <workflow name>
+//
+// on:
+//   ...
+//     ...
+//
+// jobs:
+//   job1_name:
+//     ...
+//     steps:
+//       - step1: ...
+//
+//       - [step2, etc.]
+//
+//   [job2_name:]
+//     ...
+//
+
+const workflowDir = path.join(__dirname, '..', 'workflows');
+const fileExts = ['.yml', '.yaml'];
+
+let ghErrOutput = '';
+let currFile = '';
+let foundError = false;
+let fileErrors = [];
+
+const logError = (line, col, msg) => {
+  // Format error message for GitHub Actions output
+  // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
+  const errStr =
+    `::error file=.\\github\\workflows\\${currFile},line=${line},col=${col}::${line}:${col} ${msg}`;
+  fileErrors.push(errStr);
+};
+
+const processFileErrors = () => {
+  if (fileErrors.length > 0) {
+    foundError = true;
+
+    ghErrOutput += `::group::.\\.github\\workflows\\${currFile}\n`;
+    fileErrors.forEach((err) => {
+      ghErrOutput += `${err}\n`;
+    });
+    ghErrOutput += '::endgroup::\n';
+
+    console.log(`Found ${fileErrors.length} errors in ${currFile}.`);
+  }
+  fileErrors = [];
+};
+
+const parseFile = (file) => {
+  let lineNum = 0;
+  let loopState = 'start';
+  let fatalError = false;
+  fs.readFileSync(file, 'utf8').split('\r\n').forEach((line) => {
+    ++lineNum;
+
+    // If we've hit a really bad error, don't process further lines; just finish the loop.
+    if (fatalError)
+      return;
+
+    // If we have a line that consists only of whitespace, throw an error, but then treat it
+    // like an empty line and continue processing.
+    if (line.length > 0 && line.trim().length === 0) {
+      logError(lineNum, 1, 'Line consists only of whitespace characters and should be trimmed.');
+      line = '';
+    }
+
+    // Ignore comment lines.
+    if (line.trim().match(/^#/))
+      return;
+
+    // Check first three lines, which should be in a fixed format for every workflow file
+    if (loopState === 'start') {
+      if (lineNum === 1) {
+        if (!line.match(/^name: [\w\s-]+$/))
+          logError(lineNum, 1, 'Workflow name is missing or malformed.');
+      } else if (lineNum === 2) {
+        if (line !== '')
+          logError(lineNum, 1, `Must have empty line following workflow name.`);
+        if (line.match(/^on:$/))
+          loopState = 'on';
+      } else if (lineNum === 3) {
+        if (!line.match(/^on:$/))
+          logError(lineNum, 1, 'on: heading is missing or malformed.');
+        loopState = 'on';
+      } else {
+        logError(lineNum, 1, 'Did not find on: block in expected place, and cannot continue.');
+        fatalError = false;
+      }
+      return;
+    }
+
+    // The on: block can have varying levels of indentation and hyphens, so we can't
+    // apply the same logic that we do to checking spacing and flow in the jobs: block.
+    // We're going to let yamllint and actionlint handle this block, and just look for
+    // a blank line before the beginning of the jobs: block.
+    if (loopState === 'on') {
+      if (line.match(/^ {2}/)) // ignore any indented lines
+        return;
+      else if (line === '') {
+        loopState = 'jobs';
+        return;
+      } else if (line.match(/^jobs:/)) {
+        logError(lineNum, 1, 'Must have empty line following on: block.');
+        loopState = 'jobs'; // don't return; we want to process the jobs: header below
+      } else {
+        logError(
+          lineNum,
+          1,
+          'Could not find jobs: heading immediately after on: block.  Cannot continue.',
+        );
+        fatalError = false;
+        return;
+      }
+    }
+
+    // We're first going to handle end-of-step, which was triggered by a newline
+    // after a step in a job block. Depending on what this line is, we'll set the
+    // loop state and proceed with normal processing below, or throw an error.
+    if (loopState === 'end-of-step') {
+      if (line.match(/^ {2}[\w]/))
+        loopState = 'job-name';
+      else if (line.match(/^ {6}- [\w]/))
+        loopState = 'step-name';
+      else if (line === '') {
+        logError(lineNum, 1, 'Too many sequential blank lines.');
+        return;
+      } else {
+        logError(lineNum, 1, 'Unexpected line found after step details block.  Cannot continue.');
+        fatalError = true;
+        return;
+      }
+    }
+
+    // Now that we're in the jobs: block, we can apply some logic to check for spacing and flow.
+    if (line.match(/^jobs:/) || loopState === 'jobs') {
+      if (loopState !== 'jobs') // we got here, but not right after an on: block
+        logError(lineNum, 1, 'jobs: section is not in expected location after on: section.');
+      if (!line.match(/^jobs:$/))
+        logError(lineNum, 6, 'Found trailing characters or whitespace after jobs:');
+      loopState = 'job-name';
+      return;
+    }
+
+    // Fallback for job-name to keep flow control, even if we got here unexpectedly.
+    // But don't return, just process as job-name below.
+    if (line.match(/^ {2}[\w]/) && loopState !== 'job-name') {
+      if (loopState === 'step-detail')
+        logError(lineNum, 3, 'Must have empty line between job definitions.');
+      else
+        logError(lineNum, 3, 'Unexpected job definition found.');
+      loopState = 'job-name';
+    }
+
+    // In job-name, we're only looking for a properly formatted job name.
+    // Anything else, we'll throw an error.
+    if (loopState === 'job-name') {
+      if (line === '')
+        logError(lineNum, 1, 'Empty line found; job name expected.');
+      if (line.match(/^ {2}[\w]/)) {
+        if (!line.match(/^ {2}[\w-]+:$/))
+          logError(lineNum, 3, 'Improperly formatted job name, or whitespace found.');
+        loopState = 'job-detail';
+      } else {
+        logError(lineNum, 1, 'Did not find expected job name.  Cannot continue.');
+        fatalError = true;
+      }
+      return;
+    }
+
+    // Fallback for steps to keep flow control, even if we got here unexpectedly.
+    // But don't return, just process as job-detail below.
+    if (line.match(/^ {4}steps:/) && loopState !== 'job-detail') {
+      logError(lineNum, 5, 'Unexpected steps: header found; not within a job: block.');
+      loopState = 'job-detail';
+    }
+
+    // In job-detail, we'll allow any level of indentation (yamllint and actionlint will complain
+    // if something isn't right). We'll keep looking until we find 'steps:', and if we find an
+    // empty line first, we'll throw an error.
+    if (loopState === 'job-detail') {
+      if (line === '')
+        logError(lineNum, 1, 'Empty line found before job steps: block.');
+      else if (line.match(/^ {4}steps:/)) {
+        if (!line.match(/^ {4}steps:$/))
+          logError(lineNum, 5, 'Improperly formatted steps: header, or trailing whitespace found.');
+        loopState = 'step-name';
+      } else if (line.match(/^ {4}[\w\s-]/)) {
+        return; // ignore job details
+      } else {
+        logError(lineNum, 1, 'Unexpected line found in job details block.  Cannot continue.');
+        fatalError = true;
+      }
+      return;
+    }
+
+    // In step-name, we're only looking for a properly formatted step name/action.
+    // Anything else, we'll throw an error.
+    if (loopState === 'step-name') {
+      if (line === '')
+        logError(lineNum, 1, 'Empty line found; step expected.');
+      if (line.match(/^ {6}- [\w]/)) {
+        if (!line.match(/^ {6}- [\w-]+: /))
+          logError(lineNum, 7, 'Improperly formatted step.');
+        loopState = 'step-detail';
+      } else {
+        logError(lineNum, 1, 'Did not find expected step.  Cannot continue.');
+        fatalError = true;
+      }
+      return;
+    }
+
+    // In step-detail, we'll accept 2+ indentation from the step, or a newline.
+    // Anything else, we'll throw an error.
+    if (loopState === 'step-detail') {
+      if (line === '')
+        loopState = 'end-of-step';
+      else if (line.match(/^ {8}[\w\s]/)) {
+        if (!line.match(/^ {8}[\w\s-]+/))
+          logError(lineNum, 9, 'Improperly formatted step details.');
+      } else if (line.match(/^ {6}- [\w]/)) {
+        // process this like a new step, but don't change loopState
+        // just continue the loop as if we're now in step-detail
+        logError(lineNum, 7, 'New step must be preceded by an empty line.');
+        if (!line.match(/^ {6}- [\w-]+: /))
+          logError(lineNum, 7, 'Improperly formatted step.');
+      } else {
+        logError(lineNum, 1, 'Unexpected line found in step details block.  Cannot continue.');
+        fatalError = true;
+      }
+      return;
+    }
+
+    // Should never reach this point, but if we do, throw an error and set fatalError.
+    logError(lineNum, 1, 'Reached end of parsing steps unexpectedly.  Something went wrong.');
+    fatalError = true;
+  });
+};
+
+const main = () => {
+  console.log('Starting lint-workflow...');
+  fs.readdirSync(workflowDir).forEach((file) => {
+    currFile = file;
+    if (fileExts.includes(path.extname(file).toLowerCase())) {
+      console.log(`Processing ${file}...`);
+      parseFile(path.join(workflowDir, file));
+      processFileErrors();
+      console.log(`Finished processing ${file}.`);
+    } else
+      console.log(`Skipping ${file}...`);
+  });
+
+  if (foundError) {
+    console.log(ghErrOutput);
+    console.log('Errors found in workflow files.');
+    process.exit(-1);
+  } else {
+    console.log('No errors found in workflow files.');
+  }
+};
+
+void main();

--- a/.github/scripts/lint-workflow.cjs
+++ b/.github/scripts/lint-workflow.cjs
@@ -99,11 +99,11 @@ const parseFile = (file) => {
         logError(lineNum, 1, `Must have empty line following workflow name.`);
       loopState = 'on';
       if (!line.match(/^on:/)) // if this is the on: block, continue processing; otherwise return
-        return; 
+        return;
     }
     if (loopState === 'on') {
       if (!line.match(/^on:$/))
-          logError(lineNum, 1, 'on: heading is missing or malformed.');
+        logError(lineNum, 1, 'on: heading is missing or malformed.');
       loopState = 'on-block';
       return;
     }

--- a/.github/scripts/lint-workflow.cjs
+++ b/.github/scripts/lint-workflow.cjs
@@ -92,7 +92,7 @@ const parseFile = (file) => {
         loopState = 'on';
       } else {
         logError(lineNum, 1, 'Did not find on: block in expected place, and cannot continue.');
-        fatalError = false;
+        fatalError = true;
       }
       return;
     }
@@ -111,12 +111,8 @@ const parseFile = (file) => {
         logError(lineNum, 1, 'Must have empty line following on: block.');
         loopState = 'jobs'; // don't return; we want to process the jobs: header below
       } else {
-        logError(
-          lineNum,
-          1,
-          'Could not find jobs: heading immediately after on: block.  Cannot continue.',
-        );
-        fatalError = false;
+        logError(lineNum, 1, 'Expected jobs: header after on: block.  Cannot continue.');
+        fatalError = true;
         return;
       }
     }

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -30,15 +30,15 @@ on:
 jobs:
   msbuild:
     runs-on: windows-latest
-
     steps:
       - uses: actions/checkout@v3
+
       - uses: ./.github/actions/setup-js-env
 
       - name: Set artifact name
         shell: bash
         run: |
-          sha=$(echo ${{ github.sha }} | cut -c 1-8)
+          sha=$(echo "${{ github.sha }}" | cut -c 1-8)
           echo "artifact_sha=$sha" >> $GITHUB_ENV
 
       - name: Check dependencies cache
@@ -46,7 +46,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./plugin/ThirdParty
-          key: ${{ runner.os }}-cactbot-${{ hashFiles('./util/fetch_deps.ts', './util/DEPS.json5') }}
+          key: |
+            ${{ runner.os }}-cactbot-${{ hashFiles('./util/fetch_deps.ts', './util/DEPS.json5') }}
           restore-keys: |
             ${{ runner.os }}-cactbot-
 

--- a/.github/workflows/css-lint.yml
+++ b/.github/workflows/css-lint.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - uses: ./.github/actions/setup-js-env
 
       - name: Add Custom Problem Matcher

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - uses: ./.github/actions/setup-js-env
 
       - name: TypeScript checking

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -2,7 +2,7 @@ name: Auto Label
 
 on:
   pull_request_target:
-    types: [ opened, synchronize ]
+    types: [opened, synchronize]
 
 jobs:
   main:
@@ -13,6 +13,7 @@ jobs:
           # force to ci checkout main repo to avoid
           # unexpected PR code to be executed with out github token
           ref: main
+
       - uses: ./.github/actions/setup-js-env
 
       - name: Run Label Script

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -2,7 +2,7 @@ name: Lint PR Title
 
 on:
   pull_request_target:
-    types: [ edited, opened, reopened, synchronize ]
+    types: [edited, opened, reopened, synchronize]
 
 jobs:
   main:
@@ -13,6 +13,7 @@ jobs:
           # force to ci checkout main repo to avoid
           # unexpected PR code to be executed with out github token
           ref: main
+
       - uses: ./.github/actions/setup-js-env
 
       - name: Run Lint Script

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - uses: ./.github/actions/setup-js-env
 
       - name: Add Custom Problem Matcher

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -29,9 +29,9 @@ jobs:
         run: |
           pip install -r requirements.txt
 
-      - name: black **/*.py --line-length 100 --check --diff
+      - name: Run black
         run: |
-          black **/*.py --line-length 100 --check --diff
+          black --line-length 100 --check --diff -- **/*.py
 
   pylint:
     runs-on: ubuntu-latest
@@ -51,6 +51,6 @@ jobs:
         run: |
           pip install -r requirements.txt
 
-      - name: pylint **/*.py --errors-only
+      - name: Run pylint
         run: |
-          pylint **/*.py --errors-only
+          pylint --errors-only -- **/*.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,13 @@ jobs:
           if [ "${{ steps.get_version.outputs.version }}" == "" ]; then
             echo "Error: Unable to determine version from package.json"
             exit 1
-          elif [ $(git tag -l "v${{ steps.get_version.outputs.version }}") ]; then
-              echo "No version bump - ${{ steps.get_version.outputs.version }}.  Skipping remaining jobs..."
+          elif [ "$(git tag -l 'v${{ steps.get_version.outputs.version }}')" ]; then
+              echo "No version bump - ${{ steps.get_version.outputs.version }}."
+              echo "do_release=false" >> $GITHUB_OUTPUT
+              echo "Skipping remaining jobs."
           else
               echo "Version bump detected - ${{ steps.get_version.outputs.version }}"
-              echo "::set-output name=do_release::true"
+              echo "do_release=true" >> $GITHUB_OUTPUT
           fi
 
   validate_versions:
@@ -45,7 +47,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - uses: ./.github/actions/setup-js-env
+
       - name: Validate AssemblyInfo Versions
         run: |
           npm run validate-versions
@@ -53,7 +57,9 @@ jobs:
   create_release:
     runs-on: windows-latest
     needs: [validate_tag, validate_versions]
-    if: ${{ github.repository == 'OverlayPlugin/cactbot' && needs.validate_tag.outputs.do_release == 'true' }}
+    if: |
+      github.repository == 'OverlayPlugin/cactbot' &&
+      needs.validate_tag.outputs.do_release == 'true'
     env:
       GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
     steps:
@@ -72,7 +78,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./plugin/ThirdParty
-          key: ${{ runner.os }}-cactbot-${{ hashFiles('./util/fetch_deps.ts', './util/DEPS.json5') }}
+          key: |
+            ${{ runner.os }}-cactbot-${{ hashFiles('./util/fetch_deps.ts',
+            './util/DEPS.json5') }}
           restore-keys: |
             ${{ runner.os }}-cactbot-
 
@@ -115,6 +123,7 @@ jobs:
 
       - name: Set Release Attributes
         id: set_attributes
+        # Using pwsh, so output must be sent to $env:GITHUB_OUTPUT instead of $GITHUB_OUTPUT
         shell: pwsh
         run: |
           $release_name = "${{ needs.validate_tag.outputs.version }}";
@@ -128,8 +137,8 @@ jobs:
           }
           echo "Release Name: $release_name";
           echo "Release as Draft: $release_draft";
-          echo "::set-output name=release_name::$release_name"
-          echo "::set-output name=release_draft::$release_draft"
+          echo "release_name=$release_name" >> $env:GITHUB_OUTPUT
+          echo "release_draft=$release_draft" >> $env:GITHUB_OUTPUT
 
       - name: Create Release
         uses: ncipollo/release-action@v1
@@ -148,6 +157,7 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+
       - uses: ./.github/actions/setup-js-env
 
       - run: node .github/scripts/npm-package.cjs

--- a/.github/workflows/test-sync-files.yml
+++ b/.github/workflows/test-sync-files.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - uses: ./.github/actions/setup-js-env
 
       - name: npm run sync-files

--- a/.github/workflows/test-validate-versions.yml
+++ b/.github/workflows/test-validate-versions.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - uses: ./.github/actions/setup-js-env
 
       - name: npm run validate-versions

--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -2,7 +2,7 @@ name: Update gh-pages
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   check-gh-pages:
@@ -16,24 +16,27 @@ jobs:
         run: |
           GITHUB_URL="https://github.com/${{ github.repository }}"
           if git ls-remote --exit-code --heads $GITHUB_URL gh-pages; then
-            echo "::set-output name=found::true"
+            echo "found=true" >> $GITHUB_OUTPUT
             echo "gh-pages branch found. Updating..."
           else
-            echo "::set-output name=found::false"
+            echo "found=false" >> $GITHUB_OUTPUT
             echo "gh-pages branch not found. Skipping..."
           fi
+
   update-gh-pages:
     runs-on: ubuntu-latest
     needs: check-gh-pages
     if: needs.check-gh-pages.outputs.found == 'true'
     steps:
       - uses: actions/checkout@v3
+
       - uses: ./.github/actions/setup-js-env
 
       - name: Build
         run: |
           npm run coverage-report
           npm run build-gh-pages
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/update-triggers-branch.yml
+++ b/.github/workflows/update-triggers-branch.yml
@@ -1,7 +1,8 @@
 name: Update triggers
+
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   check-triggers:
@@ -15,12 +16,13 @@ jobs:
         run: |
           GITHUB_URL="https://github.com/${{ github.repository }}"
           if git ls-remote --exit-code --heads $GITHUB_URL triggers; then
-            echo "::set-output name=found::true"
+            echo "found=true" >> $GITHUB_OUTPUT
             echo "triggers branch found. Updating..."
           else
-            echo "::set-output name=found::false"
+            echo "found=false" >> $GITHUB_OUTPUT
             echo "triggers branch not found. Skipping..."
           fi
+
   update-triggers:
     runs-on: ubuntu-latest
     needs: check-triggers
@@ -33,6 +35,7 @@ jobs:
       - name: Build
         run: |
           npm run process-triggers
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,49 @@
+name: Workflow Lint
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '*.yml'
+      - '.github/workflows/*.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '*.yml'
+      - '.github/workflows/*.yml'
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install yamllint
+        run: |
+          pip install yamllint
+
+      - name: Run yamllint
+        run: |
+          yamllint -c .yamllint.yml -f github .
+
+      - name: Run workflow lint script
+        run: |
+          node .github/scripts/lint-workflow.cjs
+        env:
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+
+      - name: Download actionlint
+        id: get_actionlint
+        run: |
+          bash <(curl \
+          https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+
+      - name: Run actionlint
+        run: |
+          ${{ steps.get_actionlint.outputs.executable }} \
+          -ignore 'SC2086:' \
+          -color
+        shell: bash

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Run yamllint
         run: |
-          yamllint -c .yamllint.yml -f github .
+          yamllint -c .yamllint.yml -f github .github/workflows
 
       - name: Run workflow lint script
         run: |

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -34,16 +34,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}
 
-      - name: Download actionlint
-        id: get_actionlint
-        run: |
-          bash <(curl \
-          https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-        shell: bash
-
       - name: Run actionlint
-        run: |
-          ${{ steps.get_actionlint.outputs.executable }} \
-          -ignore 'SC2086:' \
-          -color
-        shell: bash
+        uses: docker://rhysd/actionlint:latest
+        env:
+          SHELLCHECK_OPTS: --exclude=SC2086
+        with:
+          args: -color

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,28 @@
+extends: default
+
+locale: en_US.UTF-8
+
+ignore: node_modules/
+
+rules:
+  braces:
+    max-spaces-inside: 1 # don't complain about Github Actions syntax
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: enable
+  document-end: disable
+  document-start: disable
+  empty-lines:
+    max: 1
+    max-end: 1
+  indentation:
+    spaces: 2
+  key-ordering: disable
+  line-length:
+    max: 100
+    allow-non-breakable-inline-mappings: true
+  new-line-at-end-of-file: enable
+  new-lines:
+    type: dos
+  trailing-spaces: enable
+  truthy: disable

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -2,8 +2,6 @@ extends: default
 
 locale: en_US.UTF-8
 
-ignore: node_modules/
-
 rules:
   braces:
     max-spaces-inside: 1 # don't complain about Github Actions syntax

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "stylelint": "stylelint \"resources/**/*.css\" \"ui/**/*.css\" \"user/**/*.css\" \"test/**/*.css\" \"util/**/*.css\"",
     "stylelintfix": "stylelint --fix \"resources/**/*.css\" \"ui/**/*.css\" \"user/**/*.css\" \"test/**/*.css\" \"util/**/*.css\"",
     "markdownlint": "markdownlint . --ignore node_modules --ignore publish --ignore plugin/ThirdParty",
+    "workflowlint": "yamllint -c .yamllint.yml . && node .github/scripts/lint-workflow.cjs",
     "test": "mocha",
     "sync-files": "node --loader=ts-node/esm util/sync_files.ts && git diff --exit-code",
     "lint-staged": "lint-staged",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "stylelint": "stylelint \"resources/**/*.css\" \"ui/**/*.css\" \"user/**/*.css\" \"test/**/*.css\" \"util/**/*.css\"",
     "stylelintfix": "stylelint --fix \"resources/**/*.css\" \"ui/**/*.css\" \"user/**/*.css\" \"test/**/*.css\" \"util/**/*.css\"",
     "markdownlint": "markdownlint . --ignore node_modules --ignore publish --ignore plugin/ThirdParty",
-    "workflowlint": "yamllint -c .yamllint.yml . && node .github/scripts/lint-workflow.cjs",
+    "workflowlint": "yamllint -c .yamllint.yml .github/workflows/ && node .github/scripts/lint-workflow.cjs",
     "test": "mocha",
     "sync-files": "node --loader=ts-node/esm util/sync_files.ts && git diff --exit-code",
     "lint-staged": "lint-staged",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Linting, formatting
 black==22.3.0
 pylint==2.13.7
+yamllint==1.28.0
 
 # dependencies for utils/*.py
 PyYAML


### PR DESCRIPTION
Closes #65 

This adds a linter and corresponding workflow to lint GitHub workflow files.  It has three components:

1. [yamllint](https://pypi.org/project/yamllint/), which handles general YAML syntax lint and some formatting
2. A custom linting script, `.github/scripts/lint_workflow.cjs`, which enforces some specific constraints around workflow file formatting, especially newlines and block ordering.  (I looked for existing tools to provide this functionality but came up empty; newline usage is not governed by YAML schema, so enforcing it is something we'll have to do on our own.)
3. [actionlint](https://github.com/rhysd/actionlint), which provides extensive checking specific to GitHub workflow scripts, including things like semantic errors, shellcheck, dependency checking, etc.

This also adds a workflowlint script command (e.g. `npm run workflowlint`).