### PR TITLE
util: add new OP lines to log splitter

### DIFF
--- a/util/logtools/splitter.ts
+++ b/util/logtools/splitter.ts
@@ -32,6 +32,9 @@ export default class Splitter {
     losesEffectSpecificIds: CactbotBaseRegExp<'GainsEffect'>;
   };
 
+  // All logline types to be included without a specifici filterRegex
+  private catchAlls: string[] = [];
+
   private ignoredAbilities: string[];
 
   // startLine and stopLine are both inclusive.
@@ -57,6 +60,18 @@ export default class Splitter {
       }),
       losesEffectSpecificIds: NetRegexes.gainsEffect({ effectId: ['B9A', '808'] }),
     };
+
+    this.catchAlls = [
+      logDefinitions.HeadMarker.type,
+      logDefinitions.Tether.type,
+      logDefinitions.MapEffect.type,
+      logDefinitions.NpcYell.type,
+      logDefinitions.BattleTalk2.type,
+      logDefinitions.ActorSetPos.type,
+      logDefinitions.SpawnNpcExtra.type,
+      logDefinitions.ActorControlExtra.type,
+    ];
+
     this.ignoredAbilities = ['Attack', 'attack', ''];
 
     const defs: LogDefinitionMap = logDefinitions;
@@ -98,7 +113,12 @@ export default class Splitter {
     // * GainsEffect (26)/LosesEffect (30) with a known effectId of interest
     // * Headmarker (27)
     // * Tether (35)
-    //  * MapEffect (257)
+    // * MapEffect (257)
+    // * NpcYell (266)
+    // * BattleTalk2 (267)
+    // * ActorSetPos (271)
+    // * SpawnNpcExtra (272)
+    // * ActorControExtra (273) (although should be revisited if/when categories expand)
 
     if (typeField === undefined)
       return;
@@ -166,13 +186,7 @@ export default class Splitter {
       return;
     }
 
-    if (typeField === logDefinitions.HeadMarker.type)
-      return line;
-
-    if (typeField === logDefinitions.Tether.type)
-      return line;
-
-    if (typeField === logDefinitions.MapEffect.type)
+    if (this.catchAlls.includes(typeField))
       return line;
 
     return;


### PR DESCRIPTION
Proposing to add some of the new OP log lines to the log splitter analysis function, specifically:

- `NpcYell` (266) & `BattleTalk2` (267) - possibly useful for identifying phase jumps or mechanics
- `ActorSetPos` (271) - useful for identifying combatant movement associated with a mechanic (esp. with forthcoming changes to `LineCombatant`)
- `SpawnNpcExtra` (272) - initial tether/animation states for combatants
- `ActorControlExtra` (273)  animation changes (although probably revisit this if high-volume categories are added later)

`ActorSetPos` is the most "spammy" -- although I think that's probably also fight-dependant -- so open to excluding it.  But since we already exclude `CombatantMemory` (much more "spammy"), it seems like adding something here would be good, or we'll otherwise have to refer back to the unfiltered log quite a bit.

Here's the impact of this change using a recent ~6m run of Asura:

| Line Type           	| Current 	| As Modified 	|
|---------------------	|---------	|-------------	|
| ALL                 	| 376     	| 498         	|
| `NpcYell`           	| 0       	| 8           	|
| `BattleTalk2`       	| 0       	| 13          	|
| `ActorSetPos`       	| 0       	| 97          	|
| `SpawnNpcExtra`     	| 0       	| 4           	|
| `ActorControlExtra` 	| 0       	| 0           	|