### PR TITLE
ci: fix permissions issue in label-pr workflow

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -64,6 +64,8 @@ jobs:
           type: remove
 
   pr_review:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     needs: job_picker
     if: needs.job_picker.outputs.run == 'pr_review'


### PR DESCRIPTION
Small fix for the PR labeling workflow.  It appears that the job that's supposed to run when a PR review is submitted [isn't removing the needs-review label](https://github.com/OverlayPlugin/cactbot/actions/runs/8132959713/job/22223972723) because it relies on a different GH event (`pull_request_review`) than the other jobs (`pull_request_target`), and therefore doesn't auto-inherit read/write permissions on PRs.  Didn't pick this up in testing because it's affected by whether the PR originates from the same repo or a fork.

This is hopefully the easy fix, but the [doc](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) on maximum token permissions seems inconsistent with the [doc](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions) on the permissions attribute, so it might need a different approach if this doesn't work.