### PR TITLE
util: add export-all option to web splitter

### DIFF
--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -1213,7 +1213,7 @@ const latestLogDefinitions = {
       npcNameId: 3,
       npcYellId: 4,
     },
-    canAnonymize: false,
+    canAnonymize: true,
     firstOptionalField: undefined,
   },
   BattleTalk2: {
@@ -1234,7 +1234,7 @@ const latestLogDefinitions = {
       // unknown3: 9,
       // unknown4: 10,
     },
-    canAnonymize: false,
+    canAnonymize: true,
     firstOptionalField: undefined,
   },
   Countdown: {
@@ -1291,7 +1291,10 @@ const latestLogDefinitions = {
       y: 7,
       z: 8,
     },
-    canAnonymize: false,
+    playerIds: {
+      2: null,
+    },
+    canAnonymize: true,
     firstOptionalField: undefined,
   },
   ActorSetPos: {
@@ -1303,14 +1306,17 @@ const latestLogDefinitions = {
       type: 0,
       timestamp: 1,
       id: 2,
-      heading: 3, // OP call this 'rotation', but cactbot consistently uses 'heading'
+      heading: 3, // OP calls this 'rotation', but cactbot consistently uses 'heading'
       // unknown1: 4,
       // unknown2: 5,
       x: 6,
       y: 7,
       z: 8,
     },
-    canAnonymize: false,
+    playerIds: {
+      2: null,
+    },
+    canAnonymize: true,
     firstOptionalField: undefined,
   },
   SpawnNpcExtra: {
@@ -1326,7 +1332,10 @@ const latestLogDefinitions = {
       tetherId: 4,
       animationState: 5,
     },
-    canAnonymize: false,
+    playerIds: {
+      3: null, // `id` is an npc, but parentId could be a tethered player?
+    },
+    canAnonymize: true,
     firstOptionalField: undefined,
   },
   ActorControlExtra: {
@@ -1344,7 +1353,10 @@ const latestLogDefinitions = {
       param3: 6,
       param4: 7,
     },
-    canAnonymize: false,
+    playerIds: {
+      2: null,
+    },
+    canAnonymize: true,
     firstOptionalField: undefined,
   },
 } as const;

--- a/util/logtools/split_log.ts
+++ b/util/logtools/split_log.ts
@@ -114,7 +114,7 @@ const writeFile = (
     const lines: string[] = [];
     const noAnonymize = args.no_anonymize ?? false;
     lineReader.on('line', (line) => {
-      splitter.processWithCallback(line, (line) => {
+      splitter.processWithCallback(line, false, (line) => {
         let writeLine = line;
         if (!noAnonymize) {
           const anonLine = anonymizer.process(line, notifier);

--- a/util/logtools/splitter.css
+++ b/util/logtools/splitter.css
@@ -12,6 +12,11 @@
   align-items: center;
 }
 
+#export-buttons {
+  white-space: nowrap;
+  vertical-align: top;
+}
+
 #fight-table {
   display: grid;
   grid-template-columns: repeat(var(--table-cols), max-content);
@@ -30,6 +35,11 @@
 .input-label {
   display: block;
   margin: 5px 10px 10px 5px;
+}
+
+.button-label {
+    display: inline-block;
+    margin: 5px 10px 10px 5px;
 }
 
 button {

--- a/util/logtools/splitter.css
+++ b/util/logtools/splitter.css
@@ -38,8 +38,8 @@
 }
 
 .button-label {
-    display: inline-block;
-    margin: 5px 10px 10px 5px;
+  display: inline-block;
+  margin: 5px 10px 10px 5px;
 }
 
 button {

--- a/util/logtools/splitter.html
+++ b/util/logtools/splitter.html
@@ -16,7 +16,8 @@
   </label>
 </div>
 <div id="export-buttons" class="hide">
-  <button class="button-label" id="exportSelected" disabled></button><button class="button-label" id="exportAll" disabled></button>
+  <button class="button-label" id="exportSelected" disabled></button>
+  <button class="button-label" id="exportAll" disabled></button>
 </div>
 <div id="errors"></div>
 <div id="fight-table"></div>

--- a/util/logtools/splitter.html
+++ b/util/logtools/splitter.html
@@ -14,8 +14,9 @@
     <input id="analysisFilter" type="checkbox"></input>
     <span id="analysisFilter-label"></span>
   </label>
-
-  <button class="input-label" id="export" disabled></button>
+</div>
+<div id="export-buttons" class="hide">
+  <button class="button-label" id="exportSelected" disabled></button><button class="button-label" id="exportAll" disabled></button>
 </div>
 <div id="errors"></div>
 <div id="fight-table"></div>

--- a/util/logtools/splitter.ts
+++ b/util/logtools/splitter.ts
@@ -317,9 +317,20 @@ export default class Splitter {
     return lines;
   }
 
+  processWithAnalysisOnly(line: string): string {
+    const splitLine = line.split('|');
+    const typeField = splitLine[0];
+    const filteredLine = this.doAnalysisFilter ? this.analysisFilter(line, typeField) : line;
+    return filteredLine ?? line;
+  }
+
   // Call callback with any emitted line.
-  public processWithCallback(line: string, callback: (str: string) => void): void {
-    const result = this.process(line);
+  public processWithCallback(
+    line: string,
+    analysisOnly: boolean,
+    callback: (str: string) => void,
+  ): void {
+    const result = analysisOnly ? this.processWithAnalysisOnly(line) : this.process(line);
     if (typeof result === 'undefined') {
       return;
     } else if (typeof result === 'string') {

--- a/util/logtools/web_splitter.ts
+++ b/util/logtools/web_splitter.ts
@@ -174,8 +174,9 @@ const buildTable = (state: PageState): void => {
         includeCheck.addEventListener('click', () => {
           state.selectedFights[idx] = includeCheck.checked;
           const anyClicked = Object.values(state.selectedFights).reduce((prev, cur) => prev || cur);
+          const globalsChecked = state.anonInput.checked || state.analysisFilterInput.checked;
           state.exportSelectedButton.disabled = !anyClicked;
-          state.exportAllButton.disabled = anyClicked;
+          state.exportAllButton.disabled = anyClicked || !globalsChecked;
         });
         state.table.appendChild(includeCheck);
         continue;
@@ -374,12 +375,16 @@ const onLoaded = () => {
 
   anonCheckbox.addEventListener('click', () => {
     const optionChecked = anonCheckbox.checked || analysisFilterCheckbox.checked;
-    pageState.exportAllButton.disabled = !optionChecked;
+    const anyClicked = Object.values(pageState.selectedFights).length > 0 &&
+      Object.values(pageState.selectedFights).reduce((prev, cur) => prev || cur);
+    pageState.exportAllButton.disabled = !optionChecked || anyClicked;
   });
 
   analysisFilterCheckbox.addEventListener('click', () => {
     const optionChecked = anonCheckbox.checked || analysisFilterCheckbox.checked;
-    pageState.exportAllButton.disabled = !optionChecked;
+    const anyClicked = Object.values(pageState.selectedFights).length > 0 &&
+      Object.values(pageState.selectedFights).reduce((prev, cur) => prev || cur);
+    pageState.exportAllButton.disabled = !optionChecked || anyClicked;
   });
 
   setLabelText('anon-label', 'anonInput', lang);

--- a/util/logtools/web_splitter.ts
+++ b/util/logtools/web_splitter.ts
@@ -295,12 +295,7 @@ const doExportSelected = (state: PageState): void => {
     }
   }
 
-  const blob = new Blob([output.join('\n')], { type: 'text/plain' });
-  const a = document.createElement('a');
-  a.setAttribute('download', filename);
-  a.href = window.URL.createObjectURL(blob);
-  a.click();
-  window.URL.revokeObjectURL(a.href);
+  downloadFile(output, filename);
 };
 
 const doExportAll = (state: PageState): void => {
@@ -330,7 +325,10 @@ const doExportAll = (state: PageState): void => {
       anonymizer.validateLine(line, notifier);
   }
 
-  const filename = 'processed.log';
+  downloadFile(output, 'processed.log');
+};
+
+const downloadFile = (output: string[], filename: string): void => {
   const blob = new Blob([output.join('\n')], { type: 'text/plain' });
   const a = document.createElement('a');
   a.setAttribute('download', filename);

--- a/util/logtools/web_splitter.ts
+++ b/util/logtools/web_splitter.ts
@@ -374,17 +374,17 @@ const onLoaded = () => {
   });
 
   anonCheckbox.addEventListener('click', () => {
-    const optionChecked = anonCheckbox.checked || analysisFilterCheckbox.checked;
+    const globalsChecked = anonCheckbox.checked || analysisFilterCheckbox.checked;
     const anyClicked = Object.values(pageState.selectedFights).length > 0 &&
       Object.values(pageState.selectedFights).reduce((prev, cur) => prev || cur);
-    pageState.exportAllButton.disabled = !optionChecked || anyClicked;
+    pageState.exportAllButton.disabled = !globalsChecked || anyClicked;
   });
 
   analysisFilterCheckbox.addEventListener('click', () => {
-    const optionChecked = anonCheckbox.checked || analysisFilterCheckbox.checked;
+    const globalsChecked = anonCheckbox.checked || analysisFilterCheckbox.checked;
     const anyClicked = Object.values(pageState.selectedFights).length > 0 &&
       Object.values(pageState.selectedFights).reduce((prev, cur) => prev || cur);
-    pageState.exportAllButton.disabled = !optionChecked || anyClicked;
+    pageState.exportAllButton.disabled = !globalsChecked || anyClicked;
   });
 
   setLabelText('anon-label', 'anonInput', lang);

--- a/util/logtools/web_splitter.ts
+++ b/util/logtools/web_splitter.ts
@@ -35,11 +35,11 @@ const pageText = {
     fr: 'Filtrer le log pour analyse',
     cn: '过滤日志进行分析',
   },
-  exportInput: {
-    en: 'Export',
-    de: 'Export',
-    fr: 'Exporter',
-    cn: '导出',
+  exportSelectedInput: {
+    en: 'Export Selected',
+  },
+  exportAllInput: {
+    en: 'Export Entire Log',
   },
 } as const;
 
@@ -174,7 +174,8 @@ const buildTable = (state: PageState): void => {
         includeCheck.addEventListener('click', () => {
           state.selectedFights[idx] = includeCheck.checked;
           const anyClicked = Object.values(state.selectedFights).reduce((prev, cur) => prev || cur);
-          state.exportButton.disabled = !anyClicked;
+          state.exportSelectedButton.disabled = !anyClicked;
+          state.exportAllButton.disabled = anyClicked;
         });
         state.table.appendChild(includeCheck);
         continue;
@@ -196,7 +197,8 @@ class PageState {
   constructor(
     public lang: Lang,
     public table: HTMLElement,
-    public exportButton: HTMLButtonElement,
+    public exportSelectedButton: HTMLButtonElement,
+    public exportAllButton: HTMLButtonElement,
     public anonInput: HTMLInputElement,
     public analysisFilterInput: HTMLInputElement,
     public errorDiv: HTMLElement,
@@ -225,7 +227,7 @@ class WebNotifier implements Notifier {
   }
 }
 
-const doExport = (state: PageState): void => {
+const doExportSelected = (state: PageState): void => {
   const selected: number[] = [];
   for (const keyStr in state.selectedFights) {
     const key = parseInt(keyStr);
@@ -261,7 +263,7 @@ const doExport = (state: PageState): void => {
 
     // TODO: we could be smarter here and not loop every time through all lines
     for (const line of state.lines) {
-      splitter.processWithCallback(line, (line) => {
+      splitter.processWithCallback(line, false, (line) => {
         if (anonymizeLogs) {
           const anonLine = anonymizer.process(line, notifier);
           if (anonLine === undefined)
@@ -301,13 +303,51 @@ const doExport = (state: PageState): void => {
   window.URL.revokeObjectURL(a.href);
 };
 
+const doExportAll = (state: PageState): void => {
+  const anonymizeLogs = state.anonInput.checked;
+  const analysisFilter = state.analysisFilterInput.checked;
+  const output: string[] = [];
+  const notifier = new WebNotifier(state.errorDiv);
+  const anonymizer = new Anonymizer();
+  const splitter = new Splitter('', '', notifier, true, analysisFilter);
+
+  for (const line of state.lines) {
+    splitter.processWithCallback(line, true, (line) => {
+      if (anonymizeLogs) {
+        const anonLine = anonymizer.process(line, notifier);
+        if (anonLine === undefined)
+          return;
+        output.push(anonLine);
+      } else {
+        output.push(line);
+      }
+    });
+  }
+
+  if (anonymizeLogs) {
+    anonymizer.validateIds(notifier);
+    for (const line of output)
+      anonymizer.validateLine(line, notifier);
+  }
+
+  const filename = 'processed.log';
+  const blob = new Blob([output.join('\n')], { type: 'text/plain' });
+  const a = document.createElement('a');
+  a.setAttribute('download', filename);
+  a.href = window.URL.createObjectURL(blob);
+  a.click();
+  window.URL.revokeObjectURL(a.href);
+};
+
 const onLoaded = () => {
   const lang = browserLanguagesToLang(navigator.languages);
 
   const table = getElement('fight-table');
   const fileDrop = getElement('filedrop');
   const exportOptions = getElement('export-options');
-  const exportButton = getElement('export') as HTMLButtonElement;
+  const exportButtons = getElement('export-buttons');
+  const exportSelectedButton = getElement('exportSelected') as HTMLButtonElement;
+  const exportAllButton = getElement('exportAll') as HTMLButtonElement;
   const anonCheckbox = getElement('anon') as HTMLInputElement;
   const analysisFilterCheckbox = getElement('analysisFilter') as HTMLInputElement;
   const errorDiv = getElement('errors');
@@ -322,22 +362,39 @@ const onLoaded = () => {
   const pageState = new PageState(
     lang,
     table,
-    exportButton,
+    exportSelectedButton,
+    exportAllButton,
     anonCheckbox,
     analysisFilterCheckbox,
     errorDiv,
   );
   fileDrop.addEventListener('drop', (e) => {
     exportOptions.classList.remove('hide');
+    exportButtons.classList.remove('hide');
     void dropHandler(e, pageState);
+  });
+
+  anonCheckbox.addEventListener('click', () => {
+    const optionChecked = anonCheckbox.checked || analysisFilterCheckbox.checked;
+    pageState.exportAllButton.disabled = !optionChecked;
+  });
+
+  analysisFilterCheckbox.addEventListener('click', () => {
+    const optionChecked = anonCheckbox.checked || analysisFilterCheckbox.checked;
+    pageState.exportAllButton.disabled = !optionChecked;
   });
 
   setLabelText('anon-label', 'anonInput', lang);
   setLabelText('analysisFilter-label', 'analysisFilterInput', lang);
-  setLabelText('export', 'exportInput', lang);
+  setLabelText('exportSelected', 'exportSelectedInput', lang);
+  setLabelText('exportAll', 'exportAllInput', lang);
 
-  exportButton.addEventListener('click', () => {
-    doExport(pageState);
+  exportSelectedButton.addEventListener('click', () => {
+    doExportSelected(pageState);
+  });
+
+  exportAllButton.addEventListener('click', () => {
+    doExportAll(pageState);
   });
 };
 


### PR DESCRIPTION
Adds an "Export Entire Log" button to the web splitter.  It will be disabled if a particular fight is selected (essentially, it will toggle states with the "Export Selected" button), and will otherwise be enabled only if either "Anonymize Log" or "Filter Log for Analysis" is checked (since without one of those, it would just dump the entire file, unmodified, back to the user which is rather pointless).

Also cleans up a couple of the `canAnonymize` properties in `netlog_defs`.

Ref #96 - this is necessary to allow a full log file to be anonymized and exported (without being split), in case the splitter is not properly detecting encounters.