### PR TITLE
raidemulator: Fix bug with first/last timestamp detection

### DIFF
--- a/ui/raidboss/emulator/data/CombatantTracker.ts
+++ b/ui/raidboss/emulator/data/CombatantTracker.ts
@@ -35,8 +35,9 @@ export default class CombatantTracker {
   }
 
   initialize(logLines: LineEvent[]): void {
-    this.firstTimestamp = logLines[0]?.timestamp ?? 0;
-    this.lastTimestamp = logLines.slice(-1)[0]?.timestamp ?? 0;
+    const timestamps = logLines.map((line) => line.timestamp).sort();
+    this.firstTimestamp = timestamps[0] ?? 0;
+    this.lastTimestamp = timestamps.slice(-1)[0] ?? 0;
 
     const eventTracker: { [key: string]: number } = {};
 


### PR DESCRIPTION
In some extremely rare cases, if the first log line of a split encounter is memory-generated instead of network-generated, and the user's system clock skews later than the server timestamp, and the first network line arrives before that skew offset has elapsed, the first timestamp detection for `CombatantTracker` will not have the correct timestamp.

This causes the forward assignment of "known first-state values" in `addCombatantFromSourceLine` to target the wrong initial state, which breaks player detection.

Sort the timestamps and get an actual first and last timestamp value that's guaranteed to be correct.