### PR TITLE
raidboss: replace GameLog lines (HW)

### DIFF
--- a/ui/raidboss/data/03-hw/alliance/dun_scaith.ts
+++ b/ui/raidboss/data/03-hw/alliance/dun_scaith.ts
@@ -1,6 +1,5 @@
 import Conditions from '../../../../../resources/conditions';
 import { Responses } from '../../../../../resources/responses';
-import Util from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
@@ -452,15 +451,14 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.aoe(),
     },
     {
-      // Ordinarily we wouldn't use a game log line for this.
+      // Ordinarily we wouldn't use a log message for this.
       // However, the RP text seems to be the only indicator.
+      // (Not a MapEffect packet either.)
+      // https://xivapi.com/LogMessage/2747
+      // en: Shadows gather on the floor.
       id: 'Dun Scaith Shadow Links',
-      type: 'GameLog',
-      netRegex: {
-        line: 'Shadows gather on the floor.*?',
-        code: Util.gameLogCodes.message,
-        capture: false,
-      },
+      type: 'SystemLogMessage',
+      netRegex: { id: 'ABB', capture: false },
       suppressSeconds: 5,
       response: Responses.stopMoving(),
     },
@@ -654,7 +652,6 @@ const triggerSet: TriggerSet<Data> = {
         'Scathach': 'Scathach',
         'Shadow Limb': 'Schattenhand',
         'Shadowcourt Jester': 'Schattenhof-Narr',
-        'Shadows gather on the floor': 'Schatten sammeln sich auf dem Boden',
         'The Queen\'s Graces': 'Anmut der Königin',
         'The Queen\'s Pride': 'Stolz der Königin',
         'The Rostrum': 'Podium',
@@ -755,7 +752,6 @@ const triggerSet: TriggerSet<Data> = {
         'Scathach': 'Scáthach',
         'Shadow Limb': 'Mains d\'ombre',
         'Shadowcourt Jester': 'bouffon de la Cour des ombres',
-        'Shadows gather on the floor': 'Le pouvoir des ombres se concentre sur le sol',
         'The Queen\'s Graces': 'Grâces de la Reine',
         'The Queen\'s Pride': 'Fierté de la Reine',
         'The Rostrum': 'Scène',
@@ -855,7 +851,6 @@ const triggerSet: TriggerSet<Data> = {
         'Scathach': 'スカアハ',
         'Shadow Limb': '影の手',
         'Shadowcourt Jester': 'クィーンズ・ジェスター',
-        'Shadows gather on the floor': '床に影の力が集束していく',
         'The Queen\'s Graces': '女王の間',
         'The Queen\'s Pride': '女王の観閲広場',
         'The Rostrum': '道化の舞台',
@@ -956,7 +951,6 @@ const triggerSet: TriggerSet<Data> = {
         'Scathach': '斯卡哈',
         'Shadow Limb': '影之手',
         'Shadowcourt Jester': '女王小丑',
-        'Shadows gather on the floor': '影之力正在向地面聚集',
         'The Queen\'s Graces': '女王之间',
         'The Queen\'s Pride': '女王的阅兵广场',
         'The Rostrum': '小丑舞台',
@@ -1057,7 +1051,6 @@ const triggerSet: TriggerSet<Data> = {
         'Scathach': '스카하크',
         'Shadow Limb': '그림자 손',
         'Shadowcourt Jester': '여왕의 어릿광대',
-        'Shadows gather on the floor': '바닥에 그림자의 힘이 모여듭니다',
         'The Queen\'s Graces': '여왕의 방',
         'The Queen\'s Pride': '여왕의 사열 광장',
         'The Rostrum': '광대의 무대',

--- a/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.txt
+++ b/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.txt
@@ -50,8 +50,9 @@ hideall "--sync--"
 
 # Liquid Flame
 # -ii 1946 1953 194B
-# We use game log lines for the phases because the ACT log lines are unreliable
-# Whichever intermission comes second ends up with phantom "Gains Effect" lines
+# Whichever form (Hand/Tornado) comes second creates multiple phantom 0x1A "GainsEffect" lines
+# This will cause the timeline to desync if the syncs happen at the phase start,
+# so instead, put the syncs with jumps after each phase.
 
 # Astrology and Astromancy Camera will be sealed off
 1000.0 "--sync--"  SystemLogMessage { id: "7DC", param1: "658" } window 1000,0
@@ -61,10 +62,12 @@ hideall "--sync--"
 1030.5 "Slosh" Ability { id: "1947", source: "Liquid Flame" } window 10,10
 1034.6 "Searing Wind" Ability { id: "1944", source: "Liquid Flame" }
 1042.7 "Bibliocide" Ability { id: "1945", source: "Liquid Flame" }
+1054.3 "--sync--" GainsEffect { effectId: '2FF' } window 54,20 jump 1100.0 # Chiromorph
+1054.3 "--sync--" GainsEffect { effectId: '300' } window 54,20 jump 1200.0 # Anemomorph
 1054.3 "Hand/Tornado?"
 
-# Hand Form
-1100.0 "--sync--" GameLog { line: "The liquid flame gains the effect of Chiromorph.*?" } window 100,250
+# Hand Form (Chiromorph)
+1100.0 "--sync--" # No actual sync; this is a jump destination
 1108.4 "Seal Of Night And Day" Ability { id: "1949", source: "Liquid Flame" } window 10,10
 1112.5 "Searing Wind" Ability { id: "1948", source: "Liquid Flame" }
 1116.4 "Searing Wind" Ability { id: "1948", source: "Liquid Flame" }
@@ -72,18 +75,20 @@ hideall "--sync--"
 1130.6 "Searing Wind" Ability { id: "1948", source: "Liquid Flame" }
 1134.7 "Searing Wind" Ability { id: "1948", source: "Liquid Flame" }
 1138.9 "Searing Wind" Ability { id: "1948", source: "Liquid Flame" }
+1149.1 "--sync--" GainsEffect { effectId: '300' } window 49,20 jump 1200 # jump to ignore phantom line
 1149.1 "Form Shift"
 
-# Tornado Form
-1200.0 "--sync--" GameLog { line: "The liquid flame gains the effect of Anemomorph.*?" } window 200,0
+# Tornado Form (Anemomorph)
+1200.0 "--sync--" # No actual sync; this is a jump destination
 1204.5 "Bibliocide" Ability { id: "1945", source: "Liquid Flame" } window 10,10
 1215.4 "Magnetism/Repel?" Ability { id: "194[CD]", source: "Liquid Flame" }
 1226.9 "Bibliocide" Ability { id: "1945", source: "Liquid Flame" }
 1237.8 "Magnetism/Repel" Ability { id: "194[CD]", source: "Liquid Flame" }
+1246.1 "--sync--" GainsEffect { effectId: '2FF' } window 46,20 jump 1100 # jump to ignore phantom line
 1246.1 "Form Shift"
 
-# Human Form
-1300.0 "--sync--" GameLog { line: "The liquid flame gains the effect of Anthropomorph.*?" } window 300,10
+# Human Form (Anthropomorph)
+1300.0 "--sync--" GainsEffect { effectId: '2FE' } window 200,10 # no phantom line problem here
 1307.5 "Searing Wind" Ability { id: "1944", source: "Liquid Flame" } window 10,20
 1314.7 "Bibliocide" Ability { id: "1945", source: "Liquid Flame" }
 1326.0 "Sea Of Flames x3"

--- a/ui/raidboss/data/03-hw/pvp/shatter.ts
+++ b/ui/raidboss/data/03-hw/pvp/shatter.ts
@@ -4,21 +4,35 @@ import { TriggerSet } from '../../../../../types/trigger';
 
 export type Data = RaidbossData;
 
+type Location = 'center' | 'north' | 'southeast' | 'southwest';
+
+const bNpcNameIdToLocation: { [bNpcNameId: string]: Location } = {
+  '12D6': 'center', // Icebound Tomelith A1
+  '12D7': 'southwest', // Icebound Tomelith A2
+  '12D8': 'southeast', // Icebound Tomelith A3
+  '12D9': 'north', // Icebound Tomelith A4
+};
+
+const bNpcNameIds = Object.keys(bNpcNameIdToLocation);
+
 // Frontlines: Shatter
 const triggerSet: TriggerSet<Data> = {
   id: 'TheFieldsOfGloryShatter',
   zoneId: ZoneId.TheFieldsOfGloryShatter,
   triggers: [
+    // https://xivapi.com/LogMessage/2652
+    // en: <Clickable(<SheetEn(BNpcName,2,IntegerParameter(1),1,1)/>)/> activates and begins to emit heat.
     {
-      id: 'Shatter Big Ice Center',
-      type: 'GameLog',
-      netRegex: {
-        line: 'The icebound tomelith A1 activates and begins to emit heat.*?',
-        capture: false,
+      id: 'Shatter Big Ice',
+      type: 'SystemLogMessage',
+      netRegex: { id: 'A5C', param1: bNpcNameIds },
+      alertText: (_data, matches, output) => {
+        const location = bNpcNameIdToLocation[matches.param1];
+        if (location !== undefined)
+          return output[location]!();
       },
-      alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {
-        text: {
+        center: {
           en: 'Big Ice: Center',
           de: 'Grosses Eis: Mitte',
           fr: 'Grosse Glace : Centre',
@@ -26,18 +40,7 @@ const triggerSet: TriggerSet<Data> = {
           cn: '大冰: 中央',
           ko: '큰 얼음: 중앙',
         },
-      },
-    },
-    {
-      id: 'Shatter Big Ice North',
-      type: 'GameLog',
-      netRegex: {
-        line: 'The icebound tomelith A4 activates and begins to emit heat.*?',
-        capture: false,
-      },
-      alertText: (_data, _matches, output) => output.text!(),
-      outputStrings: {
-        text: {
+        north: {
           en: 'Big Ice: North',
           de: 'Grosses Eis: Norden',
           fr: 'Grosse Glace : Nord',
@@ -45,18 +48,7 @@ const triggerSet: TriggerSet<Data> = {
           cn: '大冰: 北方',
           ko: '큰 얼음: 북쪽',
         },
-      },
-    },
-    {
-      id: 'Shatter Big Ice Southeast',
-      type: 'GameLog',
-      netRegex: {
-        line: 'The icebound tomelith A3 activates and begins to emit heat.*?',
-        capture: false,
-      },
-      alertText: (_data, _matches, output) => output.text!(),
-      outputStrings: {
-        text: {
+        southeast: {
           en: 'Big Ice: Southeast',
           de: 'Grosses Eis: Süden',
           fr: 'Grosse Glace : Sud-Est',
@@ -64,18 +56,7 @@ const triggerSet: TriggerSet<Data> = {
           cn: '大冰: 东南',
           ko: '큰 얼음: 남동쪽',
         },
-      },
-    },
-    {
-      id: 'Shatter Big Ice Southwest',
-      type: 'GameLog',
-      netRegex: {
-        line: 'The icebound tomelith A2 activates and begins to emit heat.*?',
-        capture: false,
-      },
-      alertText: (_data, _matches, output) => output.text!(),
-      outputStrings: {
-        text: {
+        southwest: {
           en: 'Big Ice: Southwest',
           de: 'Grosses Eis: Südwesten',
           fr: 'Grosse Glace : Sud-Ouest',
@@ -83,65 +64,6 @@ const triggerSet: TriggerSet<Data> = {
           cn: '大冰: 西南',
           ko: '큰 얼음: 남서쪽',
         },
-      },
-    },
-  ],
-  timelineReplace: [
-    {
-      'locale': 'de',
-      'replaceSync': {
-        'The icebound tomelith A1 activates and begins to emit heat':
-          'Vereister Echolith A1 setzt sich in Betrieb und das Eis beginnt zu bröckeln',
-        'The icebound tomelith A2 activates and begins to emit heat':
-          'Vereister Echolith A2 setzt sich in Betrieb und das Eis beginnt zu bröckeln',
-        'The icebound tomelith A3 activates and begins to emit heat':
-          'Vereister Echolith A3 setzt sich in Betrieb und das Eis beginnt zu bröckeln',
-        'The icebound tomelith A4 activates and begins to emit heat':
-          'Vereister Echolith A4 setzt sich in Betrieb und das Eis beginnt zu bröckeln',
-      },
-    },
-    {
-      'locale': 'fr',
-      'replaceSync': {
-        'The icebound tomelith A1 activates and begins to emit heat':
-          'Mémolithe Congelé A1 e et la glace s\'est fragilisée',
-        'The icebound tomelith A2 activates and begins to emit heat':
-          'Mémolithe Congelé A2 e et la glace s\'est fragilisée',
-        'The icebound tomelith A3 activates and begins to emit heat':
-          'Mémolithe Congelé A3 e et la glace s\'est fragilisée',
-        'The icebound tomelith A4 activates and begins to emit heat':
-          'Mémolithe Congelé A4 e et la glace s\'est fragilisée',
-      },
-    },
-    {
-      'locale': 'ja',
-      'replaceSync': {
-        'The icebound tomelith A1 activates and begins to emit heat': 'アイスドトームリスA1号基が起動し、氷がもろくなった！',
-        'The icebound tomelith A2 activates and begins to emit heat': 'アイスドトームリスA2号基が起動し、氷がもろくなった！',
-        'The icebound tomelith A3 activates and begins to emit heat': 'アイスドトームリスA3号基が起動し、氷がもろくなった！',
-        'The icebound tomelith A4 activates and begins to emit heat': 'アイスドトームリスA4号基が起動し、氷がもろくなった！',
-      },
-    },
-    {
-      'locale': 'cn',
-      'replaceSync': {
-        'The icebound tomelith A1 activates and begins to emit heat': '冰封的石文A1启动了，冰块变得脆弱了！',
-        'The icebound tomelith A2 activates and begins to emit heat': '冰封的石文A2启动了，冰块变得脆弱了！',
-        'The icebound tomelith A3 activates and begins to emit heat': '冰封的石文A3启动了，冰块变得脆弱了！',
-        'The icebound tomelith A4 activates and begins to emit heat': '冰封的石文A4启动了，冰块变得脆弱了！',
-      },
-    },
-    {
-      'locale': 'ko',
-      'replaceSync': {
-        'The icebound tomelith A1 activates and begins to emit heat':
-          '얼음탑 A1호기가 기동하여 표면이 녹기 시작합니다!',
-        'The icebound tomelith A2 activates and begins to emit heat':
-          '얼음탑 A2호기가 기동하여 표면이 녹기 시작합니다!',
-        'The icebound tomelith A3 activates and begins to emit heat':
-          '얼음탑 A3호기가 기동하여 표면이 녹기 시작합니다!',
-        'The icebound tomelith A4 activates and begins to emit heat':
-          '얼음탑 A4호기가 기동하여 표면이 녹기 시작합니다!',
       },
     },
   ],

--- a/ui/raidboss/data/03-hw/raid/a11s.ts
+++ b/ui/raidboss/data/03-hw/raid/a11s.ts
@@ -343,11 +343,12 @@ const triggerSet: TriggerSet<Data> = {
         },
       },
     },
+    // There is a GameLog message (en: The plasma shield is shattered!), but no corresponding
+    // SystemLogMessage. The 0x19 (NetworkDeath) line shows up >2 seconds later (too late).
     {
       id: 'A11S Plasma Shield Shattered',
-      type: 'GameLog',
-      netRegex: { line: 'The plasma shield is shattered.*?', capture: false },
-
+      type: 'NetworkEffectResult',
+      netRegex: { name: 'Plasma Shield', currentHp: '0', capture: false },
       response: Responses.spread(),
     },
     {


### PR DESCRIPTION
Some comments in-line.  @JLGarber - tagging you since you did the initial Gubal Hard timeline.  I really wanted to get rid of those `GameLog` syncs, so I took a look back at the [discussion you had on the original PR](https://github.com/quisquous/cactbot/pull/693#discussion_r339324028), and I think this is the right implementation of the alternative (at least, it works, so 🤷 ).