### PR TITLE
ci: fix perms issue in label-pr workflow (round 2)

### DIFF
--- a/.github/scripts/pr-review.cjs
+++ b/.github/scripts/pr-review.cjs
@@ -1,0 +1,114 @@
+/**
+ * This script will automatically check all PRs in the repository, and for any that have
+ *  the 'needs-review' label *and* a review from a contributor posted after
+ * the date of the most recent commit, it will remove the 'needs-review' label.
+ *
+ * This can be tested locally with the Github CLI installed, with:
+ * set GH_TOKEN=**** GH_REPO=OverlayPlugin/cactbot
+ * node ./.github/scripts/pr-review.cjs
+ */
+'use strict';
+
+const github = require('@actions/github');
+const { execSync } = require('child_process');
+
+/**
+ * @typedef {ReturnType<typeof import("@actions/github").getOctokit>} GitHub
+ */
+
+/**
+ * @param {GitHub} github
+ * @param {string} owner
+ * @param {string} repo
+ * @returns {Promise<void>}
+ */
+const checkAllPRs = async (github, owner, repo) => {
+  // Start by grabbing all PRs (including closed), as the workflow that fires this script
+  // will have latency and otherwise wouldn't pick up PRs that are approved and merged
+  // before the script has time to complete.
+  const iterator = github.paginate.iterator(github.rest.pulls.list, {
+    owner: owner,
+    repo: repo,
+    per_page: 100, // eslint-disable-line camelcase
+    state: 'all',
+  });
+
+  // iterate through each response
+  console.log('Fetching PRs...');
+  for await (const { data: prs } of iterator) {
+    for (const pr of prs) {
+      const prNumber = pr.number;
+
+      // check if the PR has a `needs-review` label; if not, skip for efficiency
+      const prLabels = pr.labels;
+      const hasNeedsReviewLabel = prLabels
+        .map((label) => label.name)
+        .includes('needs-review');
+      if (!hasNeedsReviewLabel)
+        continue;
+
+      console.log(`PR #${pr.number} has 'needs-review' label.  Checking...`);
+
+      // use the PR created date as the starting point, in case all commits
+      // are from before the PR was opened.
+      console.log(`PR created on: ${pr.created_at}`);
+      let latestCommitDate = new Date(pr.created_at).valueOf();
+      let latestReviewDate = 0;
+
+      const { data: prCommits } = await github.rest.pulls.listCommits({
+        owner: owner,
+        repo: repo,
+        pull_number: prNumber, // eslint-disable-line camelcase
+      });
+
+      if (prCommits)
+        prCommits.forEach((commit) => {
+          console.log(`Found commit ${commit.sha} (date: ${commit.commit.author.date})`);
+          const commitDate = new Date(commit.commit.author.date).valueOf();
+          latestCommitDate = Math.max(latestCommitDate, commitDate);
+        });
+      console.log(`Using latest commit date: ${new Date(latestCommitDate).toISOString()}`);
+
+      const { data: prReviews } = await github.rest.pulls.listReviews({
+        owner: owner,
+        repo: repo,
+        pull_number: prNumber, // eslint-disable-line camelcase
+      });
+      if (prReviews)
+        prReviews.forEach((review) => {
+          const reviewDate = new Date(review.submitted_at).valueOf();
+          const reviewerRole = review.author_association;
+          if (reviewerRole === 'COLLABORATOR' || reviewerRole === 'OWNER') {
+            console.log(`Found valid review ${review.id} (date: ${review.submitted_at})`);
+            latestReviewDate = Math.max(latestReviewDate, reviewDate);
+          }
+        });
+
+      if (latestReviewDate > 0) {
+        console.log(`Using latest review date: ${new Date(latestReviewDate).toISOString()}`);
+        if (latestReviewDate > latestCommitDate) {
+          console.log(`PR #${prNumber} has a post-commit review; removing 'needs-review' label.`);
+          execSync(`gh pr edit ${prNumber} --remove-label "needs-review"`);
+        } else {
+          console.log(`PR #${prNumber} has no review after the latest commit; skipping.`);
+        }
+      } else {
+        console.log(`PR #${prNumber} has no reviews; skipping.`);
+      }
+    }
+  }
+  console.log('Update complete.');
+};
+
+const run = async () => {
+  const owner = github.context.repo.owner;
+  const repo = github.context.repo.repo;
+  const octokit = github.getOctokit(process.env.GH_TOKEN);
+
+  await checkAllPRs(octokit, owner, repo);
+};
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/.github/workflows/label-pr-review.yml
+++ b/.github/workflows/label-pr-review.yml
@@ -1,0 +1,25 @@
+# This is a dummy workflow that runs when a pull request review is submitted.
+# It serves no purpose other than to fire a `workflow_run` event that can be
+# picked up and handled by the `label-pr.yml` workflow.
+#
+# This workaround is necessary because the `pull_request_review` event, when fired
+# from a PR out of a forked repo, targets the PR head branch and does not have access to repo
+# secrets.  This doesn't affect most PR workflows because they use the `pull_request_target`
+# event, which specifically targets the base branch (and GITHUB_TOKEN gets read/write permissions).
+# But there is no equivalent for `pull_request_review` events, because... GitHub. So instead,
+# we have to use a `workflow_run` event, which does target the base branch and does have access
+# to repo secrets.
+#
+# Hopefully, someday, this hack won't be necessary because GitHub will implement a
+# `pull_request_review_target` event that targets the base branch instead of the PR head branch.
+name: PR Review
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  pr_review:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Dummy job complete."

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -19,6 +19,8 @@ on:
       - auto_merge_enabled
       - auto_merge_disabled
       - ready_for_review
+  # Use the 'workflow_run' event as a workaround/hook to catch runs of the 'PR Review' workflow.
+  # See `label-pr-review.yml` comments for more info about why these gymnastics are necessary.
   workflow_run:
     workflows:
       - PR Review
@@ -73,8 +75,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          # force to ci checkout main repo to avoid
-          # unexpected PR code to be executed with out github token
+          # Force checkout the main repo (base branch) so that repo secrets
+          # are not available to unexpected/malicious PR code.
           ref: main
 
       - uses: ./.github/actions/setup-js-env
@@ -104,8 +106,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          # force to ci checkout main repo to avoid
-          # unexpected PR code to be executed with out github token
+          # Force checkout the main repo (base branch) so that repo secrets
+          # are not available to unexpected/malicious PR code.
           ref: main
 
       - name: Check for linked issues

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -19,8 +19,11 @@ on:
       - auto_merge_enabled
       - auto_merge_disabled
       - ready_for_review
-  pull_request_review:
-    types: [submitted]
+  workflow_run:
+    workflows:
+      - PR Review
+    types:
+      - completed
 
 jobs:
   job_picker:
@@ -34,7 +37,7 @@ jobs:
         run: |
           if [ "${{ contains(github.event.action,'auto_merge_') }}" == "true" ]; then
               echo "run=auto_merge" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event.action }}" == "submitted" ]; then
+          elif [ "${{ github.event.action }}" == "completed" ]; then
               echo "run=pr_review" >> $GITHUB_OUTPUT
           elif [ "${{ github.event.action }}" == "ready_for_review" ]; then
               echo "run=pr_ready" >> $GITHUB_OUTPUT
@@ -64,21 +67,23 @@ jobs:
           type: remove
 
   pr_review:
-    permissions:
-      pull-requests: write
     runs-on: ubuntu-latest
     needs: job_picker
     if: needs.job_picker.outputs.run == 'pr_review'
     steps:
-      - name: Remove needs-review label
-        if: >
-          github.event.review.author_association == 'COLLABORATOR' ||
-          github.event.review.author_association == 'OWNER'
-        uses: buildsville/add-remove-label@v2.0.1
+      - uses: actions/checkout@v3
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
-          labels: needs-review
-          type: remove
+          # force to ci checkout main repo to avoid
+          # unexpected PR code to be executed with out github token
+          ref: main
+
+      - uses: ./.github/actions/setup-js-env
+
+      - name: Update PR Review Labels
+        run: |
+          node .github/scripts/pr-review.cjs
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
   pr_ready:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -10,8 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          # force to ci checkout main repo to avoid
-          # unexpected PR code to be executed with out github token
+          # Force checkout the main repo (base branch) so that repo secrets
+          # are not available to unexpected/malicious PR code.
           ref: main
 
       - uses: ./.github/actions/setup-js-env


### PR DESCRIPTION
#77 didn't quite do it, but this one should.  Tested against PRs from a forked repo, and it now works fine.

It's a little hacky in terms of a fix, but the reasons (and steps) are explained in a comment at the top of `label-pr-review.yml`.  