### PR TITLE
ci/raidboss: add timeline linter & lint timeline files

### DIFF
--- a/docs/TimelineGuide.md
+++ b/docs/TimelineGuide.md
@@ -763,7 +763,7 @@ to turn on filtering.  From your cactbot directory, run the following command:
 Alternatively, you can use the web-based [log splitter](https://overlayplugin.github.io/cactbot/util/logtools/splitter.html) tool
 and check the option to filter the log for analysis.
 
-This filtering will limit the exported log lines to things that are potentially useful in writing triggers,
+This filtering will limit the exported log lines to things that are potentially useful for writing triggers,
 like boss abilities, added combatants, tethers, map effects, head markers,
 and debuffs applied to and removed from players. It's not perfect, but it's a place to start.
 
@@ -1057,7 +1057,7 @@ Here's what the timeline looks like.
 ```
 
 Note: this old timeline does not use `forcejump` or `label` but should!
-Note 2: This is an example of when adn how `#cactbot-timeline-lint...`
+Note 2: This is an example of when and how `#cactbot-timeline-lint...`
 should be used to disable sync order linting.
 Otherwise, this timeline file would fail validation when added to the repo due to the
 out-of-order sync times.

--- a/docs/TimelineGuide.md
+++ b/docs/TimelineGuide.md
@@ -106,9 +106,24 @@ If that line occurs outside the valid window, it is ignored.
 ## Timeline File Syntax
 
 Each line in a timeline file is considered its own timeline entry.
-There is no ordering at all.
+Ordering is irrelevant insofar as processing/usage of the file.
 The fact that timeline files are ordered is as a convenience to the reader.
 (Two lines with the same time do keep their relative ordering.)
+
+That said, cactbot's linting tools require that timelines be be ordered by time
+to help with readability and accuracy.
+
+If you have a specific reason why certain timeline entries should be out of order --
+for example, if you have a fight that branches and want to include several fake entries,
+but want to keep each branch separate (despite the overlap in time) --
+you can add the following comments to temporarily disable & renable the linter
+from enforcing sync order:
+
+```text
+#cactbot-timeline-lint-disable-sync-order
+[out of order timeline entries]
+#cactbot-timeline-lint-enable-sync-order
+```
 
 ### Comments
 
@@ -150,11 +165,14 @@ hideall "Reset"
 ```
 
 `[number]` can be an integer, e.g. `34`, or a float, e.g. `84.381`.
+For timeline entries, if the sync time (the first entry on the line) is a float,
+it cannot have more than one digit after the decimal (e.g. `203.6` is valid, but `203.61` is not).
+This is because the extra precision is unnecessary.
 
 `[numberOrLabel]` can be a `[number]` (e.g. `42` or `12.8`)
 or a label name with double quotes (e.g. `"loop"` or `"branch2"`).
 
-`"[string]"` is a character string, e.g. `"Liftoff"` or `"Double Attack"`
+`"[string]"` is a double-quoted character string, e.g. `"Liftoff"` or `"Double Attack"`
 
 `[LogType]` is a key from [netlog_defs.ts](../resources/netlog_defs.ts),
 e.g. `Ability` or `StartsUsing` or `AddedCombatant`.
@@ -176,10 +194,22 @@ Additionally, if you are using [sync_files.ts](RaidbossGuide.md#sync-files) for 
 you should spell out ability ids in full, e.g. `id: "(8B43|8B46)"` instead of `id: "8B4[36]"`,
 so that the script can find and replace them properly.
 
-The ability time and ability name always need to come first,
-but `duration`, `forcejump`, `jump`, `[LogType]`, and `window`
-do not have to be in any order with respect to each other.
-Stylistically, usually the`[LogType]` sync is put first.
+With the exception of `hideall` (a command that must be on its own line with no sync time),
+the ability time must come first, followed either by an ability name or a `label` keyword.
+
+If it is a normal timeline entry, the ability name must be followed by `[LogType]` and `{params}`
+before any other optional keywords.
+
+With user files, the remaining keywords (`duration`, `window`, `forcejump`, and `jump`) can be in any order.
+However, for timeline files that are distributed with cactbot, the keywords must appear in that order,
+to ensure consistency.
+
+Please also note that `jump` and `forcejump` are mutually exclusive
+and cannot be used together on the same line.
+
+### Keywords/Commands
+
+#### duration
 
 **duration** is a time in seconds to display the accompanying action.
 Usually, timeline entries disappear immediately,
@@ -189,6 +219,32 @@ It does not need a sync to do this.
 
 The syntax for **duration** is `duration [number]`,
 as `duration 5.5`.
+
+#### window
+
+**window** is the time frame in which to consider the sync.
+By default, if **window** is not specified, cactbot considers it the
+same as specifying `window 2.5,2.5`.
+In other words,
+2.5 seconds before the ability time and 2.5 seconds after.
+As an example, for the line `3118.9 "Lancing Bolt" Ability { id: "3876", source: "Raiden" }`,
+if the log line for this ability is encountered anywhere between `3116.4` and `3121.4`
+then it will resync the timeline playback to `3118.9`.
+Often timelines will use very large windows for unique abilities,
+to make sure that timelines sync to the right place even if started mid-fight
+or if hp pushes are discovered when the content is no longer current.
+
+The syntax for **window** is `window [number],[number]` (e.g `window 10,30`).
+There is no space after the comma.
+
+**window** also supports a single parameter in the format `window [number]`,
+in which case the window will be split evenly on both sides of the sync time.
+For example, specifying `window 5000` is equivalent to `window 2500,2500`.
+
+While this can be used in personal/user timelines, any timelines uploaded
+to the cactbot repository must use the explicit `window [number],[number]` format.
+
+#### forcejump
 
 **forcejump** tells the timeline playback to jump to a particular time
 if the sync is encountered *or* if the line containing the **forcejump**
@@ -211,6 +267,8 @@ until the next sync or jump occurs.
 The syntax for **forcejump** is `forcejump [number]` (e.g. `forcejump 204.2`)
 or `forcejump [label]` (e.g. `forcejump "quaqua-middle-poison-loop"`).
 
+#### jump
+
 **jump** tells the timeline playback to jump to a particular time
 if and only if the sync is encountered.
 This is usually used for phase pushes and loops that involve multiple blocks.
@@ -221,34 +279,23 @@ If you jump to time 0, the timeline will stop playback.
 The syntax for **jump** is `jump [number]` (e.g. `jump 204.2`)
 or `jump [label]` (e.g. `jump "Hieroglyphika"`).
 
-**window** is the time frame in which to consider the sync.
-By default, if **window** is not specified, cactbot considers it the
-same as specifying `window 2.5,2.5`.
-In other words,
-2.5 seconds before the ability time and 2.5 seconds after.
-As an example, for the line `3118.9 "Lancing Bolt" Ability { id: "3876", source: "Raiden" }`,
-if the log line for this ability is encountered anywhere between `3116.4` and `3121.4`
-then it will resync the timeline playback to `3118.9`.
-Often timelines will use very large windows for unique abilities,
-to make sure that timelines sync to the right place even if started mid-fight
-or if hp pushes are discovered when the content is no longer current.
+#### label
 
-The syntax for **window** is `window [number],[number]` (e.g `window 10,30`).
-There is no space after the comma.
+**label** is simply a way to assign a name to a particular time in the timeline.
+With a label, you can then use `jump` or `forcejump` to jump to that particular label,
+instead of having to specify a specific jump time.
 
-**window** also supports a single parameter in the format `window [number]`,
-in which case the window will be split evenly on both sides of the sync time.
-For example, specifying `window 5000` is equivalent to `window 2500,2500`.
-While this can be used in personal/user timelines, it should be avoided in
-timeline files that are distributed with cactbot,
-which should instead use the explicit `window [number],[number]` format.
+`label` should appear immediately after a sync time, with only a name as a parameter and nothing else.
+For example: `204.2 label "thordan-branch"`
 
-### Commands
+#### hideall
 
 To hide all instances of an ability, you can use the `hideall` command.
 Most timelines start with the line `hideall "--sync--"`
 to hide syncs that are just used to keep the timeline on track but should not be shown to the player.
 Timeline triggers can still match hidden entries.
+
+#### other commands
 
 There are a number of other commands for generating alerts based on timeline entries.
 These are still supported but are not documented.
@@ -389,7 +436,7 @@ For example:
 
 ```text
 # Landfast Floe will be sealed off
-100.0 "--sync--" SystemLogMessage { id: "7DC", param1: "10CD" } window 100000,0
+100.0 "--sync--" SystemLogMessage { id: "7DC", param1: "10CD" } window 100,0
 ```
 
 (`make_timeline` generates this by default if the encounter begins with a zone seal.)
@@ -431,14 +478,14 @@ On fights where the entire zone resets (e.g. all of omegascape, a4s, a8s, a12s, 
 you can use the ActorControl line that is sent on a wipe:
 
 ```bash
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 ```
 
 On fights with zones that seal and unseal, (e.g. a1s, t1-8)
 you can use the zone unsealing message itself to reset:
 
 ```bash
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 ```
 
 This `SystemLogMessage` is the equivalent to the `GameLog` line for something like
@@ -716,8 +763,9 @@ to turn on filtering.  From your cactbot directory, run the following command:
 Alternatively, you can use the web-based [log splitter](https://overlayplugin.github.io/cactbot/util/logtools/splitter.html) tool
 and check the option to filter the log for analysis.
 
-This filtering should limit the exported log lines to just boss abilities and casts, added combatants, tethers,
-map effects, head markers, and debuffs applied to and removed from players. It's not perfect, but it's a place to start.
+This filtering will limit the exported log lines to things that are potentially useful in writing triggers,
+like boss abilities, added combatants, tethers, map effects, head markers,
+and debuffs applied to and removed from players. It's not perfect, but it's a place to start.
 
 You can then walk through a log with video, and look at which abilities hit players and do damage
 and which are castbars on the boss (not all `StartsUsing` are castbars) and then fill out the ability table
@@ -989,6 +1037,7 @@ it will automatically show 10 seconds until `Tetraktys 1` at `1280.9`.
 Here's what the timeline looks like.
 
 ```text
+#cactbot-timeline-lint-disable-sync-order
 # => Snake first branch
 58.7 "--sync--" #Ability { id: "7108", source: "Hephaistos" }
 63.9 "--sync--" Ability { id: "794C", source: "Hephaistos" } window 100,100 jump 163.9
@@ -1004,9 +1053,14 @@ Here's what the timeline looks like.
 79.3 "Uplift 2?" #Ability { id: "7935", source: "Hephaistos" }
 81.5 "Uplift 3?" #Ability { id: "7935", source: "Hephaistos" }
 83.6 "Uplift 4?" #Ability { id: "7935", source: "Hephaistos" }
+#cactbot-timeline-lint-enable-sync-order
 ```
 
 Note: this old timeline does not use `forcejump` or `label` but should!
+Note 2: This is an example of when adn how `#cactbot-timeline-lint...`
+should be used to disable sync order linting.
+Otherwise, this timeline file would fail validation when added to the repo due to the
+out-of-order sync times.
 
 `794C` and `794B` are the first abilities that differ between the two branches
 and so are used as the jumping point with a large `window` (just in case)

--- a/test/helper/test_timeline.ts
+++ b/test/helper/test_timeline.ts
@@ -9,7 +9,12 @@ import Regexes from '../../resources/regexes';
 import { translateWithReplacements } from '../../resources/translations';
 import { LooseTimelineTrigger, LooseTriggerSet } from '../../types/trigger';
 import { CommonReplacement, commonReplacement } from '../../ui/raidboss/common_replacement';
-import { TimelineParser, TimelineReplacement, Error, regexes } from '../../ui/raidboss/timeline_parser';
+import {
+  Error,
+  regexes,
+  TimelineParser,
+  TimelineReplacement,
+} from '../../ui/raidboss/timeline_parser';
 
 const parseTimelineFileFromTriggerFile = (filepath: string) => {
   const fileContents = fs.readFileSync(filepath, 'utf8');
@@ -387,10 +392,10 @@ const testTimelineFiles = (timelineFiles: string[]): void => {
           // Dynamic imports don't have a type, so add type assertion.
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           triggerSet = (await import(importPath)).default as LooseTriggerSet;
-            timeline = new TimelineParserLint(
-              timelineText,
-              triggerSet.timelineTriggers ?? [],
-            );
+          timeline = new TimelineParserLint(
+            timelineText,
+            triggerSet.timelineTriggers ?? [],
+          );
         });
         // This test loads an individual raidboss timeline and makes sure
         // that timeline.js can parse it without errors.

--- a/test/helper/test_timeline.ts
+++ b/test/helper/test_timeline.ts
@@ -44,7 +44,7 @@ class TimelineParserLint extends TimelineParser {
   private lastSyncTime = 0;
   // Override to stop checking sync order during linting
   private ignoreSyncOrder = false;
-  // Capture lint errors separatly from TimelineParser's errors so we can do a separate unit test
+  // Capture lint errors separately from TimelineParser's errors so we can do a separate unit test
   public lintErrors: LintError[] = [];
 
   constructor(
@@ -142,7 +142,7 @@ class TimelineParserLint extends TimelineParser {
       this.lintErrors.push({
         lineNumber: lineNumber,
         line: origLine,
-        error: 'Sync time must be an integer or float with a single-digit fractional',
+        error: 'Sync time must be an integer or a float with a single decimal place',
       });
       // don't return; continue processing the line
     }
@@ -156,7 +156,8 @@ class TimelineParserLint extends TimelineParser {
           error:
             `Sync time of "${time.toString()}" predates prior entry of "${this.lastSyncTime.toString()}"`,
         });
-      this.lastSyncTime = time;
+      else
+        this.lastSyncTime = time;
       // don't return; continue processing the line
     }
 
@@ -575,7 +576,7 @@ const testTimelineFiles = (timelineFiles: string[]): void => {
             }
           }
         });
-        it('should not have lint', () => {
+        it('should not have lint errors', () => {
           let errorStr = '';
           for (const err of timeline.lintErrors) {
             errorStr += `\n${err.lineNumber}:${err.error}:${err.line}`;

--- a/test/helper/test_timeline.ts
+++ b/test/helper/test_timeline.ts
@@ -159,7 +159,15 @@ const testTimelineFiles = (timelineFiles: string[]): void => {
           // Dynamic imports don't have a type, so add type assertion.
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           triggerSet = (await import(importPath)).default as LooseTriggerSet;
-          timeline = new TimelineParser(timelineText, [], triggerSet.timelineTriggers ?? []);
+          timeline = new TimelineParser(
+            timelineText,
+            [],
+            triggerSet.timelineTriggers ?? [],
+            undefined, // styles
+            undefined, // options
+            undefined, // zoneId
+            true, // runLint
+          );
         });
         // This test loads an individual raidboss timeline and makes sure
         // that timeline.js can parse it without errors.

--- a/test/helper/test_timeline.ts
+++ b/test/helper/test_timeline.ts
@@ -4,11 +4,12 @@ import path from 'path';
 import { assert } from 'chai';
 
 import { keysThatRequireTranslation } from '../../resources/netregexes';
+import { UnreachableCode } from '../../resources/not_reached';
 import Regexes from '../../resources/regexes';
 import { translateWithReplacements } from '../../resources/translations';
-import { LooseTriggerSet } from '../../types/trigger';
+import { LooseTimelineTrigger, LooseTriggerSet } from '../../types/trigger';
 import { CommonReplacement, commonReplacement } from '../../ui/raidboss/common_replacement';
-import { TimelineParser, TimelineReplacement } from '../../ui/raidboss/timeline_parser';
+import { TimelineParser, TimelineReplacement, Error, regexes } from '../../ui/raidboss/timeline_parser';
 
 const parseTimelineFileFromTriggerFile = (filepath: string) => {
   const fileContents = fs.readFileSync(filepath, 'utf8');
@@ -18,6 +19,233 @@ const parseTimelineFileFromTriggerFile = (filepath: string) => {
     throw new Error(`Error: Trigger file ${filepath} has no timelineFile attribute defined`);
   return timelineFile;
 };
+
+// syncKeywords must appear on a sync line in the order specified
+const syncKewordsOrder = [
+  'duration',
+  'window',
+  'jump',
+  'forcejump',
+];
+
+// Make all props required
+type LintError = Error & {
+  lineNumber: number;
+  line: string;
+};
+
+class TimelineParserLint extends TimelineParser {
+  // Track the last sync time during linting to ensure proper order
+  private lastSyncTime = 0;
+  // Override to stop checking sync order during linting
+  private ignoreSyncOrder = false;
+  // Capture lint errors separatly from TimelineParser's errors so we can do a separate unit test
+  public lintErrors: LintError[] = [];
+
+  constructor(
+    text: string,
+    triggers: LooseTimelineTrigger[],
+  ) {
+    super(text, [], triggers); // calls TimelineParser's parse() method
+    this.lintTimelineFile(text);
+  }
+
+  private lintTimelineFile(text: string): void {
+    const lines = text.split('\n');
+    let lineNumber = 0;
+    for (const line of lines) {
+      ++lineNumber;
+
+      if (line.includes('#cactbot-timeline-lint-disable-sync-order'))
+        this.ignoreSyncOrder = true;
+      else if (line.includes('#cactbot-timeline-lint-enable-sync-order'))
+        this.ignoreSyncOrder = false;
+
+      if (!line || regexes.comment.test(line))
+        continue;
+
+      this.lintLine(line, lineNumber);
+    }
+  }
+
+  private lintLine(
+    line: string,
+    lineNumber: number,
+  ): void {
+    const origLine = line;
+    // First, reduce all double-quoted strings to just "".  We don't check/lint string contents,
+    // and this avoids various problems like inadvertently matching double-spaces inside a string,
+    // or the use of a {} regex occurence modifier causing errors in identifying line groups.
+    line = line.replace(/"[^"]*?"/g, '""');
+
+    line = line.replace(/\r/g, ''); // remove \r before checking for extraneous whitespace
+    if (line.trim() !== line) {
+      this.lintErrors.push({
+        lineNumber: lineNumber,
+        line: origLine,
+        error: 'Line has leading or trailing whitespace',
+      });
+    }
+    line = line.trim();
+
+    // Remove in-line comments from further lint checks
+    line = line.replace(/#.*$/, '').trim();
+    if (line.length === 0)
+      return;
+
+    // There should be no remaining allowable double-spacing within the line
+    if (line.match(/ {2}.+/)) {
+      this.lintErrors.push({
+        lineNumber: lineNumber,
+        line: origLine,
+        error: 'Line has double spaces not enclosed by quotes',
+      });
+      // don't return; continue processing the line
+    }
+
+    // Capture each part of the line (separated by spaces).
+    // Anything encapsulated by double-quotes or braces will be treated as a single element.
+    const lineParts = line.match(/"[^"]*"|\{[^}]*\}|[^ ]+/g);
+    if (lineParts === null || lineParts[0] === undefined) {
+      this.lintErrors.push({
+        lineNumber: lineNumber,
+        line: origLine,
+        error: 'Bad format - cannot parse line into parts for further linting',
+      });
+      return;
+    }
+
+    const first = lineParts[0];
+    if (first === 'hideall') {
+      // parse() throws errors if a hideall line has an invalid format
+      return;
+    }
+
+    // At this point, if `first` is not a time, it's not a valid timeline entry
+    const time = parseFloat(first);
+    if (isNaN(time)) {
+      this.lintErrors.push({
+        lineNumber: lineNumber,
+        line: origLine,
+        error: 'Line does not begin with a config keyword, comment, or sync time.',
+      });
+      return;
+    }
+
+    // Ensure that the time is either an integer or has a single digit after the decimal
+    if (!Number.isInteger(time) && !/^\d+\.\d$/.test(time.toString())) {
+      this.lintErrors.push({
+        lineNumber: lineNumber,
+        line: origLine,
+        error: 'Sync time must be an integer or float with a single-digit fractional',
+      });
+      // don't return; continue processing the line
+    }
+
+    // Enforce chronological order of sync lines
+    if (!this.ignoreSyncOrder) {
+      if (time < this.lastSyncTime)
+        this.lintErrors.push({
+          lineNumber: lineNumber,
+          line: origLine,
+          error:
+            `Sync time of "${time.toString()}" predates prior entry of "${this.lastSyncTime.toString()}"`,
+        });
+      this.lastSyncTime = time;
+      // don't return; continue processing the line
+    }
+
+    const second = lineParts[1];
+    if (second === undefined) {
+      this.lintErrors.push({
+        lineNumber: lineNumber,
+        line: origLine,
+        error: 'Sync time specified with no other parameters',
+      });
+      return;
+    }
+    // parse() throws errors if the label line is invalidly formatted.
+    if (second === 'label')
+      return;
+
+    // This is a normal timeline entry
+
+    // Some entries may only have a time and name with nothing else.
+    // They may also have a duration keyword (and only that keyword).
+    // parse() throws errors if a no-sync line has invalid args
+    if (lineParts.length === 2)
+      return;
+    else if (lineParts[2] === 'duration' && lineParts.length === 4)
+      return;
+
+    // From this point, we should expect [time] [name] [type] [NetRegex]
+    // So just check keyword ordering (everything after), and 'window' format.
+    const keywords = lineParts.slice(4);
+    if (keywords.length === 0)
+      return;
+
+    const keywordList = keywords.filter((_, i) => i % 2 === 0);
+    for (let i = 0; i < keywordList.length - 1; i++) {
+      const thisKeyword = keywordList[i];
+      if (thisKeyword === undefined)
+        throw new UnreachableCode();
+
+      if (!syncKewordsOrder.includes(thisKeyword)) {
+        this.lintErrors.push({
+          lineNumber: lineNumber,
+          line: origLine,
+          error: `Keyword "${thisKeyword}" is not valid`,
+        });
+        return;
+      }
+
+      // check that `window` is in a [number],[number] format
+      if (thisKeyword === 'window') {
+        const windowKwIdx = keywords.indexOf('window');
+        const windowArgs = keywords[windowKwIdx + 1];
+        if (windowArgs === undefined) {
+          this.lintErrors.push({
+            lineNumber: lineNumber,
+            line: origLine,
+            error: `Missing parameter for 'window' keyword`,
+          });
+          return;
+        }
+        if (!/^\d+(\.\d)?,\d+(\.\d)?$/.test(windowArgs)) {
+          this.lintErrors.push({
+            lineNumber: lineNumber,
+            line: origLine,
+            error: `Invalid 'window' parameter "${windowArgs}": must be in [#],[#] format.`,
+          });
+          // don't return; continue processing the line
+        }
+      }
+
+      const nextKeyword = keywordList[i + 1];
+      if (nextKeyword === undefined)
+        break;
+
+      if (!syncKewordsOrder.includes(nextKeyword)) {
+        this.lintErrors.push({
+          lineNumber: lineNumber,
+          line: origLine,
+          error: `Cannot validate keyword order - invalid next keyword "${nextKeyword}"`,
+        });
+        return;
+      }
+
+      if (syncKewordsOrder.indexOf(thisKeyword) > syncKewordsOrder.indexOf(nextKeyword)) {
+        this.lintErrors.push({
+          lineNumber: lineNumber,
+          line: origLine,
+          error: `Keyword "${thisKeyword}" cannot precede "${nextKeyword}"`,
+        });
+        return;
+      }
+    }
+    return;
+  }
+}
 
 type TestFile = {
   timelineFile: string;
@@ -147,7 +375,7 @@ const testTimelineFiles = (timelineFiles: string[]): void => {
         const triggersFile = testFile.triggersFile;
         let timelineText;
         let triggerSet: LooseTriggerSet;
-        let timeline: TimelineParser;
+        let timeline: TimelineParserLint;
 
         before(async () => {
           // Normalize path
@@ -159,15 +387,10 @@ const testTimelineFiles = (timelineFiles: string[]): void => {
           // Dynamic imports don't have a type, so add type assertion.
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           triggerSet = (await import(importPath)).default as LooseTriggerSet;
-          timeline = new TimelineParser(
-            timelineText,
-            [],
-            triggerSet.timelineTriggers ?? [],
-            undefined, // styles
-            undefined, // options
-            undefined, // zoneId
-            true, // runLint
-          );
+            timeline = new TimelineParserLint(
+              timelineText,
+              triggerSet.timelineTriggers ?? [],
+            );
         });
         // This test loads an individual raidboss timeline and makes sure
         // that timeline.js can parse it without errors.
@@ -346,6 +569,13 @@ const testTimelineFiles = (timelineFiles: string[]): void => {
               }
             }
           }
+        });
+        it('should not have lint', () => {
+          let errorStr = '';
+          for (const err of timeline.lintErrors) {
+            errorStr += `\n${err.lineNumber}:${err.error}:${err.line}`;
+          }
+          assert.isEmpty(errorStr, `${errorStr}\n`);
         });
       });
     }

--- a/ui/raidboss/data/00-misc/test.txt
+++ b/ui/raidboss/data/00-misc/test.txt
@@ -16,7 +16,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0 "--Reset--" GameLog { code: "001D", line: "You bid farewell to the striking dummy.*?" } window 10000 jump 0
+0 "--Reset--" GameLog { code: "001D", line: "You bid farewell to the striking dummy.*?" } window 0,10000 jump 0
 
 # two examples with different quoting which should both be supported
 0 "--sync--" GameLog { line: 'testNetRegexTimeline' } window 100000,100000

--- a/ui/raidboss/data/02-arr/raid/t12.txt
+++ b/ui/raidboss/data/02-arr/raid/t12.txt
@@ -34,7 +34,7 @@ hideall "Scorched Pinion"
 268.3 "Redfire" Ability { id: "B93", source: "Phoenix" }
 
 280.6 "Bluefire" Ability { id: "B91", source: "Phoenix" } duration 4.1
-293.6 "Flames Of Unforgiveness" Ability { id: "B8B", source: "Phoenix" } jump 223.6 window 20,20
+293.6 "Flames Of Unforgiveness" Ability { id: "B8B", source: "Phoenix" } window 20,20 jump 223.6
 301.0 "Redfire"
 307.1 "Revelation"
 

--- a/ui/raidboss/data/02-arr/raid/t13.txt
+++ b/ui/raidboss/data/02-arr/raid/t13.txt
@@ -127,7 +127,7 @@ hideall "--sync--"
 672.2 "Pain Add (W)"
 692.8 "--sync--" Ability { id: "BBF", source: "Bahamut Prime" }
 698.9 "Megaflare Dive" Ability { id: "BC0", source: "Bahamut Prime" }
-702.1 "--sync--" Ability { id: "BB  E", source: "Bahamut Prime" }
+702.1 "--sync--" Ability { id: "BBE", source: "Bahamut Prime" }
 702.9 "MF Spread"
 705.1 "MF Pepperoni"
 707.2 "MF Share"
@@ -138,7 +138,7 @@ hideall "--sync--"
 735.6 "--sync--" Ability { id: "BBE", source: "Bahamut Prime" }
 737.8 "--sync--" Ability { id: "BBF", source: "Bahamut Prime" }
 
-745.1 "Akh Morn x2" Ability { id: "BC2", source: "Bahamut Prime" } window 40,40 duration 2.1
+745.1 "Akh Morn x2" Ability { id: "BC2", source: "Bahamut Prime" } duration 2.1 window 40,40
 759.5 "Megaflare" Ability { id: "BAF", source: "Bahamut Prime" }
 764.6 "MF Pepperoni"
 766.6 "Tempest Wing" Ability { id: "BC4", source: "Bahamut Prime" }
@@ -152,7 +152,7 @@ hideall "--sync--"
 794.9 "--sync--" Ability { id: "C89", source: "Bahamut Prime" }
 795.9 "Flare Breath" Ability { id: "BAD", source: "Bahamut Prime" }
 
-807.1 "Akh Morn x3" Ability { id: "BC2", source: "Bahamut Prime" } window 40,40 duration 3.1
+807.1 "Akh Morn x3" Ability { id: "BC2", source: "Bahamut Prime" } duration 3.1 window 40,40
 822.3 "Megaflare" Ability { id: "BAF", source: "Bahamut Prime" }
 827.4 "MF Pepperoni"
 829.4 "Tempest Wing" Ability { id: "BC4", source: "Bahamut Prime" }
@@ -168,7 +168,7 @@ hideall "--sync--"
 
 871.4 "Gigaflare" Ability { id: "BB9", source: "Bahamut Prime" } window 100,100
 
-880.8 "Akh Morn x4" Ability { id: "BC2", source: "Bahamut Prime" } window 40,40 duration 4.1
+880.8 "Akh Morn x4" Ability { id: "BC2", source: "Bahamut Prime" } duration 4.1 window 40,40
 897.2 "Megaflare" Ability { id: "BAF", source: "Bahamut Prime" }
 902.3 "MF Pepperoni"
 904.3 "Tempest Wing" Ability { id: "BC4", source: "Bahamut Prime" }
@@ -182,7 +182,7 @@ hideall "--sync--"
 932.6 "--sync--" Ability { id: "C89", source: "Bahamut Prime" }
 933.6 "Flare Breath" Ability { id: "BAD", source: "Bahamut Prime" }
 
-944.8 "Akh Morn x5" Ability { id: "BC2", source: "Bahamut Prime" } window 40,40 duration 5.1
+944.8 "Akh Morn x5" Ability { id: "BC2", source: "Bahamut Prime" } duration 5.1 window 40,40
 962.2 "Megaflare" Ability { id: "BAF", source: "Bahamut Prime" }
 967.3 "MF Pepperoni"
 969.3 "Tempest Wing" Ability { id: "BC4", source: "Bahamut Prime" }
@@ -198,7 +198,7 @@ hideall "--sync--"
 
 1011.3 "Gigaflare" Ability { id: "BB9", source: "Bahamut Prime" } window 100,100
 
-1020.7 "Akh Morn x6" Ability { id: "BC2", source: "Bahamut Prime" } window 40,40 duration 6.1
+1020.7 "Akh Morn x6" Ability { id: "BC2", source: "Bahamut Prime" } duration 6.1 window 40,40
 1039.1 "Megaflare" Ability { id: "BAF", source: "Bahamut Prime" }
 1044.2 "MF Pepperoni"
 1046.2 "Tempest Wing" Ability { id: "BC4", source: "Bahamut Prime" }
@@ -212,7 +212,7 @@ hideall "--sync--"
 1074.5 "--sync--" Ability { id: "C89", source: "Bahamut Prime" }
 1075.5 "Flare Breath" Ability { id: "BAD", source: "Bahamut Prime" }
 
-1086.7 "Akh Morn x7" Ability { id: "BC2", source: "Bahamut Prime" } window 40,40 duration 7.1
+1086.7 "Akh Morn x7" Ability { id: "BC2", source: "Bahamut Prime" } duration 7.1 window 40,40
 1106.1 "Megaflare" Ability { id: "BAF", source: "Bahamut Prime" }
 1111.2 "MF Pepperoni"
 1113.2 "Tempest Wing" Ability { id: "BC4", source: "Bahamut Prime" }

--- a/ui/raidboss/data/02-arr/raid/t4.txt
+++ b/ui/raidboss/data/02-arr/raid/t4.txt
@@ -1,22 +1,22 @@
 ### T4
 # http://forum.square-enix.com/ffxiv/threads/103985-EXTREME-BINDING-COIL-OF-BAHAMUT-TURN-4-GUIDE
 
-0.0 "6x Bug" AddedCombatant { name: "Clockwork Bug" }  window 0,1
+0.0 "6x Bug" AddedCombatant { name: "Clockwork Bug" } window 0,1
 
-63.0 "Knight + Soldier (NW)" AddedCombatant { name: "Clockwork Knight" }  window 70,0
+63.0 "Knight + Soldier (NW)" AddedCombatant { name: "Clockwork Knight" } window 70,0
 63.0 "Knight + Soldier (NE)"
 
-123.0 "Dreadnaught (NW)" AddedCombatant { name: "Clockwork Dreadnaught" }  window 130,0
+123.0 "Dreadnaught (NW)" AddedCombatant { name: "Clockwork Dreadnaught" } window 130,0
 123.0 "4x Bug (S)"
 
-183.0 "2x Rook (E/W)" AddedCombatant { name: "Spinner-rook" }  window 190,0
+183.0 "2x Rook (E/W)" AddedCombatant { name: "Spinner-rook" } window 190,0
 183.0 "4x Bug (outside)"
 
-243.0 "Dreadnaught (NE)" AddedCombatant { name: "Clockwork Dreadnaught" }  window 115,0
+243.0 "Dreadnaught (NE)" AddedCombatant { name: "Clockwork Dreadnaught" } window 115,0
 243.0 "Soldier (center)"
 243.0 "Knight (SE)"
 
-303.0 "Dreadnaught (NE)" AddedCombatant { name: "Clockwork Dreadnaught" }  window 55,0
+303.0 "Dreadnaught (NE)" AddedCombatant { name: "Clockwork Dreadnaught" } window 55,0
 303.0 "Knight (center)"
 303.0 "Soldier (SW)"
 303.0 "Rook (NE)"

--- a/ui/raidboss/data/02-arr/raid/t7.txt
+++ b/ui/raidboss/data/02-arr/raid/t7.txt
@@ -55,15 +55,15 @@ hideall "--sync--"
 ### Phase 2 (80%): shriek, 3 adds 30 seconds apart
 # Note: This used to be synced from a HP% log line that is no longer present.
 306.6 "Tail Slap" Ability { id: "7A8", source: "Melusine" } window 10,10
-345.6 "Cursed Voice" Ability { id: "7AC", source: "Melusine" } window 155,10
 314.6 "Circle Of Flames x2" #Ability { id: "7AA", source: "Melusine" }
-319.0 "Cursed Shriek" Ability { id: "7AF", source: "Melusine" } window 319,30 duration 11
+319.0 "Cursed Shriek" Ability { id: "7AF", source: "Melusine" } duration 11 window 319,30
 322.6 "Tail Slap" Ability { id: "7A8", source: "Melusine" }
 328.2 "Circle Blade" Ability { id: "7AB", source: "Melusine" }
 330.0 "Deathdancer Add (NE)"
 330.7 "Circle Of Flames x2" #Ability { id: "7AA", source: "Melusine" }
 336.6 "Cursed Voice" Ability { id: "7AC", source: "Melusine" }
 338.8 "Tail Slap" Ability { id: "7A8", source: "Melusine" }
+345.6 "Cursed Voice" Ability { id: "7AC", source: "Melusine" } window 155,10
 346.7 "Circle Of Flames x2" #Ability { id: "7AA", source: "Melusine" }
 
 354.6 "Tail Slap" Ability { id: "7A8", source: "Melusine" }

--- a/ui/raidboss/data/02-arr/raid/t9.txt
+++ b/ui/raidboss/data/02-arr/raid/t9.txt
@@ -108,7 +108,7 @@ hideall "--sync--"
 500.0 "--untargetable--"
 503.3 "Golem Meteors" HeadMarker { id: "0007" } duration 11 window 505,0
 514.3 "--sync--" Ability { id: "7EB", source: "Dalamud Fragment" }
-582.3 "Meteor 1/6" duration 7 HeadMarker { id: "000[9A]" } window 83,0
+582.3 "Meteor 1/6" HeadMarker { id: "000[9A]" } duration 7 window 83,0
 584.3 "Meteor 2/6" duration 7
 586.3 "Meteor 3/6" duration 7
 588.3 "Meteor 4/6" duration 7

--- a/ui/raidboss/data/02-arr/trial/shiva-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/shiva-ex.txt
@@ -136,7 +136,7 @@ hideall "--Reset--"
 801.0 "--sync--" #Ability { id: "C7F", source: "Shiva" }
 # If you push *really* fast and skip a 3a/3b weapon phase, you'll miss the melt jump.
 # So, fix that up with a combatant sync here.
-806.6 "--adds targetable--" AddedCombatant { name: "Ice Soldier" }  window 807,10
+806.6 "--adds targetable--" AddedCombatant { name: "Ice Soldier" } window 807,10
 807.6 "Dreams Of Ice" Ability { id: "BEA", source: "Shiva" }
 813.2 "Frost Blade" Ability { id: "993", source: "Shiva" }
 818.5 "Icebrand" Ability { id: "BE1", source: "Shiva" }

--- a/ui/raidboss/data/02-arr/trial/shiva-hm.txt
+++ b/ui/raidboss/data/02-arr/trial/shiva-hm.txt
@@ -66,7 +66,7 @@ hideall "--Reset--"
 800.0 "Melt" Ability { id: "994", source: "Shiva" } window 800,0
 # If you push *really* fast and skip a weapon phase, you'll miss the melt jump.
 # So, fix that up with a combatant sync here.
-806.2 "--adds targetable--" AddedCombatant { name: "Ice Soldier" }  window 807,2.5
+806.2 "--adds targetable--" AddedCombatant { name: "Ice Soldier" } window 807,2.5
 809.9 "Dreams Of Ice" Ability { id: "99D", source: "Shiva" }
 
 # Note: Yes, really.  These times are different.
@@ -87,8 +87,8 @@ hideall "--Reset--"
 1079.1 "Dreams Of Ice" Ability { id: "99D", source: "Shiva" }
 1088.3 "Icicle Impact (circle)" duration 4 #Ability { id: "99E", source: "Shiva" }
 
-1095.3 "Frost Staff?" Ability { id: "995", source: "Shiva" } jump 1400 window 50,90
-1095.3 "Frost Blade?" Ability { id: "993", source: "Shiva" } jump 1600 window 50,90
+1095.3 "Frost Staff?" Ability { id: "995", source: "Shiva" } window 50,90 jump 1400
+1095.3 "Frost Blade?" Ability { id: "993", source: "Shiva" } window 50,90 jump 1600
 
 
 # Phase 4b: Adds (Blade)
@@ -106,8 +106,8 @@ hideall "--Reset--"
 1284.2 "Dreams Of Ice" Ability { id: "99D", source: "Shiva" }
 1293.4 "Icicle Impact (circle)" duration 4 #Ability { id: "99E", source: "Shiva" }
 
-1300.6 "Frost Staff?" Ability { id: "995", source: "Shiva" } jump 1400 window 50,90
-1300.6 "Frost Blade?" Ability { id: "993", source: "Shiva" } jump 1600 window 50,90
+1300.6 "Frost Staff?" Ability { id: "995", source: "Shiva" } window 50,90 jump 1400
+1300.6 "Frost Blade?" Ability { id: "993", source: "Shiva" } window 50,90 jump 1600
 
 
 # Phase 5a: Staff
@@ -120,8 +120,8 @@ hideall "--Reset--"
 1440.5 "Dreams Of Ice" Ability { id: "99D", source: "Shiva" }
 1450.7 "Icicle Impact" Ability { id: "99E", source: "Shiva" }
 
-1454.7 "Frost Staff?" Ability { id: "995", source: "Shiva" } jump 1800 window 50,90
-1454.7 "Frost Blade?" Ability { id: "993", source: "Shiva" } jump 2000 window 50,90
+1454.7 "Frost Staff?" Ability { id: "995", source: "Shiva" } window 50,90 jump 1800
+1454.7 "Frost Blade?" Ability { id: "993", source: "Shiva" } window 50,90 jump 2000
 
 
 # Phase 5b: Blade
@@ -136,8 +136,8 @@ hideall "--Reset--"
 1643.1 "Dreams Of Ice" Ability { id: "99D", source: "Shiva" }
 1653.3 "Icicle Impact" #Ability { id: "99E", source: "Shiva" }
 
-1657.6 "Frost Staff?" Ability { id: "995", source: "Shiva" } jump 1800 window 90,90
-1657.6 "Frost Blade?" Ability { id: "993", source: "Shiva" } jump 2000 window 90,90
+1657.6 "Frost Staff?" Ability { id: "995", source: "Shiva" } window 90,90 jump 1800
+1657.6 "Frost Blade?" Ability { id: "993", source: "Shiva" } window 90,90 jump 2000
 
 
 # Phase 6a: Staff
@@ -150,8 +150,8 @@ hideall "--Reset--"
 1837.5 "Dreams Of Ice" Ability { id: "99D", source: "Shiva" }
 1847.8 "Icicle Impact" Ability { id: "99E", source: "Shiva" }
 
-1851.8 "Frost Staff?" Ability { id: "995", source: "Shiva" } jump 1800 window 90,90
-1851.8 "Frost Blade?" Ability { id: "993", source: "Shiva" } jump 2000 window 90,90
+1851.8 "Frost Staff?" Ability { id: "995", source: "Shiva" } window 90,90 jump 1800
+1851.8 "Frost Blade?" Ability { id: "993", source: "Shiva" } window 90,90 jump 2000
 
 
 # Phase 6b: Blade
@@ -164,5 +164,5 @@ hideall "--Reset--"
 2038.5 "Dreams Of Ice" Ability { id: "99D", source: "Shiva" }
 2048.7 "Icicle Impact" #Ability { id: "99E", source: "Shiva" }
 
-2053.5 "Frost Staff?" Ability { id: "995", source: "Shiva" } jump 1800 window 90,90
-2053.5 "Frost Blade?" Ability { id: "993", source: "Shiva" } jump 2000 window 90,90
+2053.5 "Frost Staff?" Ability { id: "995", source: "Shiva" } window 90,90 jump 1800
+2053.5 "Frost Blade?" Ability { id: "993", source: "Shiva" } window 90,90 jump 2000

--- a/ui/raidboss/data/02-arr/trial/ultima-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/ultima-ex.txt
@@ -164,10 +164,10 @@ hideall "--sync--"
 658.7 "Tank Purge?" #Ability { id: "5EA", source: "The Ultima Weapon" }
 662.0 "Homing Lasers" Ability { id: "5E1", source: "The Ultima Weapon" } window 12,5
 667.3 "Ceruleum Vent" Ability { id: "5E0", source: "The Ultima Weapon" }
-670.7 "Viscous Aetheroplasm?" #Ability { id: "5DF", source: "The Ultima Weapon" }
 
 # From here, the late Cyclone/EruptionHoming Lasers blocks are added.
 669.9 "--sync--" StartsUsing { id: "5F1", source: "The Ultima Weapon" } window 15,15 jump 697.3 # Radiant Plume
+670.7 "Viscous Aetheroplasm?" #Ability { id: "5DF", source: "The Ultima Weapon" }
 671.0 "--sync--" StartsUsing { id: "5F4", source: "The Ultima Weapon" } window 15,15 jump 797.3 # Eruption
 672.6 "Radiant Plume?"
 673.7 "Eruption x5?"
@@ -205,7 +205,7 @@ hideall "--sync--"
 819.2 "Ceruleum Vent" Ability { id: "5E0", source: "The Ultima Weapon" }
 822.5 "Viscous Aetheroplasm" Ability { id: "5DF", source: "The Ultima Weapon" }
 
-825.1 "--sync--" StartsUsing { id: "5F1", source: "The Ultima Weapon" } window 15,15 jump 697.3 # Radiant  Plume
+825.1 "--sync--" StartsUsing { id: "5F1", source: "The Ultima Weapon" } window 15,15 jump 697.3 # Radiant Plume
 827.8 "Radiant Plume?"
 829.8 "Homing Lasers?" Ability { id: "5E1", source: "The Ultima Weapon" } window 10,10 jump 900
 830.6 "Crimson Cyclone?"

--- a/ui/raidboss/data/03-hw/alliance/dun_scaith.txt
+++ b/ui/raidboss/data/03-hw/alliance/dun_scaith.txt
@@ -291,7 +291,7 @@ hideall "--sync--"
 
 # Intermission at 45% HP. Might be a time push too? but it's uncertain.
 3300.0 "--untargetable--" NameToggle { name: "Scathach", toggle: "00" } window 300,5
-3302.2 "--sync--" AddedCombatant { name: "Shadowcourt Jester" }  window 300,5
+3302.2 "--sync--" AddedCombatant { name: "Shadowcourt Jester" } window 300,5
 3323.6 "--towers appear--"
 3333.6 "Particle Beam" Ability { id: "1D2[78]", source: "Scathach" }
 
@@ -403,9 +403,9 @@ hideall "--sync--"
 # This is the dueling-lasers part where the party kills the big deathgate and two small ones.
 
 4274.0 "--sync--" NameToggle { name: "Diabolos", toggle: "00" } window 100,5
-4286.2 "--lifegate spawn--" AddedCombatant { name: "Lifegate" }  window 300,5
+4286.2 "--lifegate spawn--" AddedCombatant { name: "Lifegate" } window 300,5
 4300.0 "--sync--" Ability { id: "1C16", source: "Diabolos" } window 300,5
-4320.0 "--deathgate spawn--" AddedCombatant { name: "Deathgate" }  window 50,5
+4320.0 "--deathgate spawn--" AddedCombatant { name: "Deathgate" } window 50,5
 4477.1 "--sync--" Ability { id: "1AFB", source: "Diabolos" } window 177,5
 4488.5 "--sync--" Ability { id: "1AFD", source: "Diabolos" }
 4494.6 "Dream Shroud" Ability { id: "1DB1", source: "Diabolos Hollow" } window 194,5
@@ -452,7 +452,7 @@ hideall "--sync--"
 4613.6 "Shadethrust" Ability { id: "1C1A", source: "Diabolos Hollow" }
 4620.4 "Particle Beam" Ability { id: "1C2[456]", source: "Diabolos Hollow" }
 4620.8 "Hollow Camisado" Ability { id: "1C19", source: "Diabolos Hollow" }
-4624.1 "--deathgate spawn--" AddedCombatant { name: "Deathgate" }  window 25,5
+4624.1 "--deathgate spawn--" AddedCombatant { name: "Deathgate" } window 25,5
 4627.1 "Hollowshield" Ability { id: "1C1E", source: "Diabolos Hollow" } window 27.1,5
 4637.5 "Hollow Camisado" Ability { id: "1C19", source: "Diabolos Hollow" }
 4646.8 "Shadethrust" Ability { id: "1C1A", source: "Diabolos Hollow" } window 20,10

--- a/ui/raidboss/data/03-hw/alliance/dun_scaith.txt
+++ b/ui/raidboss/data/03-hw/alliance/dun_scaith.txt
@@ -205,7 +205,7 @@ hideall "--sync--"
 # Timing might be a little different?
 2060.0 "Aether Bend" Ability { id: "1D99", source: "Proto Ultima" } window 30,15 jump 2007.8
 2070.6 "Aetherochemical Laser 1"
-2074.6 "Aetherochemical Laser 2" 
+2074.6 "Aetherochemical Laser 2"
 2078.6 "Aetherochemical Laser 3"
 2079.8 "Diffractive Laser"
 2085.8 "Light Pillar x8"

--- a/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
+++ b/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
@@ -415,7 +415,7 @@ hideall "--sync--"
 3092.6 "Height Of Chaos"
 
 # Intermission 1 at HP < 80%
-3100.0 "--sync--" AddedCombatant { name: "Firesphere" }  window 100,5
+3100.0 "--sync--" AddedCombatant { name: "Firesphere" } window 100,5
 
 3110.0 "Ancient Circle Appears"
 3115.1 "Ancient Circle" Ability { id: "1102", source: "Ascian Prime" }
@@ -442,7 +442,7 @@ hideall "--sync--"
 3260.0 "Shadow Flare"
 
 # Intermission 2 at HP < 40%
-3300.0 "--sync--" AddedCombatant { name: "Firesphere" }  window 200,5
+3300.0 "--sync--" AddedCombatant { name: "Firesphere" } window 200,5
 
 3304.6 "Ancient Circle Appears"
 3309.7 "Ancient Circle" Ability { id: "1102", source: "Ascian Prime" }

--- a/ui/raidboss/data/03-hw/dungeon/baelsars_wall.txt
+++ b/ui/raidboss/data/03-hw/dungeon/baelsars_wall.txt
@@ -26,7 +26,7 @@ hideall "--sync--"
 68.7 "Magitek Missile" Ability { id: "1CB4", source: "Magitek Predator" }
 70.8 "Magitek Missile" Ability { id: "1CB4", source: "Magitek Predator" }
 
-73.2 "--sync--"   StartsUsing { id: "1CB3", source: "Magitek Predator" } window 10,10
+73.2 "--sync--" StartsUsing { id: "1CB3", source: "Magitek Predator" } window 10,10
 75.9 "Magitek Ray" Ability { id: "1CB3", source: "Magitek Predator" } jump 44.4
 89.0 "Magitek Claw"
 98.4 "Magitek Missile"
@@ -109,7 +109,7 @@ hideall "--sync--"
 2118.2 "Sanguine Blade" Ability { id: "1CC5", source: "The Griffin" }
 2125.3 "Beak Of The Griffin" Ability { id: "1CC3", source: "The Griffin" }
 
-2133.4 "Claw Of The Griffin" Ability { id: "1CC2", source: "The Griffin" } jump 2036.0 window 30,30
+2133.4 "Claw Of The Griffin" Ability { id: "1CC2", source: "The Griffin" } window 30,30 jump 2036.0
 2139.6 "Gull Dive"
 2146.5 "Lionshead"
 2153.7 "Dull Blade"

--- a/ui/raidboss/data/03-hw/dungeon/fractal_continuum.txt
+++ b/ui/raidboss/data/03-hw/dungeon/fractal_continuum.txt
@@ -18,14 +18,14 @@ hideall "--sync--"
 56.5 "Double Sever 2" Ability { id: "F7[BC]", source: "Phantom Ray" }
 58.3 "Atmospheric Displacement" Ability { id: "F7E", source: "Phantom Ray" }
 
-72.4 "Rapid Sever" Ability { id: "F7A", source: "Phantom Ray" }  window 15,15 jump 41.5
+72.4 "Rapid Sever" Ability { id: "F7A", source: "Phantom Ray" } window 15,15 jump 41.5
 78.6 "Atmospheric Displacement"
 83.3 "Double Sever 1"
 87.4 "Double Sever 2"
 89.2 "Atmospheric Displacement"
 # Phase 2 at < 75% HP
 
-100.0 "Damage Up" Ability { id: "F7F", source: "Phantom Ray" }  window 100,30 #Overclock
+100.0 "Damage Up" Ability { id: "F7F", source: "Phantom Ray" } window 100,30 #Overclock
 104.8 "Double Sever 1" Ability { id: "F7[BC]", source: "Phantom Ray" }
 107.6 "Atmospheric Compression" Ability { id: "F80", source: "Phantom Ray" }
 109.0 "Double Sever 2" Ability { id: "F7[BC]", source: "Phantom Ray" }
@@ -58,7 +58,7 @@ hideall "--sync--"
 1043.5 "11-Tonze Swipe" Ability { id: "F81", source: "Minotaur" }
 
 # Rotation desyncs here due to timing on cage use
-1048.0  "--sync--" HeadMarker { id: "0036", target: "Minotaur" } window 45,15 jump 1151.0
+1048.0 "--sync--" HeadMarker { id: "0036", target: "Minotaur" } window 45,15 jump 1151.0
 1064.2 "Feast?"
 1064.3 "1111-Tonze Swing?" Ability { id: "F87", source: "Minotaur" } window 1,10 jump 1167.3
 

--- a/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.txt
+++ b/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.txt
@@ -55,7 +55,7 @@ hideall "--sync--"
 # so instead, put the syncs with jumps after each phase.
 
 # Astrology and Astromancy Camera will be sealed off
-1000.0 "--sync--"  SystemLogMessage { id: "7DC", param1: "658" } window 1000,0
+1000.0 "--sync--" SystemLogMessage { id: "7DC", param1: "658" } window 1000,0
 1007.3 "Searing Wind" Ability { id: "1944", source: "Liquid Flame" } window 7.3,5
 1014.3 "Bibliocide" Ability { id: "1945", source: "Liquid Flame" }
 1025.7 "Sea Of Flames x3"

--- a/ui/raidboss/data/03-hw/dungeon/sohm_al.txt
+++ b/ui/raidboss/data/03-hw/dungeon/sohm_al.txt
@@ -143,6 +143,7 @@ hideall "--Reset--"
 # Tioman keeps using Dark Star every 23.5 seconds,
 # increasing Damage Up stacks, maximum is 16.
 
+#cactbot-timeline-lint-disable-sync-order
 # Jump back to normal loop
 2300.0 "--sync--" Ability { id: "366", source: "Tioman" } window 100,0
 2305.6 "Abyssic Buster" Ability { id: "EE3", source: "Tioman" } window 101,5 jump 2006.0
@@ -151,3 +152,4 @@ hideall "--Reset--"
 2320.0 "Abyssic Buster" # Ability { id: "EE3", source: "Tioman" }
 2329.6 "Comet" # Ability { id: "EE6", source: "Tioman" }
 2343.2 "Meteor Impact" # Ability { id: "1387", source: "Tioman" }
+#cactbot-timeline-lint-enable-sync-order

--- a/ui/raidboss/data/03-hw/dungeon/sohm_al.txt
+++ b/ui/raidboss/data/03-hw/dungeon/sohm_al.txt
@@ -145,6 +145,7 @@ hideall "--Reset--"
 
 #cactbot-timeline-lint-disable-sync-order
 # Jump back to normal loop
+# TODO: update to use forcejump
 2300.0 "--sync--" Ability { id: "366", source: "Tioman" } window 100,0
 2305.6 "Abyssic Buster" Ability { id: "EE3", source: "Tioman" } window 101,5 jump 2006.0
 2312.8 "Chaos Blast" # Ability { id: "EE5", source: "Tioman" }

--- a/ui/raidboss/data/03-hw/dungeon/the_lost_city_of_amdapor_hard.txt
+++ b/ui/raidboss/data/03-hw/dungeon/the_lost_city_of_amdapor_hard.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 # Use zone-unseal Reset line
 # Trigger set contains 'resetWhenOutOfCombat: false'
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000,100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~~~#
 # ACHAMOTH #

--- a/ui/raidboss/data/03-hw/dungeon/the_lost_city_of_amdapor_hard.txt
+++ b/ui/raidboss/data/03-hw/dungeon/the_lost_city_of_amdapor_hard.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 # Use zone-unseal Reset line
 # Trigger set contains 'resetWhenOutOfCombat: false'
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000,100000 jump 0
 
 #~~~~~~~~~~#
 # ACHAMOTH #
@@ -93,8 +93,8 @@ hideall "--sync--"
 2254.2 "Ancient Stone" Ability { id: "15D2", source: "Winged Lion" }
 2259.3 "Scratch" Ability { id: "15D5", source: "Winged Lion" }
 
-2266.7 "--adds--"
 2264.4 "--sync--" StartsUsing { id: "15C9", source: "Winged Lion" } window 80,5
+2266.7 "--adds--"
 2267.4 "--sync--" Ability { id: "15C9", source: "Winged Lion" }
 2269.4 "--untargetable--"
 2287.5 "Ancient Holy" Ability { id: "15CA", source: "Winged Lion" } window 50,50 jump 2166.4

--- a/ui/raidboss/data/03-hw/dungeon/the_vault.txt
+++ b/ui/raidboss/data/03-hw/dungeon/the_vault.txt
@@ -63,7 +63,7 @@ hideall "--sync--"
 
 357.4 "Shining Blade 1" Ability { id: "1022", source: "Ser Adelphel" } window 2,2
 359.8 "Shining Blade 2" Ability { id: "1022", source: "Ser Adelphel" } window 2,2
-362.0 "Shining Blade 3" Ability { id: "1022", source: "Ser Adelphel" } window 2,2 
+362.0 "Shining Blade 3" Ability { id: "1022", source: "Ser Adelphel" } window 2,2
 364.4 "Shining Blade 4" Ability { id: "1022", source: "Ser Adelphel" } window 2,2
 366.4 "--Untargetable--"
 369.0 "--Targetable--"
@@ -128,7 +128,7 @@ hideall "--sync--"
 1166.8 "Hyperdimensional Slash" Ability { id: "1026", source: "Ser Grinnaux" }
 1170.8 "Heavy Swing" Ability { id: "1025", source: "Ser Grinnaux" }
 1177.4 "Dimensional Collapse" Ability { id: "1028", source: "Ser Grinnaux" } window 15,15
-1182.5 "Faith Unmoving" Ability { id: "1027", source: "Ser Grinnaux" } 
+1182.5 "Faith Unmoving" Ability { id: "1027", source: "Ser Grinnaux" }
 
 1192.7 "Dimensional Rip" Ability { id: "102C", source: "Ser Grinnaux" } window 15,15
 1195.9 "Heavy Swing" Ability { id: "1025", source: "Ser Grinnaux" }

--- a/ui/raidboss/data/03-hw/dungeon/xelphatol.txt
+++ b/ui/raidboss/data/03-hw/dungeon/xelphatol.txt
@@ -1,4 +1,5 @@
 ### XELPHATOL
+# TODO: update to use forcejump
 
 hideall "--Reset--"
 hideall "--sync--"

--- a/ui/raidboss/data/03-hw/dungeon/xelphatol.txt
+++ b/ui/raidboss/data/03-hw/dungeon/xelphatol.txt
@@ -22,7 +22,7 @@ hideall "--sync--"
 36.6 "Air Raid" Ability { id: "19CA", source: "Nuzal Hueloc" }
 48.1 "Air Raid" Ability { id: "19CA", source: "Nuzal Hueloc" }
 59.6 "Air Raid" Ability { id: "19CA", source: "Nuzal Hueloc" } jump 36.6
-71.1 "Air Raid" 
+71.1 "Air Raid"
 82.6 "Air Raid"
 94.1 "Air Raid"
 

--- a/ui/raidboss/data/03-hw/raid/a10n.txt
+++ b/ui/raidboss/data/03-hw/raid/a10n.txt
@@ -34,7 +34,7 @@ hideall "--sync--"
 105.4 "--sync--" Ability { id: "1AA2", source: "Lamebrix Strikebocks" } window 20,20
 110.7 "--targetable--"
 
-111.1 "--sync--"  StartsUsing { id: "1AC9", source: "Gobpress R-VI" } window 112,10
+111.1 "--sync--" StartsUsing { id: "1AC9", source: "Gobpress R-VI" } window 112,10
 112.8 "--sync--" Ability { id: "1A9C", source: "Lamebrix Strikebocks" }
 117.8 "Critical Wrath" Ability { id: "1ACD", source: "Lamebrix Strikebocks" }
 122.9 "Illuminati Hand Cannon" Ability { id: "1AD2", source: "Lamebrix Strikebocks" }

--- a/ui/raidboss/data/03-hw/raid/a10s.txt
+++ b/ui/raidboss/data/03-hw/raid/a10s.txt
@@ -177,8 +177,8 @@ hideall "--sync--"
 814.9 "Discharge" Ability { id: "1AA7", source: "Lamebrix Strikebocks" }
 815.9 "Weight Trap" Ability { id: "1AB0", source: "Lamebrix Strikebocks" }
 816.8 "Frostbite" Ability { id: "1A8E", source: "Lamebrix Strikebocks" }
-820.8 "Impact" Ability { id: "1A8B", source: "Weight Of The World" }
 817.2 "--jump--" Ability { id: "1AA2", source: "Lamebrix Strikebocks" }
+820.8 "Impact" Ability { id: "1A8B", source: "Weight Of The World" }
 824.9 "Discharge" Ability { id: "1AA7", source: "Lamebrix Strikebocks" }
 827.1 "Gobbie Adds x3 (NE)"
 828.4 "Gobsway Rumblerocks" Ability { id: "1AA0", source: "Lamebrix Strikebocks" }

--- a/ui/raidboss/data/03-hw/raid/a12s.txt
+++ b/ui/raidboss/data/03-hw/raid/a12s.txt
@@ -34,7 +34,7 @@ hideall "--sync--"
 124.9 "Almost Holy" Ability { id: "19F7", source: "The General's Wing" }
 133.2 "Almost Holy" Ability { id: "19F7", source: "The General's Wing" }
 
-139.2 "The General's Might (W)" AddedCombatant { name: "The General's Might" }  window 150,5
+139.2 "The General's Might (W)" AddedCombatant { name: "The General's Might" } window 150,5
 139.2 "The General's Time (E)"
 141.6 "Almost Holy?" Ability { id: "19F7", source: "The General's Wing" }
 150.4 "Smash" Ability { id: "19F3", source: "The General's Might" } window 151,3

--- a/ui/raidboss/data/03-hw/raid/a1s.txt
+++ b/ui/raidboss/data/03-hw/raid/a1s.txt
@@ -28,7 +28,7 @@ hideall "--sync--"
 1076.0 "Kaltstrahl" Ability { id: "E3C", source: "Faust" }
 1079.0 "Pressure Increase 4" Ability { id: "E3D", source: "Faust" }
 1086.0 "Kaltstrahl" Ability { id: "E3C", source: "Faust" }
-1069.7 "Sturm Doll Add"
+1089.7 "Sturm Doll Add"
 1096.0 "Kaltstrahl" Ability { id: "E3C", source: "Faust" }
 1099.0 "Pressure Increase 5" Ability { id: "E3D", source: "Faust" }
 1106.0 "Kaltstrahl" Ability { id: "E3C", source: "Faust" }

--- a/ui/raidboss/data/03-hw/raid/a2s.txt
+++ b/ui/raidboss/data/03-hw/raid/a2s.txt
@@ -18,7 +18,7 @@ hideall "--sync--"
 
 
 # Wave 2 (timed push)
-20.3 "--Wave 2--" AddedCombatant { name: "Gordian Hardmind" }  window 21,5
+20.3 "--Wave 2--" AddedCombatant { name: "Gordian Hardmind" } window 21,5
 20.3 "Sniper, Soldier x2 (NW)"
 20.3 "Hardmind (SW)"
 
@@ -26,7 +26,7 @@ hideall "--sync--"
 
 
 # Wave 3 (timed push)
-80.2 "--Wave 3--" AddedCombatant { name: "Gordian Hardhelm" }  window 70,70
+80.2 "--Wave 3--" AddedCombatant { name: "Gordian Hardhelm" } window 70,70
 80.2 "Hardhelm, Soldier (SW)"
 80.2 "Hardmind, Sniper, Soldier 2x (N)"
 
@@ -35,7 +35,7 @@ hideall "--sync--"
 
 
 # Wave 4 (triggered push)
-2000.0 "--Wave 4--" AddedCombatant { name: "Boomtype Magitek Gobwalker G-VII" }  window 2000,0
+2000.0 "--Wave 4--" AddedCombatant { name: "Boomtype Magitek Gobwalker G-VII" } window 2000,0
 2000.0 "Gobwalker (NE)"
 2000.0 "Sniper x2, Soldier x2 (mid)"
 
@@ -46,7 +46,7 @@ hideall "--sync--"
 
 
 # Wave 5 (timed push)
-2095.5 "--Wave 5--" AddedCombatant { name: "Magitek Gobwidow G-IX" }  window 2070,100
+2095.5 "--Wave 5--" AddedCombatant { name: "Magitek Gobwidow G-IX" } window 2070,100
 2095.5 "Gobwidow (N)"
 2095.5 "Gobwidow (S)"
 2095.5 "Soldier x2 (SW)"
@@ -62,7 +62,7 @@ hideall "--sync--"
 
 
 # Wave 6 (timed push)
-2168.0 "--Wave 6--" AddedCombatant { name: "Jagd Doll" }  window 2170,100
+2168.0 "--Wave 6--" AddedCombatant { name: "Jagd Doll" } window 2170,100
 2168.0 "Jagd Doll (NE)"
 2168.0 "Gobwalker (N)"
 2168.0 "Hardhelm (SW)"
@@ -94,7 +94,7 @@ hideall "--sync--"
 
 
 # Wave 7 (triggered push)
-3000.0 "--Wave 7--" AddedCombatant { name: "Jagd Doll" }  window 825,0
+3000.0 "--Wave 7--" AddedCombatant { name: "Jagd Doll" } window 825,0
 3000.0 "Jagd Doll x4 (mid)"
 
 3006.2 "Kaltstrahl" #Ability { id: "FD4", source: "Jagd Doll" }
@@ -112,7 +112,7 @@ hideall "--sync--"
 
 # Wave 8 (timed push)
 # TODO: include additional jagd doll stuff into here?
-3080.7 "--Wave 8--" AddedCombatant { name: "Gordian Sniper" }  window 1075,100
+3080.7 "--Wave 8--" AddedCombatant { name: "Gordian Sniper" } window 1075,100
 3080.7 "Sniper x3, Soldier (SW)"
 3080.7 "Hardmind (N)"
 3080.7 "Hardhelm (SE)"
@@ -126,7 +126,7 @@ hideall "--sync--"
 
 
 # Wave 9 (triggered push)
-4000.0 "--Wave 9--"  AddedCombatant { name: "Magitek Gobwidow G-IX" }  window 1900,0
+4000.0 "--Wave 9--" AddedCombatant { name: "Magitek Gobwidow G-IX" } window 1900,0
 4000.0 "Gobwidow (NW)"
 4000.0 "Gobwidow, Jagd Doll (SW)"
 4000.0 "Gobwalker (NE)"
@@ -137,10 +137,10 @@ hideall "--sync--"
 4019.4 "Kaltstrahl" Ability { id: "FD4", source: "Jagd Doll" }
 4022.1 "Boomcannon" #Ability { id: "FD8", source: "Magitek Gobwidow G-IX" }
 4027.6 "Kaltstrahl" Ability { id: "FD4", source: "Jagd Doll" }
-
-4042.6 "--sync--" #Ability { id: "1413", source: "Magitek Gobwidow G-IX" }
 4038.8 "Blitzstrahl" Ability { id: "FD6", source: "Jagd Doll" }
 4041.9 "Kaltstrahl" Ability { id: "FD4", source: "Jagd Doll" }
+
+4042.6 "--sync--" #Ability { id: "1413", source: "Magitek Gobwidow G-IX" }
 4050.1 "Kaltstrahl" Ability { id: "FD4", source: "Jagd Doll" }
 4050.3 "Boomcannon" #Ability { id: "FD8", source: "Magitek Gobwidow G-IX" }
 
@@ -165,7 +165,7 @@ hideall "--sync--"
 
 
 # Enrage
-5000.0 "--sync--" AddedCombatant { name: "Giant Bomb" }  window 5000,0
+5000.0 "--sync--" AddedCombatant { name: "Giant Bomb" } window 5000,0
 5010.0 "Massive Explosion Enrage" Ability { id: "FDD", source: "Giant Bomb" }
 
 # Technically this loops, and has a special dialog where Quickthinx says:

--- a/ui/raidboss/data/03-hw/raid/a4s.txt
+++ b/ui/raidboss/data/03-hw/raid/a4s.txt
@@ -22,8 +22,8 @@
 43.4 "Hydrothermal Missile" Ability { id: "F5B", source: "The Manipulator" }
 48.5 "Discoid" Ability { id: "F61", source: "The Manipulator" }
 53.6 "Seed Of The Sky" Ability { id: "13D0", source: "The Manipulator" }
-58.6 "Seed Of The Sky" Ability { id: "13D0", source: "The Manipulator" }
 55.6 "--stun--" duration 5
+58.6 "Seed Of The Sky" Ability { id: "13D0", source: "The Manipulator" }
 61.4 "Perpetual Ray x2" #Ability { id: "F5F", source: "The Manipulator" }
 71.5 "Hydrothermal Missile" Ability { id: "F5B", source: "The Manipulator" }
 
@@ -39,8 +39,8 @@
 126.0 "Hydrothermal Missile" #Ability { id: "F5B", source: "The Manipulator" }
 131.1 "Discoid" #Ability { id: "F61", source: "The Manipulator" }
 136.2 "Seed Of The Sky" #Ability { id: "13D0", source: "The Manipulator" }
-141.2 "Seed Of The Sky" #Ability { id: "13D0", source: "The Manipulator" }
 138.2 "--stun--" duration 5
+141.2 "Seed Of The Sky" #Ability { id: "13D0", source: "The Manipulator" }
 144.0 "Perpetual Ray x2" #Ability { id: "F5F", source: "The Manipulator" }
 154.1 "Hydrothermal Missile" #Ability { id: "F5B", source: "The Manipulator" }
 
@@ -87,7 +87,7 @@
 
 
 ### Leg 3
-1000.0 "--sync--"  NameToggle { name: "The Manipulator", toggle: "01" } window 490,0
+1000.0 "--sync--" NameToggle { name: "The Manipulator", toggle: "01" } window 490,0
 1012.1 "--untargetable--"
 1016.2 "--sync--" StartsUsing { id: "13E7", source: "The Manipulator" } window 490,5
 1022.2 "Mortal Revolution" Ability { id: "13E7", source: "The Manipulator" }
@@ -142,7 +142,7 @@
 
 
 ### Leg 4
-1500.0 "--sync--"  NameToggle { name: "The Manipulator", toggle: "01" } window 490,0
+1500.0 "--sync--" NameToggle { name: "The Manipulator", toggle: "01" } window 490,0
 1512.1 "--untargetable--"
 1516.2 "--sync--" StartsUsing { id: "13E7", source: "The Manipulator" } window 490,5
 1522.2 "Mortal Revolution" Ability { id: "13E7", source: "The Manipulator" }
@@ -177,7 +177,7 @@
 
 
 ### Final Phase
-2000.0 "--sync--"  NameToggle { name: "The Manipulator", toggle: "01" } window 490,0
+2000.0 "--sync--" NameToggle { name: "The Manipulator", toggle: "01" } window 490,0
 2012.1 "--untargetable--"
 2016.2 "--sync--" StartsUsing { id: "13E7", source: "The Manipulator" } window 490,5
 2022.2 "Mortal Revolution" Ability { id: "13E7", source: "The Manipulator" }

--- a/ui/raidboss/data/03-hw/raid/a5s.txt
+++ b/ui/raidboss/data/03-hw/raid/a5s.txt
@@ -16,7 +16,7 @@ hideall "Relaxant"
 1032.1 "Kaltstrahl x3" Ability { id: "16CC", source: "Faust" } duration 4.2 window 5,0.5
 #1034.2 "Kaltstrahl" Ability { id: "16CC", source: "Faust" }
 #1036.3 "Kaltstrahl" Ability { id: "16CC", source: "Faust" }
-1043.4 "Kaltstrahl x3" Ability { id: "16CC", source: "Faust"} duration 4.2 window 5,0.5
+1043.4 "Kaltstrahl x3" Ability { id: "16CC", source: "Faust" } duration 4.2 window 5,0.5
 #1045.5 "Kaltstrahl" Ability { id: "16CC", source: "Faust" }
 #1047.6 "Kaltstrahl" Ability { id: "16CC", source: "Faust" }
 

--- a/ui/raidboss/data/03-hw/raid/a5s.txt
+++ b/ui/raidboss/data/03-hw/raid/a5s.txt
@@ -11,17 +11,16 @@ hideall "Relaxant"
 # The Clevering will be sealed off
 1000.0 "--sync--" SystemLogMessage { id: "7DC", param1: "6AF" } window 1000,0
 1009.8 "Kaltstrahl x1" Ability { id: "16CC", source: "Faust" } window 10,5
-1018.9 "Kaltstrahl x2" duration 2.1 Ability { id: "16CC", source: "Faust" } window 5,0.5
+1018.9 "Kaltstrahl x2" Ability { id: "16CC", source: "Faust" } duration 2.1 window 5,0.5
 #1021.0 "Kaltstrahl" Ability { id: "16CC", source: "Faust" }
-1032.1 "Kaltstrahl x3" duration 4.2 Ability { id: "16CC", source: "Faust" } window 5,0.5
+1032.1 "Kaltstrahl x3" Ability { id: "16CC", source: "Faust" } duration 4.2 window 5,0.5
 #1034.2 "Kaltstrahl" Ability { id: "16CC", source: "Faust" }
 #1036.3 "Kaltstrahl" Ability { id: "16CC", source: "Faust" }
-1043.4 "Kaltstrahl x3" duration 4.2 Ability { id: "16CC", source: "Faust" } window 5,0.5
+1043.4 "Kaltstrahl x3" Ability { id: "16CC", source: "Faust"} duration 4.2 window 5,0.5
 #1045.5 "Kaltstrahl" Ability { id: "16CC", source: "Faust" }
 #1047.6 "Kaltstrahl" Ability { id: "16CC", source: "Faust" }
 
 1051.6 "--sync--" StartsUsing { id: "16D2", source: "Hummelfaust" } window 52,10
-1056.6 "Panzer Vor" Ability { id: "16D2", source: "Hummelfaust" }
 
 # Note: if previous Fausts haven't been destroyed,
 # There's a 3.7 second delay for Reducible Complexity + Pressure Increase.
@@ -30,19 +29,20 @@ hideall "Relaxant"
 1053.4 "--sync--" Ability { id: "16CF", source: "Faust" } window 10,10 # Reducible Complexity
 1056.0 "--sync--" Ability { id: "16CD", source: "Hummelfaust" } window 10,10 # Pressure Increase.
 
-1065.2 "Kaltstrahl x2" duration 2.1 Ability { id: "16CE", source: "Hummelfaust" } window 5,0.5
+1056.6 "Panzer Vor" Ability { id: "16D2", source: "Hummelfaust" }
+1065.2 "Kaltstrahl x2" Ability { id: "16CE", source: "Hummelfaust" } duration 2.1 window 5,0.5
 #1067.3 "Kaltstrahl" Ability { id: "16CE", source: "Hummelfaust" }
-1085.4 "Kaltstrahl x3" duration 4.2 Ability { id: "16CE", source: "Hummelfaust" } window 5,0.5
+1085.4 "Kaltstrahl x3" Ability { id: "16CE", source: "Hummelfaust" } duration 4.2 window 5,0.5
 #1087.5 "Kaltstrahl" Ability { id: "16CE", source: "Hummelfaust" }
 #1089.6 "Kaltstrahl" Ability { id: "16CE", source: "Hummelfaust" }
 1101.7 "Panzerschreck" Ability { id: "16D0", source: "Hummelfaust" } window 15,15
-1110.9 "Kaltstrahl x4" duration 6.3 Ability { id: "16CE", source: "Hummelfaust" } window 5,0.5
+1110.9 "Kaltstrahl x4" Ability { id: "16CE", source: "Hummelfaust" } duration 6.3 window 5,0.5
 #1113.0 "Kaltstrahl" Ability { id: "16CE", source: "Hummelfaust" }
 #1115.1 "Kaltstrahl" Ability { id: "16CE", source: "Hummelfaust" }
 #1117.2 "Kaltstrahl" Ability { id: "16CE", source: "Hummelfaust" }
 1128.3 "Panzerschreck" Ability { id: "16D0", source: "Hummelfaust" }
 1134.4 "Panzerschreck" Ability { id: "16D0", source: "Hummelfaust" }
-1138.5 "Kaltstrahl x4" duration 6.3 Ability { id: "16CE", source: "Hummelfaust" } window 5,0.5
+1138.5 "Kaltstrahl x4" Ability { id: "16CE", source: "Hummelfaust" } duration 6.3 window 5,0.5
 #1140.6 "Kaltstrahl" Ability { id: "16CE", source: "Hummelfaust" }
 #1142.7 "Kaltstrahl" Ability { id: "16CE", source: "Hummelfaust" }
 #1144.8 "Kaltstrahl" Ability { id: "16CE", source: "Hummelfaust" }

--- a/ui/raidboss/data/03-hw/raid/a6s.txt
+++ b/ui/raidboss/data/03-hw/raid/a6s.txt
@@ -82,7 +82,7 @@ hideall "Ballistic Missile"
 
 ## Brawler Orb Phase
 1500.0 "--sync--" NameToggle { name: "Brawler", toggle: "00" } window 500,0
-1503.4 "Power Plasma Alpha x2" AddedCombatant { name: "Power Plasma Alpha" }  window 500,5
+1503.4 "Power Plasma Alpha x2" AddedCombatant { name: "Power Plasma Alpha" } window 500,5
 1503.4 "Power Plasma Gamma x2"
 
 1508.6 "Attachment" Ability { id: "1601", source: "Brawler" }

--- a/ui/raidboss/data/03-hw/raid/a7s.txt
+++ b/ui/raidboss/data/03-hw/raid/a7s.txt
@@ -63,14 +63,14 @@ hideall "--sync--"
 ################# Version 1 - Phase 1
 59 "Bomb x1"
 66 "Jails" #White Prey & Green Tether
-68 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 60
+68 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 30,30
 69 "Doll"
-84 "Resync" GainsEffect { effect: "Pyretic" } window 20 jump 384
+84 "Resync" GainsEffect { effect: "Pyretic" } window 10,10 jump 384
 103 "Sizzlespark"
 116 "Uplander Doom"
 130 "Bomb x1"
 137 "Jails - Get Tether" #Red Prey & Purple Tether
-139 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 60
+139 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 30,30
 140 "Small Doll"
 178 "Sizzlebeam"
 190 "Sizzlespark"
@@ -80,12 +80,12 @@ hideall "--sync--"
 204 "Kill Heart" StartsUsing { id: "15EC", source: "Shanoa" } window 145,10
 219 "Stun Heart"
 219 "Sizzlespark"
-229 "Flamethrower" Ability { id: "1CFA", source: "Quickthinx Allthoughts" } window 20
-234 "Kill Heart" StartsUsing { id: "15EC", source: "Shanoa" } window 20
+229 "Flamethrower" Ability { id: "1CFA", source: "Quickthinx Allthoughts" } window 10,10
+234 "Kill Heart" StartsUsing { id: "15EC", source: "Shanoa" } window 10,10
 249 "Stun Heart"
 249 "Sizzlebeam"
 258 "Sizzlespark" #can be skipped
-266 "Bomb x1" AddedCombatant { name: "Bomb" }  window 50 jump 561
+266 "Bomb x1" AddedCombatant { name: "Bomb" } window 25,25 jump 561
 267 ""
 267 ""
 267 ""
@@ -101,7 +101,7 @@ hideall "--sync--"
 ################# Version 2 - Phase 1
 359 "Bomb x1"
 366 "Jails" #Purple Tether, Red Prey
-368 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 60
+368 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 30,30
 369 "Doll"
 397 "Uplander Doom"
 409 "Sizzlebeam"
@@ -117,37 +117,37 @@ hideall "--sync--"
 499 "Kill Heart" StartsUsing { id: "15EC", source: "Shanoa" } window 130,10
 514 "Stun Heart"
 514 "Sizzlespark"
-524 "Flamethrower" Ability { id: "1CFA", source: "Quickthinx Allthoughts" } window 20
-529 "Kill Heart" StartsUsing { id: "15EC", source: "Shanoa" } window 10
+524 "Flamethrower" Ability { id: "1CFA", source: "Quickthinx Allthoughts" } window 10,10
+529 "Kill Heart" StartsUsing { id: "15EC", source: "Shanoa" } window 5,5
 544 "Stun Heart"
 544 "Sizzlebeam"
 553 "Sizzlespark" #can be skipped
 
 ############################################
 ################# Version 1 - Phase 3
-561 "Bomb x1" AddedCombatant { name: "Bomb" }  window 50,20
+561 "Bomb x1" AddedCombatant { name: "Bomb" } window 50,20
 567 "Jails" #Green Prey & Red Tether
-570 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 60
+570 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 30,30
 570 "Doll"
-582 "Resync" GainsEffect { effect: "Frostbite" } window 20 jump 983
+582 "Resync" GainsEffect { effect: "Frostbite" } window 10,10 jump 983
 596 "Uplander Doom"
 613 "Sizzlespark"
 621 "Sizzlespark"
 628 "Bomb x1"
 636 "Jails - Get Prey" #Purple Prey & White Tether
-640 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 60
+640 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 30,30
 640 "Small Dolls x2"
 678 "Sizzlebeam"
 
 ################# Phase 4
 686 "Sizzlespark" Ability { id: "16F8", source: "Quickthinx Allthoughts" } window 63,0
 694 "Sizzlespark"
-707 "Sizzlebeam" Ability { id: "15EE", source: "Quickthinx Allthoughts" } window 20
+707 "Sizzlebeam" Ability { id: "15EE", source: "Quickthinx Allthoughts" } window 10,10
 711 "Bombs x8"
 740 "Sizzlespark"
 748 "Sizzlespark"
 755 "Uplander Doom"
-773 "Flamethrower" Ability { id: "1CFA", source: "Quickthinx Allthoughts" } window 30
+773 "Flamethrower" Ability { id: "1CFA", source: "Quickthinx Allthoughts" } window 15,15
 779 "Hammertime x4"
 790 "Sizzlespark"
 793 "Hammertime x4"
@@ -165,13 +165,13 @@ hideall "--sync--"
 873 "Stun Heart"
 879 "Sizzlebeam"
 888 "Flamethrower"
-888 "Kill Heart" StartsUsing { id: "15EC", source: "Shanoa" } window 10
+888 "Kill Heart" StartsUsing { id: "15EC", source: "Shanoa" } window 5,5
 901 "Sizzlespark"
 903 "Stun Heart"
 909 "Sizzlespark"
 917 "Sizzlespark"
-923 "Bombs / Sizzlebeam" AddedCombatant { name: "Bomb" }  window 20 jump 1326
-924 "" Ability { id: "15EE", source: "Quickthinx Allthoughts" } window 20 jump 1526
+923 "Bombs / Sizzlebeam" AddedCombatant { name: "Bomb" } window 10,10 jump 1326
+924 "" Ability { id: "15EE", source: "Quickthinx Allthoughts" } window 10,10 jump 1526
 924 ""
 924 ""
 924 ""
@@ -188,24 +188,24 @@ hideall "--sync--"
 970 "Jails" #White Tether, Purple Prey
 972 "Zoomdoom"
 972 "Doll"
-1011 "Sizzlebeam" Ability { id: "15EE", source: "Quickthinx Allthoughts" } window 10
+1011 "Sizzlebeam" Ability { id: "15EE", source: "Quickthinx Allthoughts" } window 5,5
 1019 "Sizzlespark"
 1027 "Sizzlespark"
 1034 "Bomb x1"
 1041 "Jails" #Red Tether, Green Prey
-1043 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 60
+1043 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 30,30
 1043 "Big Doll"
 1071 "Uplander Doom"
 
 ################# Phase 4
 1087 "Sizzlespark"
 1095 "Sizzlespark"
-1108 "Sizzlebeam" Ability { id: "15EE", source: "Quickthinx Allthoughts" } window 20
+1108 "Sizzlebeam" Ability { id: "15EE", source: "Quickthinx Allthoughts" } window 10,10
 1111 "Bombs x8"
 1141 "Sizzlespark"
 1149 "Sizzlespark"
 1156 "Uplander Doom"
-1174 "Flamethrower" Ability { id: "1CFA", source: "Quickthinx Allthoughts" } window 30
+1174 "Flamethrower" Ability { id: "1CFA", source: "Quickthinx Allthoughts" } window 15,15
 1180 "Hammertime x4"
 1191 "Sizzlespark"
 1194 "Hammertime x4"
@@ -224,7 +224,7 @@ hideall "--sync--"
 1273 "Stun Heart"
 1280 "Sizzlebeam"
 1288 "Flamethrower"
-1288 "Kill Heart" StartsUsing { id: "15EC", source: "Shanoa" } window 10
+1288 "Kill Heart" StartsUsing { id: "15EC", source: "Shanoa" } window 5,5
 1301 "Sizzlespark"
 1303 "Stun Heart"
 1308 "Sizzlespark"
@@ -235,15 +235,15 @@ hideall "--sync--"
 1326 "Bombs x2" Ability { id: "15EE", source: "Quickthinx Allthoughts" } window 40,10 jump 1526
 1333 "Jails" #Green Tether, Purple Prey
 1335 "Small Doll"
-1336 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 55
+1336 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 27.5,27.5
 1344 "Big Doll"
-1348 "Resync" GainsEffect { effect: "Pyretic" } window 20 jump 1548
-1348 "Resync" GainsEffect { effect: "Pyretic" } window 20 jump 1548
+1348 "Resync" GainsEffect { effect: "Pyretic" } window 10,10 jump 1548
+1348 "Resync" GainsEffect { effect: "Pyretic" } window 10,10 jump 1548
 1362 "Uplander Doom"
 1381 "Sizzlespark"
 1392 "Sizzlebeam"
 1396 "Jails" #Red Tether, White Prey
-1398 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 55
+1398 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 27.5,27.5
 1398 "Small Dolls x2"
 1426 "Sizzlespark"
 1433 "Sizzlebeam"
@@ -255,7 +255,7 @@ hideall "--sync--"
 ################# Version 2 - Phase 6
 1526 "Sizzlebeam"
 1530 "Jails" #White Prey & Red Tether
-1532 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 55
+1532 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 27.5,27.5
 1533 "Small Dolls x2"
 1560 "Sizzlespark"
 1568 "Sizzlebeam"
@@ -264,7 +264,7 @@ hideall "--sync--"
 1590 "Sizzlespark"
 1595 "Bombs x2"
 1601 "Jails - Get Prey" #Purple Prey & Green Tether
-1603 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 55
+1603 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 27.5,27.5
 1603 "Small Doll"
 1612 "Big Doll"
 1630 "Uplander Doom"

--- a/ui/raidboss/data/03-hw/raid/a7s.txt
+++ b/ui/raidboss/data/03-hw/raid/a7s.txt
@@ -235,7 +235,7 @@ hideall "--sync--"
 1326 "Bombs x2" Ability { id: "15EE", source: "Quickthinx Allthoughts" } window 40,10 jump 1526
 1333 "Jails" #Green Tether, Purple Prey
 1335 "Small Doll"
-1336 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 27.5,27.5
+1336 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 30,30
 1344 "Big Doll"
 1348 "Resync" GainsEffect { effect: "Pyretic" } window 10,10 jump 1548
 1348 "Resync" GainsEffect { effect: "Pyretic" } window 10,10 jump 1548
@@ -243,7 +243,7 @@ hideall "--sync--"
 1381 "Sizzlespark"
 1392 "Sizzlebeam"
 1396 "Jails" #Red Tether, White Prey
-1398 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 27.5,27.5
+1398 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 30,30
 1398 "Small Dolls x2"
 1426 "Sizzlespark"
 1433 "Sizzlebeam"
@@ -255,7 +255,7 @@ hideall "--sync--"
 ################# Version 2 - Phase 6
 1526 "Sizzlebeam"
 1530 "Jails" #White Prey & Red Tether
-1532 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 27.5,27.5
+1532 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 30,30
 1533 "Small Dolls x2"
 1560 "Sizzlespark"
 1568 "Sizzlebeam"
@@ -264,7 +264,7 @@ hideall "--sync--"
 1590 "Sizzlespark"
 1595 "Bombs x2"
 1601 "Jails - Get Prey" #Purple Prey & Green Tether
-1603 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 27.5,27.5
+1603 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 30,30
 1603 "Small Doll"
 1612 "Big Doll"
 1630 "Uplander Doom"

--- a/ui/raidboss/data/03-hw/raid/a8n.txt
+++ b/ui/raidboss/data/03-hw/raid/a8n.txt
@@ -48,7 +48,7 @@ hideall "Brute Force"
 # so we just do one full rotation and hope for the best.
 # If it would have looped past here, there are bigger problems!
 200.0 "--sync--" NameToggle { name: "Onslaughter", toggle: "00" } window 200,0
-203.8 "--sync--" AddedCombatant { name: "Brawler" }  window 150,30
+203.8 "--sync--" AddedCombatant { name: "Brawler" } window 150,30
 206.2 "--targetable--"
 214.3 "Magicked Mark" Ability { id: "173B", source: "Brawler" }
 214.3 "Brute Force" Ability { id: "1744", source: "Vortexer" }
@@ -87,7 +87,7 @@ hideall "Brute Force"
 
 # CUTE ROBOTS 2
 # One full rotation plus a tail again, for the same reasons. Don't be slow!
-500.0 "--sync--" AddedCombatant { name: "Blaster" }  window 300,30
+500.0 "--sync--" AddedCombatant { name: "Blaster" } window 300,30
 502.1 "--targetable--"
 510.3 "Magicked Mark" Ability { id: "173F", source: "Swindler" }
 510.3 "Brute Force" Ability { id: "1738", source: "Blaster" }
@@ -119,14 +119,14 @@ hideall "Brute Force"
 618.7 "Mind Blast"
 
 # GO, GO, MEGAZORD MODE (BRUTE JUSTICE)
-800.0 "--sync--" AddedCombatant { name: "Brute Justice" }  window 300,30
+800.0 "--sync--" AddedCombatant { name: "Brute Justice" } window 300,30
 810.3 "--sync--" Ability { id: "1758", source: "Brute Justice" } window 610.3,30
 813.0 "--targetable--"
 826.9 "Double Rocket Punch" Ability { id: "174E", source: "Brute Justice" } window 26,30
 829.0 "Missile Command" Ability { id: "1668", source: "Brute Justice" }
 832.4 "Flarethrower" Ability { id: "174D", source: "Brute Justice" }
 833.0 "Long Needle" Ability { id: "1754", source: "Brute Justice" }
-840.5 "Apocalyptic Ray" Ability { id: "1751", source: "Brute Justice" } window 30,30 duration 5
+840.5 "Apocalyptic Ray" Ability { id: "1751", source: "Brute Justice" } duration 5 window 30,30
 852.4 "Super Jump" Ability { id: "1750", source: "Brute Justice" }
 858.6 "Flarethrower" Ability { id: "174D", source: "Brute Justice" }
 863.7 "Missile Command" Ability { id: "1668", source: "Brute Justice" }

--- a/ui/raidboss/data/03-hw/raid/a8s.txt
+++ b/ui/raidboss/data/03-hw/raid/a8s.txt
@@ -62,7 +62,7 @@ hideall "Brute Force"
 
 ### Phase 2: Robots
 300.0 "--sync--" NameToggle { name: "Onslaughter", toggle: "00" } window 300,0
-303.0 "--sync--" AddedCombatant { name: "Blaster" }  window 303,30
+303.0 "--sync--" AddedCombatant { name: "Blaster" } window 303,30
 304.0 "Blaster (north)"
 304.0 "Brawler (middle)"
 306.2 "--targetable--"
@@ -204,7 +204,7 @@ hideall "Brute Force"
 1211.5 "--sync--" Ability { id: "1636", source: "Brute Justice" }
 1212.6 "100-Megatonze Shock" Ability { id: "1635", source: "Onslaughter" }
 # First Intermission can be skipped, but this is the first different ability.
-1217.5 "Hidden Minefield" Ability { id: "165E", source: "Hidden Mine" } window 1220,5 duration 9
+1217.5 "Hidden Minefield" Ability { id: "165E", source: "Hidden Mine" } duration 9 window 1220,5
 1217.6 "Double Drill Crush" Ability { id: "1640", source: "Brawler" }
 1218.6 "Drill Drive" Ability { id: "1641", source: "Brawler" }
 1222.1 "Mega Beam" Ability { id: "162E", source: "Onslaughter" }

--- a/ui/raidboss/data/03-hw/raid/a9s.txt
+++ b/ui/raidboss/data/03-hw/raid/a9s.txt
@@ -55,7 +55,7 @@ hideall "--sync--"
 2014.3 "Power Generator x2 (NE)"
 2014.3 "Lava (NE)" duration 42
 2023.4 "Scrap" Ability { id: "1A39", source: "Refurbisher 0" }
-2034.4 "--rocks fall--" #AddedCombatant { name: "Scrap" } 
+2034.4 "--rocks fall--" #AddedCombatant { name: "Scrap" }
 2039.6 "Scrap Burst" Ability { id: "1A3A", source: "Refurbisher 0" }
 2048.8 "Scrap" Ability { id: "1A39", source: "Refurbisher 0" }
 2055.9 "Scrap" Ability { id: "1A39", source: "Refurbisher 0" }
@@ -83,7 +83,7 @@ hideall "--sync--"
 2173.9 "Lava (SW)" duration 15
 2180.2 "Acid Rain" #Ability { id: "1C0A", source: "Refurbisher 0" }
 2189.3 "Lava (SE)" duration 15
-2195.1 "--rocks fall--" #AddedCombatant { name: "Scrap" } 
+2195.1 "--rocks fall--" #AddedCombatant { name: "Scrap" }
 2200.3 "Scrap Burst" Ability { id: "1A3A", source: "Refurbisher 0" }
 
 # Phase 4
@@ -91,7 +91,7 @@ hideall "--sync--"
 2226.5 "Power Generator x1 (SW)"
 2226.5 "Alarum x1 (SW)"
 2226.5 "Lava (SW)" duration 42
-2238.7 "--rocks fall--" #AddedCombatant { name: "Scrap" } 
+2238.7 "--rocks fall--" #AddedCombatant { name: "Scrap" }
 2243.9 "Scrap Burst" Ability { id: "1A3A", source: "Refurbisher 0" }
 2253.1 "Scrap" Ability { id: "1A39", source: "Refurbisher 0" }
 2260.2 "Scrap" Ability { id: "1A39", source: "Refurbisher 0" }
@@ -123,7 +123,7 @@ hideall "--sync--"
 2365.0 "Lava (NE/SW)" duration 42
 2376.4 "Scrap Bomb" Ability { id: "1A3E", source: "Refurbisher 0" }
 2384.6 "Scrap" Ability { id: "1A39", source: "Refurbisher 0" }
-2398.5 "--rocks fall--" #AddedCombatant { name: "Scrap" } 
+2398.5 "--rocks fall--" #AddedCombatant { name: "Scrap" }
 2403.3 "Explosion (NW/SE)" Ability { id: "1A35", source: "Bomb" }
 2403.7 "Scrap Burst" Ability { id: "1A3A", source: "Refurbisher 0" }
 

--- a/ui/raidboss/data/03-hw/raid/a9s.txt
+++ b/ui/raidboss/data/03-hw/raid/a9s.txt
@@ -123,8 +123,8 @@ hideall "--sync--"
 2365.0 "Lava (NE/SW)" duration 42
 2376.4 "Scrap Bomb" Ability { id: "1A3E", source: "Refurbisher 0" }
 2384.6 "Scrap" Ability { id: "1A39", source: "Refurbisher 0" }
-2403.3 "Explosion (NW/SE)" Ability { id: "1A35", source: "Bomb" }
 2398.5 "--rocks fall--" #AddedCombatant { name: "Scrap" } 
+2403.3 "Explosion (NW/SE)" Ability { id: "1A35", source: "Bomb" }
 2403.7 "Scrap Burst" Ability { id: "1A3A", source: "Refurbisher 0" }
 
 # Phase 7

--- a/ui/raidboss/data/03-hw/trial/sophia-ex.txt
+++ b/ui/raidboss/data/03-hw/trial/sophia-ex.txt
@@ -18,7 +18,7 @@ hideall "--sync--"
 41.4 "Arms Of Wisdom?" Ability { id: "19C4", source: "Sophia" } # May be skipped depending on DPS
 
 # This section will be reached either at 56.0, or at the time she is pushed to 90%
-56.0 "--clones appear--" AddedCombatant { name: "Aion Teleos" }  window 56,5
+56.0 "--clones appear--" AddedCombatant { name: "Aion Teleos" } window 56,5
 63.6 "Thunder II/III" Ability { id: ["19AC", "19B0"], source: "Sophia" }
 63.6 "--sync--" Ability { id: "19AB", source: "Aion Teleos" } window 30,2.5
 69.7 "Aero III" Ability { id: "19AE", source: "Sophia" }
@@ -64,7 +64,7 @@ hideall "--sync--"
 361.5 "Dischordant Cleansing" # Ability { id: ["19B3", "19B5"], source: "Sophia" }
 361.5 "Cintamani x2" duration 3 # Ability { id: "19C5", source: "Sophia" }
 370.8 "Arms Of Wisdom" Ability { id: "19C4", source: "Sophia" } window 30,5
-379.0 "--clones appear--" AddedCombatant { name: "Aion Teleos" }  window 60,20
+379.0 "--clones appear--" AddedCombatant { name: "Aion Teleos" } window 60,20
 382.0 "Cintamani x3" duration 6 # Ability { id: "19C5", source: "Sophia" }
 393.3 "--sync--" Ability { id: "19AB", source: "Aion Teleos" }
 393.3 "Thunder II/III" Ability { id: ["19AC", "19B0"], source: "Sophia" }
@@ -99,8 +99,8 @@ hideall "--sync--"
 567.0 "Quasar Tethers" Ability { id: "196E", source: "Sophia" }
 568.3 "Dischordant Cleansing" # Ability { id: ["19B3", "19B5"], source: "Sophia" }
 575.7 "Quasar (Tilt)" # Ability { id: "1A4C", source: "Sophia" }
+577.5 "--clones appear--" AddedCombatant { name: "Aion Teleos" } window 60,5
 581.5 "Cintamani x3" duration 6 # Ability { id: "19C5", source: "Sophia" }
-577.5 "--clones appear--" AddedCombatant { name: "Aion Teleos" }  window 60,5
 592.8 "Arms Of Wisdom" Ability { id: "19C4", source: "Sophia" }
 599.9 "--sync--" Ability { id: "19AB", source: "Aion Teleos" } window 10,2.5
 599.9 "Thunder II/III" Ability { id: ["19AC", "19B0"], source: "Sophia" }

--- a/ui/raidboss/data/04-sb/alliance/orbonne_monastery.txt
+++ b/ui/raidboss/data/04-sb/alliance/orbonne_monastery.txt
@@ -22,8 +22,8 @@ hideall "--sync--"
 1078.9 "Energy Burst" Ability { id: "373B", source: "Mustadio" }
 1085.6 "Arm Shot" Ability { id: "3739", source: "Mustadio" }
 1099.3 "Analysis" Ability { id: "3735", source: "Mustadio" }
-1100.8 "Ballistic Impact" Ability { id: "3745", source: "Mustadio" }
 1099.5 "--untargetable--"
+1100.8 "Ballistic Impact" Ability { id: "3745", source: "Mustadio" }
 
 ### DRAMATIC CUTSCENE~!
 1105.0 "--sync--" Ability { id: "3746", source: "Mustadio" } window 100,100
@@ -81,7 +81,7 @@ hideall "--sync--"
 1462.1 "Energy Burst" Ability { id: "373B", source: "Mustadio" }
 
 # fake loop
-1465.0 "Searchlight" Ability { id: "373D", source: "Mustadio" } jump 1281 window 100,100
+1465.0 "Searchlight" Ability { id: "373D", source: "Mustadio" } window 100,100 jump 1281
 1471.9 "Analysis"
 1475.2 "--sync--"
 1479.3 "--sync--"
@@ -273,7 +273,7 @@ hideall "--sync--"
 5208.3 "Flare IV" Ability { id: "389D", source: "Ultima, the High Seraph" }
 
 ### Phase 2: 50% Push Remix "Death awaits defiance!"
-5400.0 "--sync--" AddedCombatant { name: "Mustadio" }  window 400,0
+5400.0 "--sync--" AddedCombatant { name: "Mustadio" } window 400,0
 5413.0 "Earth Hammer" Ability { id: "38D8", source: "Demi-Hashmal" } window 400,5
 5415.9 "Time Eruption" Ability { id: "38D0", source: "Demi-Belias" }
 5418.9 "Time Eruption" Ability { id: "38D1", source: "Demi-Belias" }

--- a/ui/raidboss/data/04-sb/alliance/royal_city_of_rabanastre.txt
+++ b/ui/raidboss/data/04-sb/alliance/royal_city_of_rabanastre.txt
@@ -125,8 +125,8 @@ hideall "--start--"
 1395.3 "Hammerfall x3" Ability { id: "25CC", source: "Hashmal, Bringer of Order" }
 
 1398.3 "Summon" Ability { id: "25D4", source: "Hashmal, Bringer of Order" }
-1399.1 "--Golem Adds--"
 1398.6 "Jagged Edge 1" #Ability { id: "25CD", source: "Hashmal, Bringer of Order" }
+1399.1 "--Golem Adds--"
 1400.7 "Jagged Edge 2" #Ability { id: "25CD", source: "Hashmal, Bringer of Order" }
 1402.8 "Jagged Edge 3" #Ability { id: "25CD", source: "Hashmal, Bringer of Order" }
 1411.3 "Demolish" Ability { id: "25D6", source: "Pennantstone Golem" }
@@ -193,7 +193,7 @@ hideall "--start--"
 2189.4 "Crush Helm" Ability { id: "2680", source: "Rofocale" } duration 3.4
 
 2199.3 "--invulnerable--" # ??? from video, no debuff in logs, can push to this by hp%
-2201.3 "Archaeodemon Adds" AddedCombatant { name: "Archaeodemon" }  window 300,300
+2201.3 "Archaeodemon Adds" AddedCombatant { name: "Archaeodemon" } window 300,300
 2208.3 "--lock out--" # ??? from video
 
 # https://xivapi.com/InstanceContentTextData/18031

--- a/ui/raidboss/data/04-sb/alliance/royal_city_of_rabanastre.txt
+++ b/ui/raidboss/data/04-sb/alliance/royal_city_of_rabanastre.txt
@@ -18,7 +18,7 @@ hideall "--start--"
 # Ice phase
 27.6 "Unbind" Ability { id: "2633", source: "Mateus, The Corrupt" }
 33.6 "--sync--" Ability { id: "26A2", source: "Mateus, The Corrupt" }
-34.3 "--Aqua Sphere Adds--" AddedCombatant { name: "Aqua Sphere" } 
+34.3 "--Aqua Sphere Adds--" AddedCombatant { name: "Aqua Sphere" }
 57.5 "Flash-Freeze" Ability { id: "2647", source: "Mateus, The Corrupt" }
 66.7 "--sync--" Ability { id: "2637", source: "Mateus, The Corrupt" }
 74.6 "Flash-Freeze" Ability { id: "2647", source: "Mateus, The Corrupt" }
@@ -30,7 +30,7 @@ hideall "--start--"
 127.8 "--sync--" Ability { id: "263B", source: "Mateus, The Corrupt" }
 139.9 "Blizzard IV" Ability { id: "263D", source: "Mateus, The Corrupt" }
 152.1 "Flash-Freeze" Ability { id: "2647", source: "Mateus, The Corrupt" }
-165.4 "--Flume Toad Adds--" AddedCombatant { name: "Flume Toad" } 
+165.4 "--Flume Toad Adds--" AddedCombatant { name: "Flume Toad" }
 192.5 "Snowpierce 1" Ability { id: "2640", source: "Icicle" }
 # ??? More flume toads, hard to tell from logs
 214.6 "Snowpierce 2" Ability { id: "2640", source: "Icicle" }
@@ -40,7 +40,7 @@ hideall "--start--"
 # Adds
 259.2 "--untargetable--" # ??? from video
 259.8 "--sync--" Ability { id: "266C", source: "Mateus, The Corrupt" } window 260,20
-262.9 "--Azure Guard Adds--" AddedCombatant { name: "Azure Guard" } 
+262.9 "--Azure Guard Adds--" AddedCombatant { name: "Azure Guard" }
 333.2 "--enrage--" # ??? estimating from video
 
 # End of add phase aoe
@@ -49,7 +49,7 @@ hideall "--start--"
 # loop
 524.3 "Unbind" Ability { id: "2633", source: "Mateus, The Corrupt" } window 200,200 jump 27.6
 530.3 "--sync--" #Ability { id: "26A2", source: "Mateus, The Corrupt" }
-531.0 "--Aqua Sphere Adds--" #AddedCombatant { name: "Aqua Sphere" } 
+531.0 "--Aqua Sphere Adds--" #AddedCombatant { name: "Aqua Sphere" }
 554.2 "Flash-Freeze" #Ability { id: "2647", source: "Mateus, The Corrupt" }
 563.4 "--sync--" #Ability { id: "2637", source: "Mateus, The Corrupt" }
 571.3 "Flash-Freeze" #Ability { id: "2647", source: "Mateus, The Corrupt" }

--- a/ui/raidboss/data/04-sb/dungeon/bardams_mettle.txt
+++ b/ui/raidboss/data/04-sb/dungeon/bardams_mettle.txt
@@ -88,7 +88,7 @@ hideall "Reconstruct"
 2060.9 "Pinion" Ability { id: "1F11", source: "Yol Feather" }
 2069.3 "Wind Unbound" Ability { id: "1F0A", source: "Yol" }
 2071.4 "--untargetable--"
-2071.4 "--adds spawn--" AddedCombatant { name: "Corpsecleaner Eagle" }  window 71.4,5
+2071.4 "--adds spawn--" AddedCombatant { name: "Corpsecleaner Eagle" } window 71.4,5
 2078.0 "Pinion" Ability { id: "1F11", source: "Yol Feather" }
 2088.0 "Pinion" Ability { id: "1F11", source: "Yol Feather" }
 2098.0 "Pinion" Ability { id: "1F11", source: "Yol Feather" }
@@ -162,10 +162,10 @@ hideall "Reconstruct"
 2478.7 "Eye Of The Fierce" Ability { id: "1F0D", source: "Yol" }
 2483.9 "Feathercut" Ability { id: "1F09", source: "Yol" }
 2485.7 "Pinion" Ability { id: "1F11", source: "Yol Feather" }
-2490.0 "--untargetable--" NameToggle { name: "Yol", toggle: "00" } jump 2253.8 window 130,5
+2490.0 "--untargetable--" NameToggle { name: "Yol", toggle: "00" } window 130,5 jump 2253.8
 
 2496.5 "Flutterfall"
 2503.7 "Wingbeat"
 2513.1 "Flutterfall"
 2520.5 "Wingbeat"
-2284.9 "Pinion"
+2520.9 "Pinion"

--- a/ui/raidboss/data/04-sb/dungeon/doma_castle.txt
+++ b/ui/raidboss/data/04-sb/dungeon/doma_castle.txt
@@ -56,8 +56,8 @@ hideall "--sync--"
 1029.6 "Bits Activate"
 1039.6 "Circle Of Death" Ability { id: "20A2", source: "Magitek Hexadrone" }
 1045.7 "Hexadrone Bits" AddedCombatant { name: "Hexadrone Bit" }
-1051.2 "Bits Activate"
 1049.8 "Circle Of Death" Ability { id: "20A2", source: "Magitek Hexadrone" }
+1051.2 "Bits Activate"
 1064.5 "Magitek Missiles" Ability { id: "20A5", source: "Magitek Hexadrone" }
 1068.9 "Hexadrone Bits" AddedCombatant { name: "Hexadrone Bit" }
 1074.4 "Bits Activate"
@@ -68,8 +68,8 @@ hideall "--sync--"
 1095.5 "Bits Activate"
 1098.6 "Magitek Missiles" Ability { id: "20A5", source: "Magitek Hexadrone" }
 1111.2 "Hexadrone Bits" AddedCombatant { name: "Hexadrone Bit" }
-1116.7 "Bits Activate"
 1112.9 "Magitek Missiles" Ability { id: "20A5", source: "Magitek Hexadrone" }
+1116.7 "Bits Activate"
 1125.6 "Circle Of Death" Ability { id: "20A2", source: "Magitek Hexadrone" }
 1132.0 "Hexadrone Bits" AddedCombatant { name: "Hexadrone Bit" }
 1137.5 "Bits Activate"
@@ -84,8 +84,8 @@ hideall "--sync--"
 1186.2 "Bits Activate"
 1189.3 "Magitek Missiles"
 1201.9 "Hexadrone Bits"
-1207.4 "Bits Activate"
 1203.6 "Magitek Missiles"
+1207.4 "Bits Activate"
 
 ### Hypertuned Grynewaht
 # -ii 20A9 20AB 20AC 20AE 20A7 2447
@@ -95,48 +95,48 @@ hideall "--sync--"
 2009.4 "Chainsaw" duration 5.5 Ability { id: "20A8", source: "Hypertuned Grynewaht" }
 2022.7 "--center--"
 2022.7 "Delay-Action Charge" Ability { id: "20AD", source: "Hypertuned Grynewaht" } window 10,10 # boss walks center before using
-2023.1 "Gunsaw" duration 5.0  Ability { id: "20AA", source: "Hypertuned Grynewaht" }
+2023.1 "Gunsaw" Ability { id: "20AA", source: "Hypertuned Grynewaht" } duration 5.0
 2045.4 "Thermobaric Charge" Ability { id: "20AF", source: "Hypertuned Grynewaht" }
 2053.8 "--center--" Ability { id: "20B0", source: "Hypertuned Grynewaht" } window 10,10
-2062.0 "Gunsaw" duration 5.0  Ability { id: "20AA", source: "Hypertuned Grynewaht" }
+2062.0 "Gunsaw" Ability { id: "20AA", source: "Hypertuned Grynewaht" } duration 5.0
 2075.3 "Delay-Action Charge" Ability { id: "20AD", source: "Hypertuned Grynewaht" }
 2075.3 "Clean Cut" #Ability { id: "20B1", source: "Magitek Chakram" }
 2076.7 "--center--" Ability { id: "20B0", source: "Hypertuned Grynewaht" } window 10,10
-2084.9 "Gunsaw" duration 5.0  Ability { id: "20AA", source: "Hypertuned Grynewaht" }
+2084.9 "Gunsaw" Ability { id: "20AA", source: "Hypertuned Grynewaht" } duration 5.0
 2098.2 "Delay-Action Charge" Ability { id: "20AD", source: "Hypertuned Grynewaht" }
 2098.2 "Clean Cut" #Ability { id: "20B1", source: "Magitek Chakram" }
 2102.6 "Magitek Bits" AddedCombatant { name: "Retuned Magitek Bit" }
 2108.1 "Bits Activate"
-2117.9 "Chainsaw" duration 5.5 Ability { id: "20A8", source: "Hypertuned Grynewaht" }
+2117.9 "Chainsaw" Ability { id: "20A8", source: "Hypertuned Grynewaht" } duration 5.5
 2120.9 "Thermobaric Charge" Ability { id: "20AF", source: "Hypertuned Grynewaht" }
 2127.9 "--center--" Ability { id: "20B0", source: "Hypertuned Grynewaht" } window 10,10
-2134.2 "Gunsaw" duration 5.0 Ability { id: "20AA", source: "Hypertuned Grynewaht" }
+2134.2 "Gunsaw" Ability { id: "20AA", source: "Hypertuned Grynewaht" } duration 5.0
 2147.5 "Delay-Action Charge" Ability { id: "20AD", source: "Hypertuned Grynewaht" }
 2149.5 "Clean Cut" Ability { id: "20B1", source: "Magitek Chakram" }
 2152.6 "--center--" Ability { id: "20B0", source: "Hypertuned Grynewaht" } window 10,10
-2160.8 "Gunsaw" duration 5.0 Ability { id: "20AA", source: "Hypertuned Grynewaht" }
+2160.8 "Gunsaw" Ability { id: "20AA", source: "Hypertuned Grynewaht" } duration 5.0
 2174.1 "Delay-Action Charge" Ability { id: "20AD", source: "Hypertuned Grynewaht" }
 2174.1 "Clean Cut" #Ability { id: "20B1", source: "Magitek Chakram" }
 2179.7 "--center--" Ability { id: "20B0", source: "Hypertuned Grynewaht" } window 10,10
 2179.7 "Magitek Bits" AddedCombatant { name: "Retuned Magitek Bit" }
 2185.2 "Bits Activate"
-2194.8 "Chainsaw" duration 5.5 Ability { id: "20A8", source: "Hypertuned Grynewaht" }
+2194.8 "Chainsaw" Ability { id: "20A8", source: "Hypertuned Grynewaht" } duration 5.5
 2199.9 "Thermobaric Charge" Ability { id: "20AF", source: "Hypertuned Grynewaht" }
 2201.2 "Clean Cut" Ability { id: "20B1", source: "Magitek Chakram" }
 
 2208.5 "--center--" Ability { id: "20B0", source: "Hypertuned Grynewaht" } window 10,10
-2216.7 "Gunsaw" duration 5.0 Ability { id: "20AA", source: "Hypertuned Grynewaht" }
+2216.7 "Gunsaw" Ability { id: "20AA", source: "Hypertuned Grynewaht" } duration 5.0
 2230.0 "Delay-Action Charge" Ability { id: "20AD", source: "Hypertuned Grynewaht" }
 2230.0 "Clean Cut" #Ability { id: "20B1", source: "Magitek Chakram" }
 2232.5 "Magitek Bits" AddedCombatant { name: "Retuned Magitek Bit" }
 2238.0 "Bits Activate"
-2245.7 "Chainsaw" duration 5.5 Ability { id: "20A8", source: "Hypertuned Grynewaht" }
+2245.7 "Chainsaw" Ability { id: "20A8", source: "Hypertuned Grynewaht" } duration 5.5
 2253.4 "Thermobaric Charge" Ability { id: "20AF", source: "Hypertuned Grynewaht" }
-2259.8 "Chainsaw" duration 5.5 Ability { id: "20A8", source: "Hypertuned Grynewaht" }
+2259.8 "Chainsaw" Ability { id: "20A8", source: "Hypertuned Grynewaht" } duration 5.5
 
 2274.0 "--center--" Ability { id: "20B0", source: "Hypertuned Grynewaht" } window 10,10
 # Loop begins here, but the jump is attached to the Delay-Action Charge to preserve the duration timer for Gunsaw
-2282.2 "Gunsaw" duration 5.0 Ability { id: "20AA", source: "Hypertuned Grynewaht" }
+2282.2 "Gunsaw" Ability { id: "20AA", source: "Hypertuned Grynewaht" } duration 5.0
 2295.5 "Delay-Action Charge" Ability { id: "20AD", source: "Hypertuned Grynewaht" } jump 2230.0
 2295.5 "Clean Cut"
 2298.0 "Magitek Bits"

--- a/ui/raidboss/data/04-sb/dungeon/drowned_city_of_skalla.txt
+++ b/ui/raidboss/data/04-sb/dungeon/drowned_city_of_skalla.txt
@@ -49,7 +49,7 @@ hideall "--sync--"
 1000.0 "Start" SystemLogMessage { id: "7DC", param1: "93C" } window 1000,5
 1009.2 "Mystic Light" Ability { id: "2657", source: "The Old One" }
 1015.0 "Mystic Flame" Ability { id: "2658", source: "The Old One" }
-1018.1 "Order To Detonate (cast)" StartsUsing { id: "265B", source: "The Old One" } window 18.1,5 duration 19.7
+1018.1 "Order To Detonate (cast)" StartsUsing { id: "265B", source: "The Old One" } duration 19.7 window 18.1,5
 1037.8 "Order To Detonate?" # Ability { id: "265B", source: "The Old One" }
 1040.6 "Self-Detonate?" # Ability { id: "265C", source: "Subservient" }
 1047.7 "Mystic Flame" Ability { id: "2658", source: "The Old One" } window 20,20

--- a/ui/raidboss/data/04-sb/dungeon/fractal_continuum_hard.txt
+++ b/ui/raidboss/data/04-sb/dungeon/fractal_continuum_hard.txt
@@ -79,7 +79,7 @@ hideall "--sync--"
 
 # Sephirot's block
 
-1100.0 "--sync--" BattleTalk2 { instanceContentTextId: "484D" } 
+1100.0 "--sync--" BattleTalk2 { instanceContentTextId: "484D" }
 1107.5 "Primordial Aether" Ability { id: "2796", source: "The Ultima Warrior" } window 10,10
 1119.1 "Citadel Buster" Ability { id: "2792", source: "The Ultima Warrior" }
 1120.1 "Ratzon" Ability { id: "2797", source: "The Ultima Warrior" }
@@ -101,7 +101,7 @@ hideall "--sync--"
 
 # Sophia's Block
 
-1200.0 "--sync--" BattleTalk2 { instanceContentTextId: "484E" } 
+1200.0 "--sync--" BattleTalk2 { instanceContentTextId: "484E" }
 1207.5 "Primordial Aether" Ability { id: "2796", source: "The Ultima Warrior" } window 10,10
 1218.1 "Ceruleum Vent" Ability { id: "2794", source: "The Ultima Warrior" }
 1225.3 "Citadel Buster" Ability { id: "2792", source: "The Ultima Warrior" }
@@ -124,7 +124,7 @@ hideall "--sync--"
 
 # Zurvan's Block
 
-1300.0 "--sync--" BattleTalk2 { instanceContentTextId: "484F" } 
+1300.0 "--sync--" BattleTalk2 { instanceContentTextId: "484F" }
 1308.5 "Primordial Aether" Ability { id: "2796", source: "The Ultima Warrior" } window 10,10
 1311.1 "Infinite Fire/Infinite Ice" Ability { id: "279[DE]", source: "The Ultima Warrior" }
 1319.1 "Ceruleum Vent" Ability { id: "2794", source: "The Ultima Warrior" }

--- a/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.txt
+++ b/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.txt
@@ -168,7 +168,7 @@ hideall "--sync--"
 2386.1 "Order To Bombard" Ability { id: "3710", source: "Annia Quo Soranus" }
 2388.5 "--sync--" Ability { id: "370F", source: "Annia Quo Soranus" }
 
-2390.5 "The Order" Ability { id: "3714", source: "Julia Quo Soranus" } jump 2329.5 window 30,30
+2390.5 "The Order" Ability { id: "3714", source: "Julia Quo Soranus" } window 30,30 jump 2329.5
 2390.7 "Crossbones"
 2392.6 "Angry Salamander"
 2393.4 "Bombardment"

--- a/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.txt
+++ b/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.txt
@@ -223,4 +223,4 @@ hideall "--sync--"
 2600.0 "Artificial Boost" Ability { id: "3730", source: "Annia Quo Soranus" } window 600,5
 # 2603.2 "--sync--" StartsUsing { id: "3731", source: "Julia Quo Soranus" }
 2603.2 "Imperial Authority" StartsUsing { id: "3732", source: "Annia Quo Soranus" } duration 39.7
-2642.9 "Imperial Authority Enrage" Ability { id: "3732", source: "Annia Quo Soranus" } 
+2642.9 "Imperial Authority Enrage" Ability { id: "3732", source: "Annia Quo Soranus" }

--- a/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark64.txt
+++ b/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark64.txt
@@ -168,7 +168,7 @@ hideall "--sync--"
 2386.1 "Order To Bombard" Ability { id: "3710", source: "Annia Quo Soranus" }
 2388.5 "--sync--" Ability { id: "370F", source: "Annia Quo Soranus" }
 
-2390.5 "The Order" Ability { id: "3714", source: "Julia Quo Soranus" } jump 2329.5 window 30,30
+2390.5 "The Order" Ability { id: "3714", source: "Julia Quo Soranus" } window 30,30 jump 2329.5
 2390.7 "Crossbones"
 2392.6 "Angry Salamander"
 2393.4 "Bombardment"

--- a/ui/raidboss/data/04-sb/dungeon/hells_lid.txt
+++ b/ui/raidboss/data/04-sb/dungeon/hells_lid.txt
@@ -54,7 +54,7 @@ hideall "--sync--"
 # -ic "Tsumuji-Kaze"
 
 # The Furnace will be sealed off
-1000.0  "Start" SystemLogMessage { id: "7DC", param1: "956" } window 1000,1
+1000.0 "Start" SystemLogMessage { id: "7DC", param1: "956" } window 1000,1
 1011.5 "Whipping Whittret" Ability { id: "27C6", source: "Kamaitachi" } window 11.5,5
 1024.1 "Circling Winds" Ability { id: "27C8", source: "Kamaitachi" }
 1037.8 "The Patient Blade" Ability { id: "27C7", source: "Kamaitachi" }

--- a/ui/raidboss/data/04-sb/dungeon/shisui_of_the_violet_tides.txt
+++ b/ui/raidboss/data/04-sb/dungeon/shisui_of_the_violet_tides.txt
@@ -150,7 +150,7 @@ hideall "--sync--"
 2209.6 "Foul Nail" #Ability { id: "1F87", source: "Shisui Yohi" }
 
 # Phase 3: 75% -> 60%, introduction to adds
-2300.0 "--adds--" AddedCombatant { name: "Naishi-No-Kami" }  window 300,0
+2300.0 "--adds--" AddedCombatant { name: "Naishi-No-Kami" } window 300,0
 2303.4 "Foul Nail" Ability { id: "1F87", source: "Shisui Yohi" }
 2313.5 "Mad Stare" Ability { id: "1F82", source: "Shisui Yohi" }
 

--- a/ui/raidboss/data/04-sb/dungeon/temple_of_the_fist.txt
+++ b/ui/raidboss/data/04-sb/dungeon/temple_of_the_fist.txt
@@ -10,7 +10,7 @@ hideall "--sync--"
 17.8 "Radial Blaster" Ability { id: "1FD3", source: "Coeurl Sruti" }
 22.0 "Pounce" Ability { id: "1FD1", source: "Coeurl Sruti" }
 
-38.5 "--Smriti Appears--" AddedCombatant { name: "Coeurl Smriti" }  window 10,10
+38.5 "--Smriti Appears--" AddedCombatant { name: "Coeurl Smriti" } window 10,10
 46.5 "Wide Blaster" Ability { id: "1FD4", source: "Coeurl Smriti" } window 15,15
 46.5 "Radial Blaster" Ability { id: "1FD3", source: "Coeurl Sruti" }
 52.6 "Pounce x2" Ability { id: "1FD1", source: "Coeurl Smriti" }

--- a/ui/raidboss/data/04-sb/eureka/eureka_hydatos.txt
+++ b/ui/raidboss/data/04-sb/eureka/eureka_hydatos.txt
@@ -9,8 +9,8 @@ hideall "--sync--"
 # Trigger set contains 'resetWhenOutOfCombat: false'
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
-0.0 "--Reset--" RemovedCombatant { name: "Proto Ozma" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
+0.0 "--Reset--" RemovedCombatant { name: "Proto Ozma" } window 0,100000 jump 0
 
 
 #####################
@@ -95,8 +95,8 @@ hideall "--sync--"
 2261.4 "Elemental Shift" Ability { id: "3937", source: "Owain" }
 2267.5 "Ivory Palm Adds" # Ability { id: "3941", source: "Ivory Palm" }
 2272.5 "Elemental Magicks" Ability { id: "393[AB]", source: "Owain" }
-2290.5 "(Explosion Enrage)"
 2283.5 "Thricecull" Ability { id: "3945", source: "Owain" }
+2290.5 "(Explosion Enrage)"
 2291.6 "Spiritcull" Ability { id: "393E", source: "Owain" }
 2296.6 "Legendary Imbas" Ability { id: "3940", source: "Owain" }
 2296.6 "Piercing Light" Ability { id: "393F", source: "Owain" }
@@ -293,7 +293,7 @@ hideall "--sync--"
 
 ### Pyramid Phase
 5300.0 "Pyramid Form" Ability { id: "37A4", source: "Proto Ozma" } window 800,800
-5303.0  "--sync--" Ability { id: ["37A6", "37B4", "37A0"], source: "Ozmashade" }
+5303.0 "--sync--" Ability { id: ["37A6", "37B4", "37A0"], source: "Ozmashade" }
 5304.5 "Shade Ability" # Ability { id: ["37A7", "37B5", "37A1"], source: "Shadow" }
 
 5307.0 "--sync--" Ability { id: "37A6", source: "Proto Ozma" }
@@ -415,5 +415,5 @@ hideall "--sync--"
 
 
 ### Star Form Enrage
-6200.0 "--sync--"  StartsUsing { id: "396D", source: "Proto Ozma" } window 300,0
+6200.0 "--sync--" StartsUsing { id: "396D", source: "Proto Ozma" } window 300,0
 6210.0 "Shooting Star Enrage" Ability { id: "396D", source: "Proto Ozma" }

--- a/ui/raidboss/data/04-sb/raid/o10n.txt
+++ b/ui/raidboss/data/04-sb/raid/o10n.txt
@@ -39,7 +39,7 @@ hideall "--sync--"
 183.5 "Frost Breath" Ability { id: "33EE", source: "Ancient Dragon" } window 30,30
 195.5 "Frost Breath ready"
 
-500.0 "Protostar x4" Ability { id: "31C3", source: "Midgardsormr" } window 500,500 duration 12
+500.0 "Protostar x4" Ability { id: "31C3", source: "Midgardsormr" } duration 12 window 500,500
 523.4 "--targetable--"
 536.6 "Tail End" Ability { id: "31C5", source: "Midgardsormr" }
 544.6 "Exaflare"

--- a/ui/raidboss/data/04-sb/raid/o10s.txt
+++ b/ui/raidboss/data/04-sb/raid/o10s.txt
@@ -1,5 +1,6 @@
 # Omega - Alphascape V2.0 (Savage) - O10S
 # -ii 31FA 3249 3630 3623 35BB 35BC 31D6 31B7 31C4 362C 321E 320D
+# TODO: update to use forcejump
 
 hideall "--Reset--"
 hideall "--sync--"

--- a/ui/raidboss/data/04-sb/raid/o10s.txt
+++ b/ui/raidboss/data/04-sb/raid/o10s.txt
@@ -106,7 +106,7 @@ hideall "--sync--"
 1486.6 "Flip/Spin" Ability { id: "31AE", source: "Midgardsormr" }
 1490.6 "In/Out" Ability { id: "31B(2|4)", source: "Midgardsormr" }
 1490.6 "Earth Shaker" Ability { id: "31B6", source: "Midgardsormr" }
-1502.3 "Time Immemorial" Ability { id: "32EF", source: "Midgardsormr" } jump 502.3
+1502.3 "Time Immemorial" Ability { id: "32EF", source: "Midgardsormr" } jump 3502.3
 1512.6 "Exaflare" # Cosmetic
 1513.7 "Dry Ice"
 1515.7 "Exaflare"
@@ -121,7 +121,7 @@ hideall "--sync--"
 2486.6 "Flip/Spin" Ability { id: "31AE", source: "Midgardsormr" }
 2490.6 "Corners/Cardinals" Ability { id: "31B(3|5)", source: "Midgardsormr" }
 2492.1 "Thunderstorm" Ability { id: "31B8", source: "Midgardsormr" }
-2502.3 "Time Immemorial" Ability { id: "32EF", source: "Midgardsormr" } jump 502.3
+2502.3 "Time Immemorial" Ability { id: "32EF", source: "Midgardsormr" } jump 3502.3
 2512.6 "Exaflare" # Cosmetic
 2513.7 "Dry Ice"
 2515.7 "Exaflare"
@@ -133,76 +133,76 @@ hideall "--sync--"
 ## Branches A1/B1 converge back ##
 ##################################
 
-502.3 "Time Immemorial" Ability { id: "32EF", source: "Midgardsormr" }
-512.6 "Exaflare"
-513.7 "Dry Ice" Ability { id: "3631", source: "Midgardsormr" }
-515.7 "Exaflare"
-518.6 "Exaflare"
-520.8 "Akh Morn" Ability { id: "31AB", source: "Midgardsormr" }
-521.7 "Exaflare"
-524.7 "Exaflare"
+3502.3 "Time Immemorial" Ability { id: "32EF", source: "Midgardsormr" }
+3512.6 "Exaflare"
+3513.7 "Dry Ice" Ability { id: "3631", source: "Midgardsormr" }
+3515.7 "Exaflare"
+3518.6 "Exaflare"
+3520.8 "Akh Morn" Ability { id: "31AB", source: "Midgardsormr" }
+3521.7 "Exaflare"
+3524.7 "Exaflare"
 
 ##################
 ## Branch point ##
 ##################
 
-536.8 "Flip/Spin" Ability { id: "31AC", source: "Midgardsormr" } jump 1536.8 # C means spin->shaker
-536.8 "--sync--" Ability { id: "31AD", source: "Midgardsormr" } jump 2536.8 # D means flip->thunder
-545.9 "Northern Cross" # Cosmetic
-550.1 "Spin/Flip"
-553.6 "Position"
-553.6 "Shaker/Thunder"
+3536.8 "Flip/Spin" Ability { id: "31AC", source: "Midgardsormr" } jump 4536.8 # C means spin->shaker
+3536.8 "--sync--" Ability { id: "31AD", source: "Midgardsormr" } jump 5536.8 # D means flip->thunder
+3545.9 "Northern Cross" # Cosmetic
+3550.1 "Spin/Flip"
+3553.6 "Position"
+3553.6 "Shaker/Thunder"
 
 ## Branch A2: Spin->Earthshaker
-1536.8 "Spin" Ability { id: "31AC", source: "Midgardsormr" }
-1545.9 "Northern Cross" Ability { id: "3625", source: "Midgardsormr" }
-1550.1 "Spin/Flip" Ability { id: "31AE", source: "Midgardsormr" }
-1553.6 "In/Out" Ability { id: "31B(2|4)", source: "Midgardsormr" }
-1553.6 "Earth Shaker" Ability { id: "31B6", source: "Midgardsormr" }
-1562.3 "Horrid Roar" Ability { id: "31B9", source: "Midgardsormr" } jump 562.3
-1573.4 "Akh Rhai" # Cosmetic
-1579.6 "Tail End"
-1587.9 "Flip/Spin"
+4536.8 "Spin" Ability { id: "31AC", source: "Midgardsormr" }
+4545.9 "Northern Cross" Ability { id: "3625", source: "Midgardsormr" }
+4550.1 "Spin/Flip" Ability { id: "31AE", source: "Midgardsormr" }
+4553.6 "In/Out" Ability { id: "31B(2|4)", source: "Midgardsormr" }
+4553.6 "Earth Shaker" Ability { id: "31B6", source: "Midgardsormr" }
+4562.3 "Horrid Roar" Ability { id: "31B9", source: "Midgardsormr" } jump 6562.3
+4573.4 "Akh Rhai" # Cosmetic
+4579.6 "Tail End"
+4587.9 "Flip/Spin"
 
 ## Branch B2: Flip->Thunderstorm
-2536.8 "Flip" Ability { id: "31AD", source: "Midgardsormr" }
-2545.9 "Northern Cross" Ability { id: "3625", source: "Midgardsormr" }
-2550.1 "Spin/Flip" Ability { id: "31AE", source: "Midgardsormr" }
-2553.6 "Corners/Cardinals" Ability { id: "31B(3|5)", source: "Midgardsormr" }
-2555.1 "Thunderstorm" Ability { id: "31B8", source: "Midgardsormr" }
-2562.3 "Horrid Roar" Ability { id: "31B9", source: "Midgardsormr" } jump 562.3
-2573.4 "Akh Rhai" # Cosmetic
-2579.6 "Tail End"
-2587.9 "Flip/Spin"
+5536.8 "Flip" Ability { id: "31AD", source: "Midgardsormr" }
+5545.9 "Northern Cross" Ability { id: "3625", source: "Midgardsormr" }
+5550.1 "Spin/Flip" Ability { id: "31AE", source: "Midgardsormr" }
+5553.6 "Corners/Cardinals" Ability { id: "31B(3|5)", source: "Midgardsormr" }
+5555.1 "Thunderstorm" Ability { id: "31B8", source: "Midgardsormr" }
+5562.3 "Horrid Roar" Ability { id: "31B9", source: "Midgardsormr" } jump 6562.3
+5573.4 "Akh Rhai" # Cosmetic
+5579.6 "Tail End"
+5587.9 "Flip/Spin"
 
 ##################################
 ## Branches A2/B2 converge back ##
 ##################################
 
-562.3 "Horrid Roar" Ability { id: "31B9", source: "Midgardsormr" }
-573.4 "Akh Rhai" Ability { id: "3622", source: "Midgardsormr" }
-579.6 "Tail End" Ability { id: "31AA", source: "Midgardsormr" } # drift 0.026
+6562.3 "Horrid Roar" Ability { id: "31B9", source: "Midgardsormr" }
+6573.4 "Akh Rhai" Ability { id: "3622", source: "Midgardsormr" }
+6579.6 "Tail End" Ability { id: "31AA", source: "Midgardsormr" } # drift 0.026
 
 ##################
 ## Branch point ##
 ##################
 
 # Return to A1/B1
-587.9 "Flip/Spin" Ability { id: "31AC", source: "Midgardsormr" } jump 1474.4 # C means spin->shaker
-587.9 "--sync--" Ability { id: "31AD", source: "Midgardsormr" } jump 2474.4 # D means flip->thunder
-598.0 "Tail End" # Cosmetic
-600.1 "Flip/Spin"
-604.1 "Signal?"
-605.6 "Position?"
-615.8 "Time Immemorial"
+6587.9 "Flip/Spin" Ability { id: "31AC", source: "Midgardsormr" } jump 1474.4 # C means spin->shaker
+6587.9 "--sync--" Ability { id: "31AD", source: "Midgardsormr" } jump 2474.4 # D means flip->thunder
+6598.0 "Tail End" # Cosmetic
+6600.1 "Flip/Spin"
+6604.1 "Signal?"
+6605.6 "Position?"
+6615.8 "Time Immemorial"
 
 # Enrage
-700.0 "--sync--" StartsUsing { id: "3247", source: "Midgardsormr" } window 700,3000
-704.9 "Enrage Hit 1"
-707.2 "Enrage Hit 2"
-708.5 "Enrage Hit 3"
-709.8 "Enrage Hit 4"
-711.1 "Enrage Hit 5"
-712.2 "Enrage Hit 6"
-713.3 "Enrage Hit 7"
-714.4 "Enrage Hit 8"
+6700.0 "--sync--" StartsUsing { id: "3247", source: "Midgardsormr" } window 6700,3000
+6704.9 "Enrage Hit 1"
+6707.2 "Enrage Hit 2"
+6708.5 "Enrage Hit 3"
+6709.8 "Enrage Hit 4"
+6711.1 "Enrage Hit 5"
+6712.2 "Enrage Hit 6"
+6713.3 "Enrage Hit 7"
+6714.4 "Enrage Hit 8"

--- a/ui/raidboss/data/04-sb/raid/o11n.txt
+++ b/ui/raidboss/data/04-sb/raid/o11n.txt
@@ -7,101 +7,101 @@ hideall "--sync--"
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 12.8 "Atomic Ray" Ability { id: "3286", source: "Omega" } window 20,80
 24.9 "Mustard Bomb" Ability { id: "3287", source: "Omega" }
-27.0 "Ballistic Missile?" Ability { id: "327E", source: "Omega" } window 30,40 jump 227.0
+27.0 "Ballistic Missile?" Ability { id: "327E", source: "Omega" } window 30,40 jump 2227.0
 37.1 "Flamethrower?"
-38.1 "Starboard/Larboard Cannon?" Ability { id: "328[13]", source: "Omega" } window 40,40 jump 138.1
+38.1 "Starboard/Larboard Cannon?" Ability { id: "328[13]", source: "Omega" } window 40,40 jump 1138.1
 43.8 "Starboard/Larboard Cannon?"
 
 ## Starboard/Larboard first path
-138.1 "Starboard/Larboard Cannon" Ability { id: "328[13]", source: "Omega" }
-143.8 "Starboard/Larboard Cannon" Ability { id: "328[24]", source: "Omega" }
-146.5 "Ballistic Missile" Ability { id: "327E", source: "Omega" }
-156.7 "Flamethrower" Ability { id: "327D", source: "Omega" }
-156.7 "Ballistic Impact" Ability { id: "327F", source: "Omega" }
-167.8 "Mustard Bomb" Ability { id: "3287", source: "Omega" } # drift 0.044
-178.7 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" } window 50,10 jump 478.7
-203.5 "Peripheral Synthesis"
-217.6 "Flamethrower"
-227.8 "Atomic Ray"
+1138.1 "Starboard/Larboard Cannon" Ability { id: "328[13]", source: "Omega" }
+1143.8 "Starboard/Larboard Cannon" Ability { id: "328[24]", source: "Omega" }
+1146.5 "Ballistic Missile" Ability { id: "327E", source: "Omega" }
+1156.7 "Flamethrower" Ability { id: "327D", source: "Omega" }
+1156.7 "Ballistic Impact" Ability { id: "327F", source: "Omega" }
+1167.8 "Mustard Bomb" Ability { id: "3287", source: "Omega" } # drift 0.044
+1178.7 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" } window 50,10 jump 2478.7
+1203.5 "Peripheral Synthesis"
+1217.6 "Flamethrower"
+1227.8 "Atomic Ray"
 
 ## Ballistic Missile first path
-227.0 "Ballistic Missile" Ability { id: "327E", source: "Omega" }
-237.1 "Flamethrower" Ability { id: "327D", source: "Omega" }
-237.1 "Ballistic Impact" Ability { id: "327F", source: "Omega" }
-248.2 "Mustard Bomb" Ability { id: "3287", source: "Omega" }
-261.4 "Starboard/Larboard Cannon" Ability { id: "328[13]", source: "Omega" }
-267.0 "Starboard/Larboard Cannon" Ability { id: "328[24]", source: "Omega" }
-278.7 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" } window 50,10 jump 478.7
-303.5 "Peripheral Synthesis"
-317.6 "Flamethrower"
-327.8 "Atomic Ray"
+2227.0 "Ballistic Missile" Ability { id: "327E", source: "Omega" }
+2237.1 "Flamethrower" Ability { id: "327D", source: "Omega" }
+2237.1 "Ballistic Impact" Ability { id: "327F", source: "Omega" }
+2248.2 "Mustard Bomb" Ability { id: "3287", source: "Omega" }
+2261.4 "Starboard/Larboard Cannon" Ability { id: "328[13]", source: "Omega" }
+2267.0 "Starboard/Larboard Cannon" Ability { id: "328[24]", source: "Omega" }
+2278.7 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" } window 50,10 jump 2478.7
+2303.5 "Peripheral Synthesis"
+2317.6 "Flamethrower"
+2327.8 "Atomic Ray"
 
 ## Paths converge
-478.7 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" }
-503.5 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" }
-517.6 "Flamethrower" Ability { id: "327D", source: "Omega" }
-527.8 "Atomic Ray" Ability { id: "3286", source: "Omega" }
+2478.7 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" }
+2503.5 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" }
+2517.6 "Flamethrower" Ability { id: "327D", source: "Omega" }
+2527.8 "Atomic Ray" Ability { id: "3286", source: "Omega" }
 
 ## Midphase
-534.5 "Program Loop" Ability { id: "3273", source: "Omega" } window 150,150
-534.5 "--untargetable--"
-549.6 "Executable 1" Ability { id: "35A8", source: "Level Checker" }
-570.6 "Executable 2" Ability { id: "35A8", source: "Level Checker" }
-574.6 "Reset" Ability { id: "35AA", source: "Level Checker" }
-578.6 "Reformat" Ability { id: "35A9", source: "Level Checker" }
-587.6 "--sync--" StartsUsing { id: "327A", source: "Level Checker" }
-611.6 "Force Quit" Ability { id: "327A", source: "Level Checker" }
+2534.5 "Program Loop" Ability { id: "3273", source: "Omega" } window 150,150
+2534.5 "--untargetable--"
+2549.6 "Executable 1" Ability { id: "35A8", source: "Level Checker" }
+2570.6 "Executable 2" Ability { id: "35A8", source: "Level Checker" }
+2574.6 "Reset" Ability { id: "35AA", source: "Level Checker" }
+2578.6 "Reformat" Ability { id: "35A9", source: "Level Checker" }
+2587.6 "--sync--" StartsUsing { id: "327A", source: "Level Checker" }
+2611.6 "Force Quit" Ability { id: "327A", source: "Level Checker" }
 
 ## Delta Attack
 # https://xivapi.com/InstanceContentTextData/20109
 # en: Program failure detected. <blip> Engaging Delta Attack protocol.
 # Note: This BattleTalk2 log line arrives in sequence with another, both with a 4000ms display time.
 # As a result, this line shows up 4000ms before the message is displayed (and the GameLog line is emitted).
-996.0 "--sync--" BattleTalk2 { instanceContentTextId: "4E8D" } window 996,100
-1007.0 "--sync--" StartsUsing { id: "327B", source: "Omega" } window 1500,100
-1037.0 "Delta Attack" Ability { id: "327B", source: "Omega" } window 1500,100
-1048.4 "--targetable--"
+2996.0 "--sync--" BattleTalk2 { instanceContentTextId: "4E8D" } window 2996,100
+3007.0 "--sync--" StartsUsing { id: "327B", source: "Omega" } window 3007,100
+3037.0 "Delta Attack" Ability { id: "327B", source: "Omega" } window 3037,100
+3048.4 "--targetable--"
 
 ## Loop
-1060.3 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" } window 10,10
-1070.5 "Flamethrower" Ability { id: "327D", source: "Omega" }
-1072.9 "Rush" Ability { id: "359C", source: "Rocket Punch" }
-1078.7 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" }
-1081.8 "Ballistic Missile" Ability { id: "327E", source: "Omega" }
-1091.3 "Rush" Ability { id: "359C", source: "Rocket Punch" } # drift -0.041999
-1091.9 "Ballistic Impact" Ability { id: "327F", source: "Omega" }
-1101.0 "Electric Slide" Ability { id: "3285", source: "Omega" }
-1115.3 "Mustard Bomb" Ability { id: "3287", source: "Omega" }
-1117.6 "Blaster" Ability { id: "3280", source: "Omega" }
-1127.7 "Starboard/Larboard Cannon" Ability { id: "328[13]", source: "Omega" }
-1133.4 "Starboard/Larboard Cannon" Ability { id: "328[24]", source: "Omega" }
-1140.1 "Atomic Ray" Ability { id: "3286", source: "Omega" }
-1150.3 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" } # drift 0.046
-1163.0 "Rush" Ability { id: "359C", source: "Rocket Punch" }
-1175.1 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" }
-1185.3 "Flamethrower" Ability { id: "327D", source: "Omega" }
-1187.6 "Rush" Ability { id: "359C", source: "Rocket Punch" }
-1196.4 "Atomic Ray" Ability { id: "3286", source: "Omega" }
-1204.5 "Ballistic Missile" Ability { id: "327E", source: "Omega" } # drift 0.042
-1214.6 "Flamethrower" Ability { id: "327D", source: "Omega" }
-1214.6 "Ballistic Impact" Ability { id: "327F", source: "Omega" }
-1221.7 "Starboard/Larboard Cannon" Ability { id: "328[13]", source: "Omega" }
-1227.3 "Starboard/Larboard Cannon" Ability { id: "328[24]", source: "Omega" }
-1237.1 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" }
-1249.8 "Rush" Ability { id: "359C", source: "Rocket Punch" }
-1255.6 "Electric Slide" Ability { id: "3285", source: "Omega" } # drift -0.049
-1262.7 "Starboard/Larboard Cannon" Ability { id: "328[13]", source: "Omega" }
-1268.4 "Starboard/Larboard Cannon" Ability { id: "328[24]", source: "Omega" }
-1275.0 "Atomic Ray" Ability { id: "3286", source: "Omega" } # drift 0.042999
-1290.3 "Mustard Bomb" Ability { id: "3287", source: "Omega" }
-1303.5 "Mustard Bomb" Ability { id: "3287", source: "Omega" }
-1305.6 "Blaster" Ability { id: "3280", source: "Omega" } # drift 0.046001
-1314.8 "Atomic Ray" Ability { id: "3286", source: "Omega" }
-1320.9 "Atomic Ray" Ability { id: "3286", source: "Omega" }
+3060.3 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" } window 10,10
+3070.5 "Flamethrower" Ability { id: "327D", source: "Omega" }
+3072.9 "Rush" Ability { id: "359C", source: "Rocket Punch" }
+3078.7 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" }
+3081.8 "Ballistic Missile" Ability { id: "327E", source: "Omega" }
+3091.3 "Rush" Ability { id: "359C", source: "Rocket Punch" } # drift -0.041999
+3091.9 "Ballistic Impact" Ability { id: "327F", source: "Omega" }
+3101.0 "Electric Slide" Ability { id: "3285", source: "Omega" }
+3115.3 "Mustard Bomb" Ability { id: "3287", source: "Omega" }
+3117.6 "Blaster" Ability { id: "3280", source: "Omega" }
+3127.7 "Starboard/Larboard Cannon" Ability { id: "328[13]", source: "Omega" }
+3133.4 "Starboard/Larboard Cannon" Ability { id: "328[24]", source: "Omega" }
+3140.1 "Atomic Ray" Ability { id: "3286", source: "Omega" }
+3150.3 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" } # drift 0.046
+3163.0 "Rush" Ability { id: "359C", source: "Rocket Punch" }
+3175.1 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" }
+3185.3 "Flamethrower" Ability { id: "327D", source: "Omega" }
+3187.6 "Rush" Ability { id: "359C", source: "Rocket Punch" }
+3196.4 "Atomic Ray" Ability { id: "3286", source: "Omega" }
+3204.5 "Ballistic Missile" Ability { id: "327E", source: "Omega" } # drift 0.042
+3214.6 "Flamethrower" Ability { id: "327D", source: "Omega" }
+3214.6 "Ballistic Impact" Ability { id: "327F", source: "Omega" }
+3221.7 "Starboard/Larboard Cannon" Ability { id: "328[13]", source: "Omega" }
+3227.3 "Starboard/Larboard Cannon" Ability { id: "328[24]", source: "Omega" }
+3237.1 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" }
+3249.8 "Rush" Ability { id: "359C", source: "Rocket Punch" }
+3255.6 "Electric Slide" Ability { id: "3285", source: "Omega" } # drift -0.049
+3262.7 "Starboard/Larboard Cannon" Ability { id: "328[13]", source: "Omega" }
+3268.4 "Starboard/Larboard Cannon" Ability { id: "328[24]", source: "Omega" }
+3275.0 "Atomic Ray" Ability { id: "3286", source: "Omega" } # drift 0.042999
+3290.3 "Mustard Bomb" Ability { id: "3287", source: "Omega" }
+3303.5 "Mustard Bomb" Ability { id: "3287", source: "Omega" }
+3305.6 "Blaster" Ability { id: "3280", source: "Omega" } # drift 0.046001
+3314.8 "Atomic Ray" Ability { id: "3286", source: "Omega" }
+3320.9 "Atomic Ray" Ability { id: "3286", source: "Omega" }
 
 # Loop lookahead
-1334.2 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" } window 50,50 jump 1060.3
-1344.4 "Flamethrower"
-1346.8 "Rush"
-1352.6 "Peripheral Synthesis"
-1355.7 "Ballistic Missile"
+3334.2 "Peripheral Synthesis" Ability { id: "3270", source: "Omega" } window 50,50 jump 3060.3
+3344.4 "Flamethrower"
+3346.8 "Rush"
+3352.6 "Peripheral Synthesis"
+3355.7 "Ballistic Missile"

--- a/ui/raidboss/data/04-sb/raid/o12n.txt
+++ b/ui/raidboss/data/04-sb/raid/o12n.txt
@@ -73,8 +73,8 @@ hideall "--sync--"
 725.1 "Firewall" Ability { id: "3392", source: "Omega-M" } window 100,10
 
 737.1 "Synthetic Blades/Shield" # branching
-737.1 "--sync--" Ability { id: "32FD", source: "Omega-M" } jump 937.1 window 20,20 # shield
-737.1 "--sync--" Ability { id: "3301", source: "Omega" } jump 1137.1 window 20,20 # blades
+737.1 "--sync--" Ability { id: "32FD", source: "Omega-M" } window 20,20 jump 937.1 # shield
+737.1 "--sync--" Ability { id: "3301", source: "Omega" } window 20,20 jump 1137.1 # blades
 739.1 "Laser Shower"
 
 # Two paths here.  The 1st Shield/Blades has a Solar Ray that the others don't.

--- a/ui/raidboss/data/04-sb/raid/o12s.txt
+++ b/ui/raidboss/data/04-sb/raid/o12s.txt
@@ -6,6 +6,8 @@
 hideall "--Reset--"
 hideall "--sync--"
 
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
+
 # Use autos/BattleTalk2 instead of InCombat lines to start timelines for door & final boss
 # as timeline resets out of combat.
 
@@ -96,7 +98,7 @@ hideall "--sync--"
 1348.2 "Efficient Bladework" Ability { id: "332A", source: "Omega-M" }
 1356.4 "Laser Shower" Ability { id: "3352", source: "Omega-M" }
 1363.4 "Laser Shower" Ability { id: "3353", source: "Omega" }
-1378.0 "Suppression" Ability { id: "3346", source: "Omega" } jump 378.0
+1378.0 "Suppression" Ability { id: "3346", source: "Omega" } jump 2578.0
 1385.1 "Optical Laser" # Cosmetic
 1385.4 "Optimized Meteor"
 1385.6 "Optimized Sagittarius Arrow"
@@ -136,7 +138,7 @@ hideall "--sync--"
 2349.6 "Efficient Bladework" Ability { id: "3329", source: "Omega-M" }
 2350.4 "Laser Shower" Ability { id: "3353", source: "Omega" }
 2357.4 "Laser Shower" Ability { id: "3353", source: "Omega" }
-2375.7 "Suppression" Ability { id: "3346", source: "Omega" } jump 378.0
+2375.7 "Suppression" Ability { id: "3346", source: "Omega" } jump 2578.0
 2382.7 "Optical Laser" # Cosmetic
 2382.7 "Optimized Meteor"
 2382.8 "Optimized Sagittarius Arrow"
@@ -144,26 +146,24 @@ hideall "--sync--"
 2401.3 "Laser Shower"
 
 # Paths converge to enrage sequence
-378.0 "Suppression" Ability { id: "3346", source: "Omega" }
-385.1 "Optical Laser" Ability { id: "3347", source: "Optical Unit" }
-385.4 "Optimized Meteor" Ability { id: "334F", source: "Omega-F" }
-385.6 "Optimized Sagittarius Arrow" Ability { id: "334D", source: "Omega-M" }
-396.4 "Cosmo Memory" Ability { id: "3343", source: "Omega" }
-404.4 "Laser Shower" Ability { id: "3353", source: "Omega" }
-412.4 "Optimized Blade Dance" Ability { id: "334C", source: "Omega" }
-430.4 "Advanced Suppression" Ability { id: "3349", source: "Omega" }
-437.4 "Advanced Optical Laser" Ability { id: "334A", source: "Optical Unit" }
-437.4 "Optimized Meteor" Ability { id: "334F", source: "Omega-F" }
-437.4 "Optimized Sagittarius Arrow" Ability { id: "334D", source: "Omega-M" }
-447.9 "Cosmo Memory" Ability { id: "3343", source: "Omega" }
-455.9 "Laser Shower" Ability { id: "3353", source: "Omega" }
-463.9 "Optimized Blade Dance" Ability { id: "334C", source: "Omega" }
-479.4 "Cosmo Memory" Ability { id: "33EC", source: "Omega" }
+2578.0 "Suppression" Ability { id: "3346", source: "Omega" }
+2585.1 "Optical Laser" Ability { id: "3347", source: "Optical Unit" }
+2585.4 "Optimized Meteor" Ability { id: "334F", source: "Omega-F" }
+2585.6 "Optimized Sagittarius Arrow" Ability { id: "334D", source: "Omega-M" }
+2596.4 "Cosmo Memory" Ability { id: "3343", source: "Omega" }
+2604.4 "Laser Shower" Ability { id: "3353", source: "Omega" }
+2612.4 "Optimized Blade Dance" Ability { id: "334C", source: "Omega" }
+2630.4 "Advanced Suppression" Ability { id: "3349", source: "Omega" }
+2637.4 "Advanced Optical Laser" Ability { id: "334A", source: "Optical Unit" }
+2637.4 "Optimized Meteor" Ability { id: "334F", source: "Omega-F" }
+2637.4 "Optimized Sagittarius Arrow" Ability { id: "334D", source: "Omega-M" }
+2647.9 "Cosmo Memory" Ability { id: "3343", source: "Omega" }
+2655.9 "Laser Shower" Ability { id: "3353", source: "Omega" }
+2663.9 "Optimized Blade Dance" Ability { id: "334C", source: "Omega" }
+2679.4 "Cosmo Memory" Ability { id: "33EC", source: "Omega" }
 
 # Final Omega - Alphascape V4.0 (Savage) - O12S+
 # -r ch1gtabdwN7QYDR6 -p 336C:3016 -ii 3380 3369 3366 335F 3377 336B 33B5
-
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
 
 3000.0 "Start"
 3002.5 "--sync--" Ability { id: "3380", source: "Omega" } window 3003,0

--- a/ui/raidboss/data/04-sb/raid/o2s.txt
+++ b/ui/raidboss/data/04-sb/raid/o2s.txt
@@ -117,21 +117,5 @@ hideall "--Reset--"
 623.5 "Tremblor" #Ability { id: "2373", source: "Catastrophe" }
 632.0 "Earthquake" Ability { id: "2374", source: "Catastrophe" }
 
-562.0 "Antilight (ground)" Ability { id: "2361", source: "Catastrophe" }
-568.0 "Tremblor" #Ability { id: "2373", source: "Catastrophe" }
-568.5 "100 Gs" Ability { id: "2355", source: "Catastrophe" }
-570.5 "Tremblor" #Ability { id: "2373", source: "Catastrophe" }
-579.0 "Earthquake" Ability { id: "2374", source: "Catastrophe" }
-587.0 "Gravitational Wave" Ability { id: "2372", source: "Catastrophe" }
-600.0 "Gravitational Collapse" Ability { id: "235D", source: "Catastrophe" }
-600.0 "-100 Gs" Ability { id: "235E", source: "Catastrophe" }
-610.0 "Death's Gaze" Ability { id: "236F", source: "Catastrophe" }
-
-615.0 "Antilight (ground)" Ability { id: "2361", source: "Catastrophe" }
-621.0 "Tremblor" #Ability { id: "2373", source: "Catastrophe" }
-621.5 "100 Gs" Ability { id: "2355", source: "Catastrophe" }
-623.5 "Tremblor" #Ability { id: "2373", source: "Catastrophe" }
-632.0 "Earthquake" Ability { id: "2374", source: "Catastrophe" }
-
 633.3 "--sync--" StartsUsing { id: "25A2", source: "Catastrophe" }
 643.3 "Gravitational Wave Enrage" Ability { id: "25A2", source: "Catastrophe" }

--- a/ui/raidboss/data/04-sb/raid/o5n.txt
+++ b/ui/raidboss/data/04-sb/raid/o5n.txt
@@ -13,7 +13,7 @@ hideall "--sync--"
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 8 "--sync--" StartsUsing { id: "28AE", source: "Wroth Ghost" } window 8,3
-13 "Encumber" Ability { id: "28AE", source: "Wroth Ghost" } 
+13 "Encumber" Ability { id: "28AE", source: "Wroth Ghost" }
 27 "Head On" Ability { id: "28AF", source: "Phantom Train" }
 38 "Ghost Beams" Ability { id: "28AA", source: "Phantom Train" }
 47 "Saintly Beam" duration 12

--- a/ui/raidboss/data/04-sb/raid/o5n.txt
+++ b/ui/raidboss/data/04-sb/raid/o5n.txt
@@ -9,7 +9,7 @@ hideall "--sync--"
 # Use ActorControl (0x21) Reset line
 # Trigger set contains 'resetWhenOutOfCombat: false'
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 8 "--sync--" StartsUsing { id: "28AE", source: "Wroth Ghost" } window 8,3

--- a/ui/raidboss/data/04-sb/raid/o5s.txt
+++ b/ui/raidboss/data/04-sb/raid/o5s.txt
@@ -9,7 +9,7 @@ hideall "--sync--"
 # Use ActorControl (0x21) Reset line
 # Trigger set contains 'resetWhenOutOfCombat: false'
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 11 "Encumber" Ability { id: "28B6", source: "Wroth Ghost" } window 11,5
@@ -95,5 +95,5 @@ hideall "--sync--"
 828 "Tether Whistle" Ability { id: "28A5", source: "Phantom Train" }
 
 # 10:00 enrage, final phase length depends on add phase time
-821 "--sync--" StartsUsing { id: "2A87", source: "Phantom Train" } window 821,500
-831 "Saintly Beam" Ability { id: "2A87", source: "Phantom Train" }
+1021 "--sync--" StartsUsing { id: "2A87", source: "Phantom Train" } window 1021,500
+1031 "Saintly Beam" Ability { id: "2A87", source: "Phantom Train" }

--- a/ui/raidboss/data/04-sb/raid/o7s.txt
+++ b/ui/raidboss/data/04-sb/raid/o7s.txt
@@ -8,7 +8,7 @@ hideall "--sync--"
 31 "Atomic Ray" Ability { id: "278D", source: "Guardian" }
 40 "Prey" Ability { id: "278A", source: "Guardian" }
 49 "Load?" Ability { id: "275C", source: "Guardian" }
-50 "--sync--" GainsEffect { effectId: "5D3", effect: "Dadaluma Simulation", target: "Guardian" } jump 1050
+50 "--sync--" GainsEffect { effectId: "5D3", effect: "Dadaluma Simulation", target: "Guardian" } jump 10050 # Version B
 52 "Shockwave?"
 
 # This is Version A of the encounter, with Bibliotaph first
@@ -92,8 +92,8 @@ hideall "--sync--"
 
 # Divergence point
 509 "Load/Skip?" Ability { id: ["275C", "2773"], source: "Guardian" }
-510 "--sync--" GainsEffect { effectId: "5D4", effect: "Bibliotaph Simulation", target: "Guardian" } jump 2510       # Bibliotaph buff, jump to A1
-510 "--sync--" GainsEffect { effectId: "5D3", effect: "Dadaluma Simulation", target: "Guardian" } jump 3510         # Dadaluma buff, jump to A2
+510 "--sync--" GainsEffect { effectId: "5D4", effect: "Bibliotaph Simulation", target: "Guardian" } jump 2510  # Bibliotaph buff, jump to A1
+510 "--sync--" GainsEffect { effectId: "5D3", effect: "Dadaluma Simulation", target: "Guardian" } jump 3510  # Dadaluma buff, jump to A2
 512 "Shockwave?"
 519 "Demon Simulation?"
 
@@ -123,7 +123,7 @@ hideall "--sync--"
 2629 "Prey" Ability { id: "278A", source: "Guardian" }
 2635 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
 2643 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
-2648 "--sync--" StartsUsing { id: ["275C", "2773"], source: "Guardian" } jump 648          # Load/Skip starts casting, return to A
+2648 "--sync--" StartsUsing { id: ["275C", "2773"], source: "Guardian" } jump 4648  # Load/Skip starts casting, return to A
 
 # Should be unreachable, only here for visual continuity before/after jump
 2653 "Load Air Force"
@@ -156,7 +156,7 @@ hideall "--sync--"
 3624 "Prey" Ability { id: "278A", source: "Guardian" }
 3633 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
 3642 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
-3648 "--sync--" StartsUsing { id: ["275C", "2773"], source: "Guardian" } jump 648 # Load/Skip starts casting, return to A
+3648 "--sync--" StartsUsing { id: ["275C", "2773"], source: "Guardian" } jump 4648 # Load/Skip starts casting, return to A
 
 # Should be unreachable, only here for visual continuity before/after jump
 3653 "Load Air Force"
@@ -171,19 +171,19 @@ hideall "--sync--"
 ##########################################################
 
 # Air Force
-653 "Load Air Force" Ability { id: ["275C", "2773"], source: "Guardian" }
-656 "Diffractive Laser" Ability { id: "2780", source: "Guardian" }
-659 "Radar" duration 2
-666 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
-678 "Run Air Force" Ability { id: "276F", source: "Guardian" }
-684 "Bomb Deployment" Ability { id: "2762", source: "Guardian" }
-685 "Plane Laser" duration 2
-691 "Arm And Hammer" Ability { id: "2789", source: "Guardian" }
-693 "Plane Laser" duration 2
-699 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+4653 "Load Air Force" Ability { id: ["275C", "2773"], source: "Guardian" }
+4656 "Diffractive Laser" Ability { id: "2780", source: "Guardian" }
+4659 "Radar" duration 2
+4666 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+4678 "Run Air Force" Ability { id: "276F", source: "Guardian" }
+4684 "Bomb Deployment" Ability { id: "2762", source: "Guardian" }
+4685 "Plane Laser" duration 2
+4691 "Arm And Hammer" Ability { id: "2789", source: "Guardian" }
+4693 "Plane Laser" duration 2
+4699 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
 
-700 "--sync--" StartsUsing { id: "2791", source: "Guardian" } window 100,100
-715 "Enrage" Ability { id: "2791", source: "Guardian" } jump 0
+4700 "--sync--" StartsUsing { id: "2791", source: "Guardian" } window 100,100
+4715 "Enrage" Ability { id: "2791", source: "Guardian" } jump 0
 
 ######################################
 ########## END of Version A ##########
@@ -191,189 +191,189 @@ hideall "--sync--"
 ######################################
 
 # Only for reference
-1000 "Start"
-1011 "Magitek Ray"
-1021 "Arm And Hammer"
-1031 "Atomic Ray"
-1040 "Prey"
-1049 "Load"
+10000 "Start"
+10011 "Magitek Ray"
+10021 "Arm And Hammer"
+10031 "Atomic Ray"
+10040 "Prey"
+10049 "Load"
 
 # This is Version B of the encounter, with Dadaluma first
 
-1052 "Shockwave" Ability { id: "2783", source: "Guardian" }
-1059 "Missile Simulation" Ability { id: "2764", source: "Guardian" }
-1074 "Chakra Burst" Ability { id: "2787", source: "Guardian" }
-1077 "Run Dada (NW)" Ability { id: "276F", source: "Guardian" }
-1090 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
-1095 "(H) Aura Cannon"
-1105 "(DPS) Aura Cannon"
-1106 "Arm And Hammer" Ability { id: "2789", source: "Guardian" }
-1118 "Prey" Ability { id: "278A", source: "Guardian" }
-1126 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
+10052 "Shockwave" Ability { id: "2783", source: "Guardian" }
+10059 "Missile Simulation" Ability { id: "2764", source: "Guardian" }
+10074 "Chakra Burst" Ability { id: "2787", source: "Guardian" }
+10077 "Run Dada (NW)" Ability { id: "276F", source: "Guardian" }
+10090 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
+10095 "(H) Aura Cannon"
+10105 "(DPS) Aura Cannon"
+10106 "Arm And Hammer" Ability { id: "2789", source: "Guardian" }
+10118 "Prey" Ability { id: "278A", source: "Guardian" }
+10126 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
 
 # Bibliotaph
-1135 "Load Biblio / Skip Air Force" Ability { id: "2773", source: "Guardian" }
-1145 "Demon Simulation" Ability { id: "2B36", source: "Guardian" }
-1153 "Retrieve Air Force" Ability { id: "2774", source: "Guardian" }
-1156 "Diffractive Laser" Ability { id: "2780", source: "Guardian" }
-1164 "Copy Air Force" Ability { id: "2775", source: "Guardian" }
-1171 "Missile Simulation" Ability { id: "2764", source: "Guardian" }
+10135 "Load Biblio / Skip Air Force" Ability { id: "2773", source: "Guardian" }
+10145 "Demon Simulation" Ability { id: "2B36", source: "Guardian" }
+10153 "Retrieve Air Force" Ability { id: "2774", source: "Guardian" }
+10156 "Diffractive Laser" Ability { id: "2780", source: "Guardian" }
+10164 "Copy Air Force" Ability { id: "2775", source: "Guardian" }
+10171 "Missile Simulation" Ability { id: "2764", source: "Guardian" }
 
 # Air Force
-1181 "Run Air Force" Ability { id: "276F", source: "Guardian" }
-1195 "Bomb Deployment" Ability { id: "2762", source: "Guardian" }
-1196 "Plane Laser" duration 2
-1204 "Plane Laser" duration 2
-1206 "Arm And Hammer" Ability { id: "2789", source: "Guardian" }
-1214 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
+10181 "Run Air Force" Ability { id: "276F", source: "Guardian" }
+10195 "Bomb Deployment" Ability { id: "2762", source: "Guardian" }
+10196 "Plane Laser" duration 2
+10204 "Plane Laser" duration 2
+10206 "Arm And Hammer" Ability { id: "2789", source: "Guardian" }
+10214 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
 
 # Ultros
-1222 "Load Ultros" Ability { id: "275C", source: "Guardian" }
-1223 "Ink" Ability { id: "277D", source: "Guardian" }
-1239 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
-1248 "Tentacle Simulation" Ability { id: "275E", source: "Guardian" }
-1252 "Tentacle"
-1258 "Wallop"
-1260 "Run Ultros (SE)" Ability { id: "276F", source: "Guardian" }
-1267 "Interrupt Stoneskin" duration 4
-1269 "--targetable--" Ability { id: "2937", source: "Guardian" }
-1276 "Chain Cannon" duration 2
-1282 "Main Cannon" Ability { id: "2790", source: "Guardian" }
-1285 "--untargetable--" Ability { id: "2938", source: "Guardian" }
-1297 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+10222 "Load Ultros" Ability { id: "275C", source: "Guardian" }
+10223 "Ink" Ability { id: "277D", source: "Guardian" }
+10239 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+10248 "Tentacle Simulation" Ability { id: "275E", source: "Guardian" }
+10252 "Tentacle"
+10258 "Wallop"
+10260 "Run Ultros (SE)" Ability { id: "276F", source: "Guardian" }
+10267 "Interrupt Stoneskin" duration 4
+10269 "--targetable--" Ability { id: "2937", source: "Guardian" }
+10276 "Chain Cannon" duration 2
+10282 "Main Cannon" Ability { id: "2790", source: "Guardian" }
+10285 "--untargetable--" Ability { id: "2938", source: "Guardian" }
+10297 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
 
 # Virus
-1305 "Virus" Ability { id: "2773", source: "Guardian" }
-1308 "Aether Rot"
-1318 "Magnetism/Repel" Ability { id: "2779", source: "Fire Control System" } # optional?
-1331 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
-1343 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
-1355 "Prey" Ability { id: "278A", source: "Guardian" }
-1365 "Viral Weapon" Ability { id: "277C", source: "Guardian" }
-1366 "Temporary Misdirection" duration 15
-1371 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
-1375 "--untargetable--" Ability { id: "2937", source: "Guardian" }
-1382 "Chain Cannon" duration 2
-1388 "Main Cannon" Ability { id: "2790", source: "Guardian" }
-1389 "Radar" duration 2
-1391 "--targetable--" Ability { id: "2938", source: "Guardian" }
-1400 "Arm And Hammer" Ability { id: "2789", source: "Guardian" }
-1408 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+10305 "Virus" Ability { id: "2773", source: "Guardian" }
+10308 "Aether Rot"
+10318 "Magnetism/Repel" Ability { id: "2779", source: "Fire Control System" } # optional?
+10331 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+10343 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+10355 "Prey" Ability { id: "278A", source: "Guardian" }
+10365 "Viral Weapon" Ability { id: "277C", source: "Guardian" }
+10366 "Temporary Misdirection" duration 15
+10371 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
+10375 "--untargetable--" Ability { id: "2937", source: "Guardian" }
+10382 "Chain Cannon" duration 2
+10388 "Main Cannon" Ability { id: "2790", source: "Guardian" }
+10389 "Radar" duration 2
+10391 "--targetable--" Ability { id: "2938", source: "Guardian" }
+10400 "Arm And Hammer" Ability { id: "2789", source: "Guardian" }
+10408 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
 
 # Air Force
-1416 "Paste Air Force" Ability { id: "2776", source: "Guardian" } window 10,10
-1419 "Diffractive Laser" Ability { id: "2780", source: "Guardian" }
-1422 "Radar" duration 2
-1431 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
-1441 "Run Air Force" Ability { id: "276F", source: "Guardian" }
-1447 "Bomb Deployment" Ability { id: "2762", source: "Guardian" }
-1454 "Plane Laser" duration 2
-1462 "Plane Laser" duration 2
-1462 "Arm And Hammer" Ability { id: "2789", source: "Guardian" }
-1470 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+10416 "Paste Air Force" Ability { id: "2776", source: "Guardian" } window 10,10
+10419 "Diffractive Laser" Ability { id: "2780", source: "Guardian" }
+10422 "Radar" duration 2
+10431 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+10441 "Run Air Force" Ability { id: "276F", source: "Guardian" }
+10447 "Bomb Deployment" Ability { id: "2762", source: "Guardian" }
+10454 "Plane Laser" duration 2
+10462 "Plane Laser" duration 2
+10462 "Arm And Hammer" Ability { id: "2789", source: "Guardian" }
+10470 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
 
 # Divergence point
-1481 "Load/Skip?" Ability { id: ["275C", "2773"], source: "Guardian" }
-1482 "--sync--" GainsEffect { effectId: "5D4", effect: "Bibliotaph Simulation", target: "Guardian" } jump 4482       # Bibliotaph buff, jump to B1
-1482 "--sync--" GainsEffect { effectId: "5D3", effect: "Dadaluma Simulation", target: "Guardian" } jump 5482         # Dadaluma buff, jump to B2
-1484 "Shockwave?"
-1491 "Demon Simulation?"
+10481 "Load/Skip?" Ability { id: ["275C", "2773"], source: "Guardian" }
+10482 "--sync--" GainsEffect { effectId: "5D4", effect: "Bibliotaph Simulation", target: "Guardian" } jump 14482  # Bibliotaph buff, jump to B1
+10482 "--sync--" GainsEffect { effectId: "5D3", effect: "Dadaluma Simulation", target: "Guardian" } jump 15482  # Dadaluma buff, jump to B2
+10484 "Shockwave?"
+10491 "Demon Simulation?"
 
 ##########################################################
 ##### Divergent path, Version B1: Biblio -> Dadaluma #####
 ##########################################################
 
 # Bibliotaph
-4481 "Load Biblio" Ability { id: ["275C", "2773"], source: "Guardian" }
-4490 "Radar" duration 2
-4491 "Demon Simulation" Ability { id: "2B36", source: "Guardian" }
-4504 "Run Biblio" Ability { id: "276F", source: "Guardian" }
-4511 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
-4518 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
-4525 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
-4533 "Prey" Ability { id: "278A", source: "Guardian" }
-4542 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
-4551 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+14481 "Load Biblio" Ability { id: ["275C", "2773"], source: "Guardian" }
+14490 "Radar" duration 2
+14491 "Demon Simulation" Ability { id: "2B36", source: "Guardian" }
+14504 "Run Biblio" Ability { id: "276F", source: "Guardian" }
+14511 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+14518 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+14525 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+14533 "Prey" Ability { id: "278A", source: "Guardian" }
+14542 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
+14551 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
 
 # Dadaluma
-4562 "Load Dada" Ability { id: ["275C", "2774"], source: "Guardian" }
-4565 "Shockwave" Ability { id: "2783", source: "Guardian" }
-4569 "Radar" duration 2
-4575 "Missile Simulation" Ability { id: "2764", source: "Guardian" }
-4584 "Atomic Ray" Ability { id: "278D", source: "Guardian" }
-4589 "Chakra Burst" Ability { id: "2787", source: "Guardian" }
-4601 "Prey" Ability { id: "278A", source: "Guardian" }
-4607 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
-4615 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
-4620 "--sync--" StartsUsing { id: ["275C", "2773"], source: "Guardian" } jump 1620         # Load/Skip casting, return to B
+14562 "Load Dada" Ability { id: ["275C", "2774"], source: "Guardian" }
+14565 "Shockwave" Ability { id: "2783", source: "Guardian" }
+14569 "Radar" duration 2
+14575 "Missile Simulation" Ability { id: "2764", source: "Guardian" }
+14584 "Atomic Ray" Ability { id: "278D", source: "Guardian" }
+14589 "Chakra Burst" Ability { id: "2787", source: "Guardian" }
+14601 "Prey" Ability { id: "278A", source: "Guardian" }
+14607 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
+14615 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+14620 "--sync--" StartsUsing { id: ["275C", "2773"], source: "Guardian" } jump 16020  # Load/Skip casting, return to B
 
 # Should be unreachable, only here for visual continuity before/after jump
-4625 "Load Ultros"
-4626 "Ink"
-4633 "Tentacle Simulation"
-4637 "Tentacle"
-4639 "Bomb Deployment"
-4643 "Wallop"
-4648 "Atomic Ray"
+14625 "Load Ultros"
+14626 "Ink"
+14633 "Tentacle Simulation"
+14637 "Tentacle"
+14639 "Bomb Deployment"
+14643 "Wallop"
+14648 "Atomic Ray"
 
 #### Divergent path, Version B2: Dadaluma -> Bibliotaph
 
 # Dadaluma
-5481 "Load Dada" Ability { id: ["275C", "2773"], source: "Guardian" }
-5484 "Shockwave" Ability { id: "2783", source: "Guardian" }
-5488 "Radar" duration 2
-5494 "Missile Simulation" Ability { id: "2764", source: "Guardian" }
-5503 "Atomic Ray" Ability { id: "278D", source: "Guardian" }
-5508 "Chakra Burst" Ability { id: "2787", source: "Guardian" }
-5520 "Prey" Ability { id: "278A", source: "Guardian" }
-5526 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
-5534 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+15481 "Load Dada" Ability { id: ["275C", "2773"], source: "Guardian" }
+15484 "Shockwave" Ability { id: "2783", source: "Guardian" }
+15488 "Radar" duration 2
+15494 "Missile Simulation" Ability { id: "2764", source: "Guardian" }
+15503 "Atomic Ray" Ability { id: "278D", source: "Guardian" }
+15508 "Chakra Burst" Ability { id: "2787", source: "Guardian" }
+15520 "Prey" Ability { id: "278A", source: "Guardian" }
+15526 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
+15534 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
 
 # Bibliotaph
-5544 "Load Biblio" Ability { id: ["275C", "2774"], source: "Guardian" }
-5553 "Radar" duration 2
-5554 "Demon Simulation" Ability { id: "2B36", source: "Guardian" }
-5567 "Run Biblio" Ability { id: "276F", source: "Guardian" }
-5574 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
-5581 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
-5588 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
-5596 "Prey" Ability { id: "278A", source: "Guardian" }
-5605 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
-5614 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
-5620 "--sync--" StartsUsing { id: ["275C", "2773"], source: "Guardian" } jump 1620         # Load/Skip casting, return to B
+15544 "Load Biblio" Ability { id: ["275C", "2774"], source: "Guardian" }
+15553 "Radar" duration 2
+15554 "Demon Simulation" Ability { id: "2B36", source: "Guardian" }
+15567 "Run Biblio" Ability { id: "276F", source: "Guardian" }
+15574 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+15581 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+15588 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+15596 "Prey" Ability { id: "278A", source: "Guardian" }
+15605 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
+15614 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+15620 "--sync--" StartsUsing { id: ["275C", "2773"], source: "Guardian" } jump 16020  # Load/Skip casting, return to B
 
 # Should be unreachable, only here for visual continuity before/after jump
-5625 "Load Ultros"
-5626 "Ink"
-5633 "Tentacle Simulation"
-5637 "Tentacle"
-5639 "Bomb Deployment"
-5643 "Wallop"
-5648 "Atomic Ray"
+15625 "Load Ultros"
+15626 "Ink"
+15633 "Tentacle Simulation"
+15637 "Tentacle"
+15639 "Bomb Deployment"
+15643 "Wallop"
+15648 "Atomic Ray"
 
 ##########################################################
 ##### Divergent paths reconverge, continue Version B #####
 ##########################################################
 
 # Ultros
-1625 "Load Ultros" Ability { id: ["275C", "2773"], source: "Guardian" }
-1626 "Ink" Ability { id: "277D", source: "Guardian" }
-1633 "Tentacle Simulation" Ability { id: "275E", source: "Guardian" }
-1637 "Tentacle"
-1639 "Bomb Deployment" Ability { id: "2762", source: "Guardian" }
-1643 "Wallop"
-1648 "Atomic Ray" Ability { id: "278D", source: "Guardian" }
-1653 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
-1662 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
-1672 "Run Ultros (NE)" Ability { id: "276F", source: "Guardian" }
-1678 "Missile Simulation" Ability { id: "2764", source: "Guardian" }
-1681 "Interrupt Stoneskin" duration 4
-1681 "--untargetable--" Ability { id: "2937", source: "Guardian" }
-1688 "Chain Cannon" duration 2
-1694 "Main Cannon" Ability { id: "2790", source: "Guardian" }
-1697 "--targetable--" Ability { id: "2938", source: "Guardian" }
-1706 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+16025 "Load Ultros" Ability { id: ["275C", "2773"], source: "Guardian" }
+16026 "Ink" Ability { id: "277D", source: "Guardian" }
+16033 "Tentacle Simulation" Ability { id: "275E", source: "Guardian" }
+16037 "Tentacle"
+16039 "Bomb Deployment" Ability { id: "2762", source: "Guardian" }
+16043 "Wallop"
+16048 "Atomic Ray" Ability { id: "278D", source: "Guardian" }
+16053 "Magitek Ray" Ability { id: "2788", source: "Guardian" }
+16062 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
+16072 "Run Ultros (NE)" Ability { id: "276F", source: "Guardian" }
+16078 "Missile Simulation" Ability { id: "2764", source: "Guardian" }
+16081 "Interrupt Stoneskin" duration 4
+16081 "--untargetable--" Ability { id: "2937", source: "Guardian" }
+16088 "Chain Cannon" duration 2
+16094 "Main Cannon" Ability { id: "2790", source: "Guardian" }
+16097 "--targetable--" Ability { id: "2938", source: "Guardian" }
+17006 "Diffractive Plasma" Ability { id: "278B", source: "Guardian" }
 
 # Enrage
-1711 "--sync--" StartsUsing { id: "2791", source: "Guardian" } window 100,100
-1726 "Enrage" Ability { id: "2791", source: "Guardian" } jump 0
+17011 "--sync--" StartsUsing { id: "2791", source: "Guardian" } window 100,100
+17026 "Enrage" Ability { id: "2791", source: "Guardian" } jump 0

--- a/ui/raidboss/data/04-sb/raid/o9n.txt
+++ b/ui/raidboss/data/04-sb/raid/o9n.txt
@@ -1,7 +1,7 @@
 # Omega - Alphascape V1.0 - O9N
 # -r v7g6rkfjhNGDzLn8 -rf 2 -ii 314E 3202 3161 3164 3157 316E 315F  3162 3163 3204 3160 3203 3158 3164 3205 3148 3153
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 hideall "--Reset--"
 hideall "--sync--"

--- a/ui/raidboss/data/04-sb/raid/o9s.txt
+++ b/ui/raidboss/data/04-sb/raid/o9s.txt
@@ -11,6 +11,7 @@ hideall "--sync--"
 10.7 "--sync--" StartsUsing { id: "317(2|3)", source: "Chaos" } window 12,12 jump 2010.1 # Long/lat means water path
 10.7 "--sync--" StartsUsing { id: "3171", source: "Chaos" } window 12,12 jump 1010.7 # Edict means fire path
 
+#cactbot-timeline-lint-disable-sync-order
 # Fake water path
 15.7 "Long/Lat Implosion?"
 29.7 "Tsunami?"
@@ -20,6 +21,7 @@ hideall "--sync--"
 # Fake fire path
 16.7 "Damning Edict?"
 29.9 "Blaze?"
+#cactbot-timeline-lint-enable-sync-order
 
 #############
 # Fire path #
@@ -103,8 +105,8 @@ hideall "--sync--"
 2048.8 "Damning Edict" Ability { id: "3171", source: "Chaos" }
 2066.8 "Chaotic Dispersion" Ability { id: "3170", source: "Chaos" }
 2078.8 "Tsunami" Ability { id: "3207", source: "Chaos" }
-2096.3 "(T/H) Stray Spray" Ability { id: "318D", source: "Chaos" }
 2089.6 "Knock" Ability { id: "317F", source: "Chaos" }
+2096.3 "(T/H) Stray Spray" Ability { id: "318D", source: "Chaos" }
 2096.3 "(DPS) Stray Spray" Ability { id: "318D", source: "Chaos" }
 2096.5 "Big Bang" Ability { id: "3181", source: "Chaos" }
 2107.8 "Fiendish Orbs" Ability { id: "317D", source: "Chaos" }

--- a/ui/raidboss/data/04-sb/raid/o9s.txt
+++ b/ui/raidboss/data/04-sb/raid/o9s.txt
@@ -106,6 +106,7 @@ hideall "--sync--"
 2066.8 "Chaotic Dispersion" Ability { id: "3170", source: "Chaos" }
 2078.8 "Tsunami" Ability { id: "3207", source: "Chaos" }
 2089.6 "Knock" Ability { id: "317F", source: "Chaos" }
+# TODO: Stray Spray may be incorrect - see comments on OverlayPlugin/cactbot#106
 2096.3 "(T/H) Stray Spray" Ability { id: "318D", source: "Chaos" }
 2096.3 "(DPS) Stray Spray" Ability { id: "318D", source: "Chaos" }
 2096.5 "Big Bang" Ability { id: "3181", source: "Chaos" }

--- a/ui/raidboss/data/04-sb/trial/lakshmi.txt
+++ b/ui/raidboss/data/04-sb/trial/lakshmi.txt
@@ -78,8 +78,8 @@ hideall "Alluring Arm"
 1360.9 "--chanchala end--"
 1378.9 "Alluring Arm" Ability { id: "2488", source: "Lakshmi" }
 1392.1 "Stotram" Ability { id: "2483", source: "Lakshmi" } window 30,30
-1393.9 "--vril spawn--"
 1393.2 "Blissful Spear" Ability { id: "2494", source: "Lakshmi" }
+1393.9 "--vril spawn--"
 1402.3 "The Pull Of Light" Ability { id: "2492", source: "Lakshmi" }
 1407.4 "--vril despawn--"
 1421.5 "Alluring Arm" Ability { id: "2488", source: "Lakshmi" }

--- a/ui/raidboss/data/04-sb/trial/shinryu.txt
+++ b/ui/raidboss/data/04-sb/trial/shinryu.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 # Elemental Attack is one of:
 # Aerial Blast, Judgment Bolt, Diamond Dust, Hellfire, Earthen Fury, Tidal Wave
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 20.6 "Tidal Wave" Ability { id: "1FAA", source: "Shinryu" } window 20.6,5

--- a/ui/raidboss/data/04-sb/trial/tsukuyomi-ex.txt
+++ b/ui/raidboss/data/04-sb/trial/tsukuyomi-ex.txt
@@ -51,8 +51,8 @@ hideall "--Reset--"
 # Add phase
 781.0 "Nightbloom" Ability { id: "2BC7", source: "Tsukuyomi" } window 800,0
 781.8 "--untargetable--"
-792.3 "Homeland adds (E->W)" AddedCombatant { name: "Specter Of The Patriarch" }  window 40,20
-852.3 "Empire adds (SW->NW)" AddedCombatant { name: "Specter Of Asahi" }  window 160,20
+792.3 "Homeland adds (E->W)" AddedCombatant { name: "Specter Of The Patriarch" } window 40,20
+852.3 "Empire adds (SW->NW)" AddedCombatant { name: "Specter Of Asahi" } window 160,20
 886.3 "Enrage"
 
 1000.0 "Concentrativity" Ability { id: "2BC8", source: "Specter of Zenos" } window 1000,0

--- a/ui/raidboss/data/04-sb/trial/tsukuyomi.txt
+++ b/ui/raidboss/data/04-sb/trial/tsukuyomi.txt
@@ -27,8 +27,8 @@ hideall "--Reset--"
 
 
 ### Phase 2: Adds
-127.8 "--Patriarch/Matriarch Adds--" AddedCombatant { name: "Specter Of The Matriarch" }  window 30,10
-174.5 "--Empire/Homeland Adds--" AddedCombatant { name: "Specter Of The Empire" }  window 80,10
+127.8 "--Patriarch/Matriarch Adds--" AddedCombatant { name: "Specter Of The Matriarch" } window 30,10
+174.5 "--Empire/Homeland Adds--" AddedCombatant { name: "Specter Of The Empire" } window 80,10
 # TODO: Specter of Asahi shows up alone after all other adds are dead, so can't have a timeline entry.
 
 400.0 "Concentrativity" Ability { id: "2BEF", source: "Specter of Zenos" } window 400,0

--- a/ui/raidboss/data/04-sb/trial/yojimbo.txt
+++ b/ui/raidboss/data/04-sb/trial/yojimbo.txt
@@ -99,10 +99,10 @@ hideall "--sync--"
 416.6 "Bitter End" Ability { id: "382E", source: "Yojimbo" }
 422.0 "Bitter End" Ability { id: "382E", source: "Yojimbo" }
 
+430.0 "Yukikaze" #Ability { id: "3832", source: "Yojimbo" }
 433.5 "--sync--" Ability { id: "382F", source: "Yojimbo" }
 436.5 "Yukikaze" #Ability { id: "3832", source: "Yojimbo" }
 437.6 "--sync--" Ability { id: "3830", source: "Yojimbo" }
-430.0 "Yukikaze" #Ability { id: "3832", source: "Yojimbo" }
 441.6 "Gekko" Ability { id: "3833", source: "Yojimbo" }
 445.7 "Kasha" Ability { id: "3834", source: "Gilgamesh" }
 445.8 "Dragon's Lair" Ability { id: "3836", source: "Yojimbo" }

--- a/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.txt
+++ b/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.txt
@@ -21,7 +21,7 @@ hideall "--sync--"
 # TODO: presumably 44.2 is a loop back to 24.5.
 
 ### Twintania P2: 75% -> 45%
-47.5 "Liquid Hell x5" duration 4.5 Ability { id: "26AD", source: "Twintania" } window 50,0
+47.5 "Liquid Hell x5" Ability { id: "26AD", source: "Twintania" } duration 4.5 window 50,0
 53.0 "--sync--" StartsUsing { id: "26AE", source: "Twintania" } window 53,10
 56.0 "Generate" Ability { id: "26AE", source: "Twintania" }
 59.1 "Liquid Hell x5" duration 4.5 #Ability { id: "26AD", source: "Twintania" }
@@ -87,19 +87,19 @@ hideall "--sync--"
 278.9 "Chain Lightning x2" Ability { id: "26C8", source: "Thunderwing" }
 281.9 "Fireball (3)" Ability { id: "26C5", source: "Firehorn" }
 
+284.7 "Bahamut's Claw x5" Ability { id: "26B5", source: "Nael deus Darnus" } duration 2.8
 290.4 "Dive + Dynamo/Chariot" duration 8
-284.7 "Bahamut's Claw x5" duration 2.8 Ability { id: "26B5", source: "Nael deus Darnus" }
 #295.3 "Raven Dive" Ability { id: "26BE", source: "Nael deus Darnus" }
 #298.3 "Lunar Dynamo" Ability { id: "26BC", source: "Nael deus Darnus" }
 302.9 "Fireball (4)" Ability { id: "26C5", source: "Firehorn" }
 303.9 "Doom x3" Ability { id: "26C9", source: "Tail of Darkness" }
 305.9 "Chain Lightning x2" Ability { id: "26C8", source: "Thunderwing" }
-306.0 "Wings Of Salvation x3" duration 8 Ability { id: "26CA", source: "Fang of Light" }
+306.0 "Wings Of Salvation x3" Ability { id: "26CA", source: "Fang of Light" } duration 8
 323.3 "Ravensbeak" Ability { id: "26B6", source: "Nael deus Darnus" }
-333.5 "Hypernova x4" duration 6 #Ability { id: "26BF", source: "Nael deus Darnus" }
 
 328.5 "Marker 1"
 332.5 "Marker 2"
+333.5 "Hypernova x4" duration 6 #Ability { id: "26BF", source: "Nael deus Darnus" }
 336.5 "Marker 3"
 339.5 "Cauterize" #Ability { id: "26CD", source: "Thunderwing" }
 #339.5 "Cauterize" #Ability { id: "26CE", source: "Tail of Darkness" }

--- a/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.txt
+++ b/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.txt
@@ -154,7 +154,7 @@ hideall "--sync--"
 ### BLACKFIRE
 572.0 "Blackfire Trio" Ability { id: "26E3", source: "Bahamut Prime" } window 70,10
 574.0 "--untargetable--"
-576.0 "Liquid Hell x5" duration 4.5 #Ability { id: "26AD", source: "Twintania" } 
+576.0 "Liquid Hell x5" duration 4.5 #Ability { id: "26AD", source: "Twintania" }
 579.0 "Thermionic Beam" Ability { id: "26BD", source: "Nael deus Darnus" }
 580.0 "Megaflare Dive" Ability { id: "26E1", source: "Bahamut Prime" }
 586.1 "Hypernova x4" duration 4.5 #Ability { id: "26BF", source: "Nael deus Darnus" }

--- a/ui/raidboss/data/05-shb/alliance/the_copied_factory.txt
+++ b/ui/raidboss/data/05-shb/alliance/the_copied_factory.txt
@@ -292,7 +292,7 @@ hideall "--sync--"
 2614.1 "Crushing Wheel" Ability { id: "474B", source: "Marx [LR]" }
 # guessing here for enrage ???
 2621.8 "Radiate Heat" Ability { id: "474C", source: "Engels" }
-2625.2 "Crushing Wheel Enrage?"  Ability { id: "474B", source: "Marx [LR]" }
+2625.2 "Crushing Wheel Enrage?" Ability { id: "474B", source: "Marx [LR]" }
 
 2700.0 "--targetable--" NameToggle { name: "Engels", toggle: "01" } window 150,0
 2706.2 "--sync--" StartsUsing { id: "4733", source: "Engels" } window 150,5

--- a/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.txt
+++ b/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.txt
@@ -424,7 +424,7 @@ hideall "--sync--"
 6115.8 "Screaming Score" Ability { id: "5BDD", source: "False Idol" }
 
 6128.0 "Darker Note" Ability { id: "5BDB", source: "False Idol" }
-6137.2  "--sync--" Ability { id: "5BD8", source: "False Idol" } # Lighter Note castbar
+6137.2 "--sync--" Ability { id: "5BD8", source: "False Idol" } # Lighter Note castbar
 6146.2 "Lighter Note" Ability { id: "5BD9", source: "False Idol" } duration 6.2
 6159.4 "Made Magic" Ability { id: "5BD[67]", source: "False Idol" }
 6167.6 "Rhythm Rings" Ability { id: "5BD4", source: "False Idol" }
@@ -444,7 +444,7 @@ hideall "--sync--"
 
 # loop ??? (plz confirm)
 6239.6 "Darker Note" Ability { id: "5BDB", source: "False Idol" }
-6248.8  "--sync--" Ability { id: "5BD8", source: "False Idol" } # Lighter Note castbar
+6248.8 "--sync--" Ability { id: "5BD8", source: "False Idol" } # Lighter Note castbar
 6257.8 "Lighter Note" Ability { id: "5BD9", source: "False Idol" } duration 6.2
 
 

--- a/ui/raidboss/data/05-shb/dungeon/amaurot.txt
+++ b/ui/raidboss/data/05-shb/dungeon/amaurot.txt
@@ -42,8 +42,8 @@ hideall "--sync--"
 523.0 "Shrill Shriek" Ability { id: "3CCF", source: "Terminus Bellwether" } window 523,5
 525.0 "--untargetable--"
 525.0 "Adds (N)"
-561.3 "Adds (SW)" AddedCombatant { name: "Terminus Roiler" }  window 60,60
-610.9 "Adds (S)" AddedCombatant { name: "Terminus Pursuer" }  window 100,100
+561.3 "Adds (SW)" AddedCombatant { name: "Terminus Roiler" } window 60,60
+610.9 "Adds (S)" AddedCombatant { name: "Terminus Pursuer" } window 100,100
 800.0 "--sync--" StartsUsing { id: "3CD0", source: "Terminus Bellwether" } window 300,00
 840.0 "Burst" Ability { id: "3CD0", source: "Terminus Bellwether" } window 40,40
 

--- a/ui/raidboss/data/05-shb/dungeon/anamnesis_anyder.txt
+++ b/ui/raidboss/data/05-shb/dungeon/anamnesis_anyder.txt
@@ -47,7 +47,7 @@ hideall "--sync--"
 
 # One add (???)
 # starts 3 second cast 10 seconds after other add dies?
-1310.0 "--sync--"  StartsUsing { id: "4E4B", source: "Unknown" } window 310,0
+1310.0 "--sync--" StartsUsing { id: "4E4B", source: "Unknown" } window 310,0
 1313.0 "Plain Weirdness" Ability { id: "4E4B", source: "Unknown" }
 1319.2 "Inscrutability" Ability { id: "4B73", source: "Unknown" }
 1329.4 "--sync--" Ability { id: "4B77", source: "Unknown" }

--- a/ui/raidboss/data/05-shb/dungeon/matoyas_relict.txt
+++ b/ui/raidboss/data/05-shb/dungeon/matoyas_relict.txt
@@ -84,7 +84,7 @@ hideall "--sync--"
 3086.5 "Minced Meat" Ability { id: "5911", source: "Mother Porxie" } window 50,10
 3093.6 "--untargetable--"
 
-3096.6 "Huff And Puff" StartsUsing { id: "591A", source: "Mother Porxie" } window 96.6,5 duration 33.7
+3096.6 "Huff And Puff" StartsUsing { id: "591A", source: "Mother Porxie" } duration 33.7 window 96.6,5
 3101.6 "Buffet" Ability { id: "5926", source: "Aeolian Cave Sprite" }
 3107.3 "Buffet" Ability { id: "5926", source: "Aeolian Cave Sprite" }
 3112.8 "Buffet" Ability { id: "5926", source: "Aeolian Cave Sprite" }

--- a/ui/raidboss/data/05-shb/dungeon/the_grand_cosmos.txt
+++ b/ui/raidboss/data/05-shb/dungeon/the_grand_cosmos.txt
@@ -38,7 +38,7 @@ hideall "--sync--"
 ### Leannan Sith
 # -ii 4724 471F -p 471B:512
 # The Font of Quintessence will be sealed off
-500.0 "--sync--" SystemLogMessage { id: "7DC", param1: "D30" } window 500,0 
+500.0 "--sync--" SystemLogMessage { id: "7DC", param1: "D30" } window 500,0
 512.0 "Storm Of Color" Ability { id: "471B", source: "Leannan Sith" } window 512,10
 522.3 "Ode To Lost Love" Ability { id: "471C", source: "Leannan Sith" }
 

--- a/ui/raidboss/data/05-shb/eureka/bozjan_southern_front.txt
+++ b/ui/raidboss/data/05-shb/eureka/bozjan_southern_front.txt
@@ -7,9 +7,9 @@ hideall "--sync--"
 # Use zone-unseal and 0x21 Reset lines
 # Trigger set contains 'resetWhenOutOfCombat: false'
 
-0.0 "--Reset--" ActorControl { command: "80000014", data0: "00" } window 100000,100000 jump 0
+0.0 "--Reset--" ActorControl { command: "80000014", data0: "00" } window 0,100000 jump 0
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000,100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 # TODO: fill in CEs
 # The idea with each of them is that you have at most two minutes of standing
@@ -145,10 +145,12 @@ hideall "--sync--"
 # Eaglesight will be sealed off
 # 30000.0 "--sync--" SystemLogMessage { id: "7DC", param1: "DD8" } window 100000,0
 
+#cactbot-timeline-lint-disable-sync-order
 # Fake intro, where you don't know if you're on the top or the bottom.
 # Don't sync because sometimes these bosses are +/- 3 seconds @_@
 20022.2 "Chain Cannon" duration 6.5 #Ability { id: "51F9", source: "4Th Legion Helldiver" }
 20036.9 "Mrv Missile" #Ability { id: "51FD", source: "4Th Legion Helldiver" }
+#cactbot-timeline-lint-enable-sync-order
 
 30022.2 "Chain Cannon" duration 6.5 #Ability { id: "51F9", source: "4Th Legion Helldiver" }
 30036.9 "Mrv Missile" Ability { id: "51FD", source: "4Th Legion Helldiver" } window 50,50

--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae.txt
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae.txt
@@ -49,21 +49,22 @@ hideall "--sync--"
 1159.7 "Verdant Tempest" Ability { id: "5AB6", source: "Trinity Seeker" }
 1168.9 "Verdant Path" # -> baleful / merciful jump
 
+#cactbot-timeline-lint-disable-sync-order
 # (Baleful jump?)
-1168.9 "--sync--" Ability { id: "5A98", source: "Trinity Seeker" } jump 1300 window 80,80
+1168.9 "--sync--" Ability { id: "5A98", source: "Trinity Seeker" } window 80,80 jump 1300
 1176.5 "Baleful Swathe?" #Ability { id: "5AB3", source: "Trinity Seeker" }
 1186.7 "Phantom Edge?" #Ability { id: "5AA0", source: "Trinity Seeker" }
 1188.9 "--sync--" #Ability { id: "5A9A", source: "Trinity Seeker" }
 1198.0 "Baleful Blade?" #Ability { id: "5AA[12]", source: "Trinity Seeker" }
 
 # (Merciful jump?)
-1168.9 "--sync--" Ability { id: "5A97", source: "Trinity Seeker" } jump 1500 window 80,80
+1168.9 "--sync--" Ability { id: "5A97", source: "Trinity Seeker" } window 80,80 jump 1500
 1176.5 "Act Of Mercy?" #Ability { id: "5AB2", source: "Trinity Seeker" }
 1183.7 "First Mercy?" #Ability { id: "5B5D", source: "Trinity Seeker" }
 1186.9 "Second Mercy?" #Ability { id: "5B5E", source: "Trinity Seeker" }
 1190.1 "Third Mercy?" #Ability { id: "5B5F", source: "Trinity Seeker" }
 1193.3 "Fourth Mercy?" #Ability { id: "5B60", source: "Trinity Seeker" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Baleful Air v2 (randomized, with chains)
 1300.0 "Verdant Path" Ability { id: "5A98", source: "Trinity Seeker" }
@@ -77,20 +78,21 @@ hideall "--sync--"
 1361.7 "Verdant Tempest" Ability { id: "5AB6", source: "Trinity Seeker" }
 1370.9 "Verdant Path" # -> iron / merciful jump
 
+#cactbot-timeline-lint-disable-sync-order
 # (Iron jump?)
-1370.9 "--sync--" Ability { id: "5A99", source: "Trinity Seeker" } jump 1700 window 80,80
+1370.9 "--sync--" Ability { id: "5A99", source: "Trinity Seeker" } window 80,80 jump 1700
 1380.5 "Iron Impact?" #Ability { id: "5ADB", source: "Trinity Seeker" }
 1390.5 "Dead Iron?" #Ability { id: "5AAF", source: "Trinity Seeker" }
 1397.7 "Dead Iron?" #Ability { id: "5B44", source: "Trinity Seeker" }
 
 # (Merciful jump?)
-1370.9 "--sync--" Ability { id: "5A97", source: "Trinity Seeker" } jump 1500 window 80,80
+1370.9 "--sync--" Ability { id: "5A97", source: "Trinity Seeker" } window 80,80 jump 1500
 1378.5 "Act Of Mercy?" #Ability { id: "5AB2", source: "Trinity Seeker" }
 1385.7 "First Mercy?" #Ability { id: "5B5D", source: "Trinity Seeker" }
 1388.9 "Second Mercy?" #Ability { id: "5B5E", source: "Trinity Seeker" }
 1392.1 "Third Mercy?" #Ability { id: "5B5F", source: "Trinity Seeker" }
 1395.3 "Fourth Mercy?" #Ability { id: "5B60", source: "Trinity Seeker" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Merciful Air v2 (with seasons of mercy))
 1500.0 "Verdant Path" Ability { id: "5A97", source: "Trinity Seeker" }
@@ -114,19 +116,20 @@ hideall "--sync--"
 1569.1 "Merciful Arc" Ability { id: "5AB7", source: "Trinity Seeker" }
 1576.2 "Verdant Path" # -> baleful / iron jump
 
+#cactbot-timeline-lint-disable-sync-order
 # (Baleful jump?)
-1576.2 "--sync--" Ability { id: "5A98", source: "Trinity Seeker" } jump 1300 window 80,80
+1576.2 "--sync--" Ability { id: "5A98", source: "Trinity Seeker" } window 80,80 jump 1300
 1583.8 "Baleful Swathe?" #Ability { id: "5AB3", source: "Trinity Seeker" }
 1594.0 "Phantom Edge?" #Ability { id: "5AA0", source: "Trinity Seeker" }
 1596.2 "--sync--" #Ability { id: "5A9A", source: "Trinity Seeker" }
 1605.3 "Baleful Blade?" #Ability { id: "5AA[12]", source: "Trinity Seeker" }
 
 # (Iron jump?)
-1576.2 "--sync--" Ability { id: "5A99", source: "Trinity Seeker" } jump 1700 window 80,80
+1576.2 "--sync--" Ability { id: "5A99", source: "Trinity Seeker" } window 80,80 jump 1700
 1585.8 "Iron Impact?" #Ability { id: "5ADB", source: "Trinity Seeker" }
 1595.8 "Dead Iron?" #Ability { id: "5AAF", source: "Trinity Seeker" }
 1603.0 "Dead Iron?" #Ability { id: "5B44", source: "Trinity Seeker" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Iron Air v2 (with iron impact / dead iron)
 1700.0 "Verdant Path" Ability { id: "5A99", source: "Trinity Seeker" }
@@ -140,21 +143,22 @@ hideall "--sync--"
 1758.1 "Verdant Tempest" Ability { id: "5AB6", source: "Trinity Seeker" }
 1767.3 "Verdant Path" # -> baleful / merciful jump
 
+#cactbot-timeline-lint-disable-sync-order
 # (Baleful jump?)
-1767.3 "--sync--" Ability { id: "5A98", source: "Trinity Seeker" } jump 1300 window 80,80
+1767.3 "--sync--" Ability { id: "5A98", source: "Trinity Seeker" } window 80,80 jump 1300
 1774.9 "Baleful Swathe?" #Ability { id: "5AB3", source: "Trinity Seeker" }
 1785.1 "Phantom Edge?" #Ability { id: "5AA0", source: "Trinity Seeker" }
 1787.3 "--sync--" #Ability { id: "5A9A", source: "Trinity Seeker" }
 1796.4 "Baleful Blade?" #Ability { id: "5AA[12]", source: "Trinity Seeker" }
 
 # (Merciful jump?)
-1767.3 "--sync--" Ability { id: "5A97", source: "Trinity Seeker" } jump 1500 window 80,80
+1767.3 "--sync--" Ability { id: "5A97", source: "Trinity Seeker" } window 80,80 jump 1500
 1774.9 "Act Of Mercy?" #Ability { id: "5AB2", source: "Trinity Seeker" }
 1782.1 "First Mercy?" #Ability { id: "5B5D", source: "Trinity Seeker" }
 1785.3 "Second Mercy?" #Ability { id: "5B5E", source: "Trinity Seeker" }
 1788.5 "Third Mercy?" #Ability { id: "5B5F", source: "Trinity Seeker" }
 1791.7 "Fourth Mercy?" #Ability { id: "5B60", source: "Trinity Seeker" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 ### Dahu
 # -p 5755:2023
@@ -226,6 +230,8 @@ hideall "--sync--"
 # We can't have huge syncs on these because many of these are used
 # multiple times.  So, 22 lines get huge syncs and ability lines
 # get more local windows here and in each block.
+
+#cactbot-timeline-lint-disable-sync-order
 3036.8 "--sync--" StartsUsing { id: "5805", source: "Queen's Soldier" } window 50,50 jump 3108.1
 3039.8 "Double Gambit?" #Ability { id: "5805", source: "Queen's Soldier" }
 
@@ -237,6 +243,7 @@ hideall "--sync--"
 
 3036.8 "--sync--" StartsUsing { id: "57F[01]", source: "Queen's Knight" } window 50,50 jump 3708.1
 3039.8 "Shield Omen/Sword Omen?" #Ability { id: "57F[01]", source: "Queen's Knight" }
+#cactbot-timeline-lint-enable-sync-order
 
 # Queen's Soldier
 # (local jumps to other blocks)

--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.txt
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.txt
@@ -9,13 +9,13 @@ hideall "--sync--"
 # boss, as the Stygimoloch Warrior and Dahu areas can be seen from one
 # another, and so a generic "is no longer sealed" from one would stop
 # any timeline running for those in the other.
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 
 ### Slimes (The Barracks, left side)
-1000.0 "--sync--" AddedCombatant { name: "Viscous Clot" }  window 1000,0
-1000.0 "--Reset--" AddedCombatant { name: "Trinity Seeker" }  window 0,1000 jump 0
-1000.0 "Viscous Clot x3" AddedCombatant { name: "Viscous Clot" }  window 1000,0
+1000.0 "--sync--" AddedCombatant { name: "Viscous Clot" } window 1000,0
+1000.0 "--Reset--" AddedCombatant { name: "Trinity Seeker" } window 0,1000 jump 0
+1000.0 "Viscous Clot x3" AddedCombatant { name: "Viscous Clot" } window 1000,0
 1005.3 "Sanguine Clot x4" AddedCombatant { name: "Sanguine Clot" }
 1012.1 "Viscous Clot x3" AddedCombatant { name: "Viscous Clot" }
 1024.1 "Viscous Clot x3" AddedCombatant { name: "Viscous Clot" }
@@ -50,7 +50,7 @@ hideall "--sync--"
 1227.2 "Bozjan Soldier x2" AddedCombatant { name: "Bozjan Soldier" }
 1233.1 "Sanguine Clot x4" AddedCombatant { name: "Sanguine Clot" }
 1277.3 "Bozjan Soldier x2" AddedCombatant { name: "Bozjan Soldier" }
-1297.3 "Grim Reaper Enrage" AddedCombatant { name: "Grim Reaper" }  window 300,10
+1297.3 "Grim Reaper Enrage" AddedCombatant { name: "Grim Reaper" } window 300,10
 1302.3 "Death Scythe" #Ability { id: "5747", source: "Grim Reaper" }
 1305.3 "Death Scythe" #Ability { id: "5747", source: "Grim Reaper" }
 1308.3 "Death Scythe" #Ability { id: "5747", source: "Grim Reaper" }
@@ -77,7 +77,7 @@ hideall "--sync--"
 
 ### Golems (The Granary, right side)
 2000.0 "--sync--" NameToggle { name: "Bicolor Golem", toggle: "01" } window 2000,0
-2000.0 "--Reset--" AddedCombatant { name: "Trinity Seeker" }  window 0,1000 jump 0
+2000.0 "--Reset--" AddedCombatant { name: "Trinity Seeker" } window 0,1000 jump 0
 2025.2 "Core Combustion" Ability { id: "5745", source: "Bicolor Golem" } window 2030,10
 2026.1 "--bleed--" # from blue golem
 2029.9 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
@@ -569,8 +569,8 @@ hideall "--sync--"
 10209.4 "Optimal Offensive" Ability { id: "581[9A]", source: "Queen's Knight" }
 10211.0 "Unlucky Lot" #Ability { id: "581D", source: "Aetherial Sphere" }
 10211.2 "Above Board" Ability { id: "5826", source: "Queen's Warrior" }
-10212.2 "--stunned--" # 3 or 7 second stun
 10211.2 "--sync--" Ability { id: "5B72", source: "Queen's Warrior" }
+10212.2 "--stunned--" # 3 or 7 second stun
 10214.2 "Lots Cast" #Ability { id: "5B6D", source: "Aetherial Burst" }
 #10215.5 "--targetable--" # knight, everybody stunned, so not listed
 10217.2 "Lots Cast" #Ability { id: "5B6C", source: "Aetherial Bolt" }
@@ -817,8 +817,8 @@ hideall "--sync--"
 12568.9 "Weave Miasma" Ability { id: "57B2", source: "Bozjan Phantom" } window 100,100 jump 12165.3
 12575.1 "Summon" #Ability { id: "57BA", source: "Bozjan Phantom" }
 12591.2 "Undying Hatred" #Ability { id: "57C2", source: "Stuffy Wraith" }
-12395.1 "Manipulate Miasma?" #Ability { id: "57B3", source: "Bozjan Phantom" }
-12395.1 "Invert Miasma?" #Ability { id: "59EE", source: "Bozjan Phantom" }
+12595.1 "Manipulate Miasma?" #Ability { id: "57B3", source: "Bozjan Phantom" }
+12595.1 "Invert Miasma?" #Ability { id: "59EE", source: "Bozjan Phantom" }
 
 
 ### Trinity Avowed
@@ -871,6 +871,7 @@ hideall "--sync--"
 14050.9 "--sync--" Ability { id: "5984", source: "Trinity Avowed" }
 14056.0 "Allegiant Arsenal" # -> random jump to initial weapon phase
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Sword v1 (initial)?
 14053.0 "--sync--" StartsUsing { id: "5985", source: "Trinity Avowed" } window 10,10 jump 14100
 14061.2 "Infernal Slash?" #Ability { id: "594A", source: "Trinity Avowed" }
@@ -880,7 +881,7 @@ hideall "--sync--"
 # -> Staff v1 (initial)?
 14053.0 "--sync--" StartsUsing { id: "5987", source: "Trinity Avowed" } window 10,10 jump 15300
 14061.2 "Fury Of Bozja?" #Ability { id: "594C", source: "Trinity Avowed" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Sword v1 (initial)
 14100.0 "--sync--" StartsUsing { id: "5985", source: "Trinity Avowed" }
@@ -895,13 +896,14 @@ hideall "--sync--"
 14160.3 "--sync--" Ability { id: "5982", source: "Trinity Avowed" }
 14167.4 "Glory Of Bozja" Ability { id: "594F", source: "Trinity Avowed" }
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Bow v1 (seen sword)?
 14175.3 "--sync--" StartsUsing { id: "5986", source: "Trinity Avowed" } window 70,10 jump 14900
 14183.5 "Flashvane?" #Ability { id: "594B", source: "Trinity Avowed" }
 # -> Staff v1 (seen sword)?
 14175.3 "--sync--" StartsUsing { id: "5987", source: "Trinity Avowed" } window 70,10 jump 15500
 14183.5 "Fury Of Bozja?" #Ability { id: "594C", source: "Trinity Avowed" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Sword v1 (seen bow)
 14300.0 "--sync--" StartsUsing { id: "5985", source: "Trinity Avowed" }
@@ -928,6 +930,7 @@ hideall "--sync--"
 14433.0 "Glory Of Bozja" Ability { id: "594F", source: "Trinity Avowed" }
 14444.5 "Allegiant Arsenal"
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Sword v2?
 14441.5 "--sync--" StartsUsing { id: "5985", source: "Trinity Avowed" } window 40,10 jump 15900
 14449.7 "Infernal Slash?" #Ability { id: "594A", source: "Trinity Avowed" }
@@ -937,7 +940,7 @@ hideall "--sync--"
 # -> Staff v2?
 14441.5 "--sync--" StartsUsing { id: "5987", source: "Trinity Avowed" } window 40,10 jump 16300
 14449.7 "Fury Of Bozja?" #Ability { id: "594C", source: "Trinity Avowed" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Sword v1 (seen staff)
 14500.0 "--sync--" StartsUsing { id: "5985", source: "Trinity Avowed" }
@@ -967,6 +970,7 @@ hideall "--sync--"
 14653.8 "Glory Of Bozja" Ability { id: "594F", source: "Trinity Avowed" }
 14664.2 "Allegiant Arsenal"
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Sword v2?
 14661.2 "--sync--" StartsUsing { id: "5985", source: "Trinity Avowed" } window 40,10 jump 15900
 14669.4 "Infernal Slash?" #Ability { id: "594A", source: "Trinity Avowed" }
@@ -976,7 +980,7 @@ hideall "--sync--"
 # -> Staff v2?
 14661.2 "--sync--" StartsUsing { id: "5987", source: "Trinity Avowed" } window 40,10 jump 16300
 14669.4 "Fury Of Bozja?" #Ability { id: "594C", source: "Trinity Avowed" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Bow v1 (initial)
 14700.0 "--sync--" StartsUsing { id: "5986", source: "Trinity Avowed" }
@@ -994,13 +998,14 @@ hideall "--sync--"
 14778.5 "Glory Of Bozja" Ability { id: "594F", source: "Trinity Avowed" }
 14788.9 "Allegiant Arsenal"
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Sword v1 (seen bow)?
 14785.9 "--sync--" StartsUsing { id: "5985", source: "Trinity Avowed" } window 70,10 jump 14300
 14794.1 "Infernal Slash?" #Ability { id: "594A", source: "Trinity Avowed" }
 # -> Staff v1 (seen bow)?
 14785.9 "--sync--" StartsUsing { id: "5987", source: "Trinity Avowed" } window 70,10 jump 15700
 14794.1 "Fury Of Bozja?" #Ability { id: "594C", source: "Trinity Avowed" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Bow v1 (seen sword)
 14900.0 "--sync--" StartsUsing { id: "5986", source: "Trinity Avowed" }
@@ -1029,6 +1034,7 @@ hideall "--sync--"
 15043.6 "Glory Of Bozja" Ability { id: "594F", source: "Trinity Avowed" }
 15055.1 "Allegiant Arsenal"
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Sword v2?
 15052.1 "--sync--" StartsUsing { id: "5985", source: "Trinity Avowed" } window 40,10 jump 15900
 15060.3 "Infernal Slash?" #Ability { id: "594A", source: "Trinity Avowed" }
@@ -1038,7 +1044,7 @@ hideall "--sync--"
 # -> Staff v2?
 15052.1 "--sync--" StartsUsing { id: "5987", source: "Trinity Avowed" } window 40,10 jump 16300
 15060.3 "Fury Of Bozja?" #Ability { id: "594C", source: "Trinity Avowed" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Bow v1 (seen staff)
 15100.0 "--sync--" StartsUsing { id: "5986", source: "Trinity Avowed" }
@@ -1067,6 +1073,7 @@ hideall "--sync--"
 15246.2 "--sync--" Ability { id: "5982", source: "Trinity Avowed" }
 15253.3 "Glory Of Bozja" Ability { id: "594F", source: "Trinity Avowed" }
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Sword v2?
 15261.2 "--sync--" StartsUsing { id: "5985", source: "Trinity Avowed" } window 40,10 jump 15900
 15269.4 "Infernal Slash?" #Ability { id: "594A", source: "Trinity Avowed" }
@@ -1076,7 +1083,7 @@ hideall "--sync--"
 # -> Staff v2?
 15261.2 "--sync--" StartsUsing { id: "5987", source: "Trinity Avowed" } window 40,10 jump 16300
 15269.4 "Fury Of Bozja?" #Ability { id: "594C", source: "Trinity Avowed" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Staff v1 (initial)
 15300.0 "--sync--" StartsUsing { id: "5987", source: "Trinity Avowed" }
@@ -1091,13 +1098,14 @@ hideall "--sync--"
 15357.7 "Glory Of Bozja" Ability { id: "594F", source: "Trinity Avowed" }
 15369.2 "Allegiant Arsenal"
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Sword v1 (seen staff)
 15366.2 "--sync--" StartsUsing { id: "5985", source: "Trinity Avowed" } window 70,10 jump 14500
 15374.4 "Infernal Slash?" #Ability { id: "594A", source: "Trinity Avowed" }
 # -> Bow v1 (seen staff)
 15366.2 "--sync--" StartsUsing { id: "5986", source: "Trinity Avowed" } window 70,10 jump 15100
 15374.4 "Flashvane?" #Ability { id: "594B", source: "Trinity Avowed" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Staff v1 (seen sword)
 15500.0 "--sync--" StartsUsing { id: "5987", source: "Trinity Avowed" }
@@ -1126,6 +1134,7 @@ hideall "--sync--"
 15644.7 "Glory Of Bozja" Ability { id: "594F", source: "Trinity Avowed" }
 15655.1 "Allegiant Arsenal"
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Sword v2?
 15652.1 "--sync--" StartsUsing { id: "5985", source: "Trinity Avowed" } window 40,10 jump 15900
 15660.3 "Infernal Slash?" #Ability { id: "594A", source: "Trinity Avowed" }
@@ -1135,7 +1144,7 @@ hideall "--sync--"
 # -> Staff v2?
 15652.1 "--sync--" StartsUsing { id: "5987", source: "Trinity Avowed" } window 40,10 jump 16300
 15660.3 "Fury Of Bozja?" #Ability { id: "594C", source: "Trinity Avowed" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Staff v1 (seen bow)
 15700.0 "--sync--" StartsUsing { id: "5987", source: "Trinity Avowed" }
@@ -1162,6 +1171,7 @@ hideall "--sync--"
 15833.6 "Glory Of Bozja" Ability { id: "594F", source: "Trinity Avowed" }
 15844.5 "Allegiant Arsenal"
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Sword v2?
 15841.5 "--sync--" StartsUsing { id: "5985", source: "Trinity Avowed" } window 40,10 jump 15900
 15849.7 "Infernal Slash?" #Ability { id: "594A", source: "Trinity Avowed" }
@@ -1171,7 +1181,7 @@ hideall "--sync--"
 # -> Staff v2?
 15841.5 "--sync--" StartsUsing { id: "5987", source: "Trinity Avowed" } window 40,10 jump 16300
 15849.7 "Fury Of Bozja?" #Ability { id: "594C", source: "Trinity Avowed" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Sword v2
 15900.0 "--sync--" StartsUsing { id: "5985", source: "Trinity Avowed" }
@@ -1188,13 +1198,14 @@ hideall "--sync--"
 15973.3 "Glory Of Bozja" Ability { id: "594F", source: "Trinity Avowed" }
 15984.6 "Allegiant Arsenal"
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Bow v2?
 15981.6 "--sync--" StartsUsing { id: "5986", source: "Trinity Avowed" } window 70,10 jump 16100
 15989.8 "Flashvane?" #Ability { id: "594B", source: "Trinity Avowed" }
 # -> Staff v2?
 15981.6 "--sync--" StartsUsing { id: "5987", source: "Trinity Avowed" } window 70,10 jump 16300
 15989.8 "Fury Of Bozja?" #Ability { id: "594C", source: "Trinity Avowed" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Bow v2
 16100.0 "--sync--" StartsUsing { id: "5986", source: "Trinity Avowed" }
@@ -1215,13 +1226,14 @@ hideall "--sync--"
 16192.3 "Wrath Of Bozja" Ability { id: "594E", source: "Trinity Avowed" }
 16203.0 "Allegiant Arsenal" Ability { id: "5987", source: "Trinity Avowed" }
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Sword v2?
 16200.0 "--sync--" StartsUsing { id: "5985", source: "Trinity Avowed" } window 70,10 jump 15900
 16208.2 "Infernal Slash?" #Ability { id: "594A", source: "Trinity Avowed" }
 # -> Staff v2?
 16200.0 "--sync--" StartsUsing { id: "5987", source: "Trinity Avowed" } window 70,10 jump 16300
 16208.2 "Fury Of Bozja?" #Ability { id: "594C", source: "Trinity Avowed" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 
 # Staff v2
@@ -1239,13 +1251,14 @@ hideall "--sync--"
 16357.6 "Glory Of Bozja" Ability { id: "594F", source: "Trinity Avowed" }
 16369.4 "Allegiant Arsenal"
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Sword v2?
 16366.4 "--sync--" StartsUsing { id: "5985", source: "Trinity Avowed" } window 70,10 jump 15900
 16374.6 "Infernal Slash?" #Ability { id: "594A", source: "Trinity Avowed" }
 # -> Bow v2?
 16366.4 "--sync--" StartsUsing { id: "5986", source: "Trinity Avowed" } window 70,10 jump 16100
 16374.6 "Flashvane?" #Ability { id: "594B", source: "Trinity Avowed" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Enrage
 # This happens ~10 seconds after when the allegiant arsenal would have cast.
@@ -1428,7 +1441,6 @@ hideall "--sync--"
 20194.7 "--sync--" Ability { id: "5BCB", source: "The Queen" }
 20198.1 "--sync--" Ability { id: "55A8", source: "The Queen" }
 20203.1 "Unlucky Lot x5" duration 8 #Ability { id: "55B6", source: "Ball Lightning" }
-20198.1 "--sync--" Ability { id: "55A8", source: "The Queen" }
 20210.0 "Maelstrom's Bolt" Ability { id: "59EF", source: "The Queen" }
 
 20224.2 "Relentless Play 1" Ability { id: "59FC", source: "The Queen" } window 20,20

--- a/ui/raidboss/data/05-shb/eureka/zadnor.txt
+++ b/ui/raidboss/data/05-shb/eureka/zadnor.txt
@@ -7,9 +7,9 @@ hideall "--sync--"
 # Use zone-unseal and 0x21 Reset lines
 # Trigger set contains 'resetWhenOutOfCombat: false'
 
-0.0 "--Reset--" ActorControl { command: "80000014", data0: "00" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "80000014", data0: "00" } window 0,100000 jump 0
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 # TODO: fill in CEs
 # The idea with each of them is that you have at most two minutes of standing
@@ -157,7 +157,7 @@ hideall "--sync--"
 # ???
 
 # Tamed Alkonost / Tamed Carrion Crow
-22500.0 "--sync--" AddedCombatant { name: "Tamed Carrion Crow" }  window 600,0
+22500.0 "--sync--" AddedCombatant { name: "Tamed Carrion Crow" } window 600,0
 22507.0 "--sync--" StartsUsing { id: "5F26", source: "Tamed Alkonost" } window 600,10
 22512.0 "Stormcall" Ability { id: "5F26", source: "Tamed Alkonost" }
 22526.9 "Orb 1" Ability { id: "5F27", source: "Vortical Orb" }

--- a/ui/raidboss/data/05-shb/raid/e11s.txt
+++ b/ui/raidboss/data/05-shb/raid/e11s.txt
@@ -34,7 +34,7 @@ hideall "--sync--"
 # Time these to burnout where it's random, and comment out the sync.
 # If testing were smarter we could have an optional sync here, otherwise test_timeline.py will be weird.
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 # Phase 1
 0 "Start"

--- a/ui/raidboss/data/05-shb/raid/e1s.txt
+++ b/ui/raidboss/data/05-shb/raid/e1s.txt
@@ -87,4 +87,4 @@ hideall "--sync--"
 
 
 ### Enrage
-900.0 "Fragor Maximus (Enrage)" StartsUsing { id: "45E4", source: "Eden Prime" } window 500,0 duration 10.0
+900.0 "Fragor Maximus (Enrage)" StartsUsing { id: "45E4", source: "Eden Prime" } duration 10.0 window 500,0

--- a/ui/raidboss/data/05-shb/raid/e3n.txt
+++ b/ui/raidboss/data/05-shb/raid/e3n.txt
@@ -31,7 +31,7 @@ hideall "--sync--"
 192.8 "Surging Tsunami" Ability { id: "4011", source: "Leviathan" }
 203.5 "Tidal Roar" Ability { id: "3FC4", source: "Leviathan" } window 20,20
 
-216.7 "Maelstrom" Ability { id: "3FD8", source: "Leviathan" } window 216.7,2.5 duration 30
+216.7 "Maelstrom" Ability { id: "3FD8", source: "Leviathan" } duration 30 window 216.7,2.5
 218.7 "--untargetable--"
 222.0 "--sync--" Ability { id: "3F7E", source: "Leviathan" }
 226.9 "Spinning Dive 1" Ability { id: "3FDB", source: "Leviathan" }

--- a/ui/raidboss/data/05-shb/raid/e4s.txt
+++ b/ui/raidboss/data/05-shb/raid/e4s.txt
@@ -100,8 +100,8 @@ hideall "Earthen Wheels"
 1201.4 "Earthen Anguish" Ability { id: "4137", source: "Titan" }
 1208.3 "Earthen Fist" Ability { id: ["4130", "4131", "4132", "412F"], source: "Titan Maximum" }
 1225.7 "Tectonic Uplift" Ability { id: "4122", source: "Titan Maximum" }
-1249.0 "Pulse of the Land" Ability { id: "4106", source: "Titan" }
 1226.6 "Force of the Land" Ability { id: "4107", source: "Titan" }
+1249.0 "Pulse of the Land" Ability { id: "4106", source: "Titan" }
 1263.2 "Weight of the World" Ability { id: "442B", source: "Titan Maximum" }
 1275.1 "Force of the Land" Ability { id: "4107", source: "Titan" }
 1283.4 "Earthen Fury" Ability { id: "4124", source: "Titan Maximum" }

--- a/ui/raidboss/data/05-shb/raid/e5s.txt
+++ b/ui/raidboss/data/05-shb/raid/e5s.txt
@@ -83,8 +83,8 @@ hideall "--sync--"
 450.4 "Judgment Volts" Ability { id: "4BB5", source: "Ramuh" }
 460.5 "Stormcloud Summons" Ability { id: "4BB8", source: "Ramuh" }
 465.6 "Chaos Strike" Ability { id: "4BBB", source: "Ramuh" }
-470.7 "Lightning Bolt" duration 24.5 # Ability { id: "4BB9", source: "Stormcloud" }
 470.0 "--sync--" Ability { id: "4BCB", source: "Ramuh" }
+470.7 "Lightning Bolt" duration 24.5 # Ability { id: "4BB9", source: "Stormcloud" }
 477.0 "Levinforce" Ability { id: "4BCC", source: "Ramuh" }
 487.4 "Judgment Volts" Ability { id: "4BB5", source: "Ramuh" }
 502.6 "Chain Lightning" Ability { id: "4BC4", source: "Ramuh" }

--- a/ui/raidboss/data/05-shb/trial/emerald_weapon-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/emerald_weapon-ex.txt
@@ -32,7 +32,7 @@ hideall "--sync--"
 
 
 ### Cutscene
-800.0 "--cutscene--" Ability { id: "5B02", source: "The Emerald Weapon" } window 800,0 duration 58.5
+800.0 "--cutscene--" Ability { id: "5B02", source: "The Emerald Weapon" } duration 58.5 window 800,0
 858.5 "--targetable--"
 
 

--- a/ui/raidboss/data/05-shb/trial/innocence-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/innocence-ex.txt
@@ -74,7 +74,7 @@ hideall "Soul And Body"
 441.3 "--sync--" Ability { id: "3EA2", source: "Innocence" }
 445.4 "Rightful Reprobation" Ability { id: "3EDC", source: "Innocence" }
 452.3 "Reprobation" Ability { id: "3ECC", source: "Innocence" }
-452.9 "God Ray x3" Ability { id: "3EE6", source: "Innocence" } window 5,1 duration 10
+452.9 "God Ray x3" Ability { id: "3EE6", source: "Innocence" } duration 10 window 5,1
 469.9 "Shadowreaver" Ability { id: "3EEA", source: "Innocence" }
 480.9 "Righteous Bolt" Ability { id: "3ECD", source: "Innocence" }
 
@@ -117,7 +117,7 @@ hideall "Soul And Body"
 675.2 "--sync--" Ability { id: "3EA2", source: "Innocence" }
 679.4 "Rightful Reprobation" Ability { id: "3EDC", source: "Innocence" }
 686.3 "Reprobation" Ability { id: "3ECC", source: "Innocence" }
-686.9 "God Ray x3" Ability { id: "3EE6", source: "Innocence" } window 5,1 duration 10
+686.9 "God Ray x3" Ability { id: "3EE6", source: "Innocence" } duration 10 window 5,1
 703.9 "Shadowreaver" Ability { id: "3EEA", source: "Innocence" }
 714.9 "Righteous Bolt" Ability { id: "3ECD", source: "Innocence" }
 
@@ -126,9 +126,9 @@ hideall "Soul And Body"
 734.9 "Holy Trinity" #Ability { id: "3EDB", source: "Innocence" }
 739.4 "Holy Trinity" #Ability { id: "3EDB", source: "Innocence" }
 740.4 "--sync--" Ability { id: "3EA2", source: "Innocence" }
+741.7 "--sync--" StartsUsing { id: "3EEF", source: "Innocence" } window 10,10
 743.9 "Holy Trinity" #Ability { id: "3EDB", source: "Innocence" }
 
-741.7 "--sync--" StartsUsing { id: "3EEF", source: "Innocence" } window 10,10
 744.7 "Starbirth Final" Ability { id: "3EEF", source: "Innocence" }
 764.7 "Beatific Vision" Ability { id: "3EF1", source: "Innocence" }
 765.6 "Explosion Enrage" Ability { id: "3EF0", source: "Innocence" }

--- a/ui/raidboss/data/05-shb/trial/ruby_weapon-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/ruby_weapon-ex.txt
@@ -86,7 +86,7 @@ hideall "--sync--"
 455.2 "Enrage" Ability { id: "4B2D", source: "The Ruby Weapon" }
 
 ### Cutscene
-800.0 "--cutscene--" Ability { id: "4E1C", source: "The Ruby Weapon" } window 800,0 duration 65.5
+800.0 "--cutscene--" Ability { id: "4E1C", source: "The Ruby Weapon" } duration 65.5 window 800,0
 865.5 "--targetable--"
 
 ### Phase 2

--- a/ui/raidboss/data/05-shb/trial/ruby_weapon.txt
+++ b/ui/raidboss/data/05-shb/trial/ruby_weapon.txt
@@ -61,7 +61,7 @@ hideall "--sync--"
 
 ### Cutscene
 # FIXME: this duration differs from the extreme version??? is that true??
-500.0 "--cutscene--" Ability { id: "4E1C", source: "The Ruby Weapon" } window 500,0 duration 61.5
+500.0 "--cutscene--" Ability { id: "4E1C", source: "The Ruby Weapon" } duration 61.5 window 500,0
 561.5 "--targetable--"
 
 ### Phase 2

--- a/ui/raidboss/data/05-shb/trial/shiva-un.txt
+++ b/ui/raidboss/data/05-shb/trial/shiva-un.txt
@@ -128,7 +128,7 @@ hideall "--Reset--"
 801.0 "--sync--" #Ability { id: "53AE", source: "Shiva" }
 # If you push *really* fast and skip a 3a/3b weapon phase, you'll miss the melt jump.
 # So, fix that up with a combatant sync here.
-806.6 "--adds targetable--" AddedCombatant { name: "Ice Soldier" }  window 807,10
+806.6 "--adds targetable--" AddedCombatant { name: "Ice Soldier" } window 807,10
 807.6 "Dreams Of Ice" Ability { id: "536A", source: "Shiva" }
 813.2 "Frost Blade" Ability { id: "5366", source: "Shiva" }
 818.5 "Icebrand" Ability { id: "5373", source: "Shiva" }

--- a/ui/raidboss/data/05-shb/trial/varis-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/varis-ex.txt
@@ -5,7 +5,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 ### Phase 1
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
@@ -53,6 +53,7 @@ hideall "--sync--"
 274.3 "--sync--" StartsUsing { id: "4CD9", source: "Varis Yae Galvus" } window 100,100 jump 700
 274.3 "--sync--" StartsUsing { id: "4CD7", source: "Varis Yae Galvus" } window 100,100 jump 900
 
+#cactbot-timeline-lint-disable-sync-order
 # loaded lookahead window
 279.3 "Loaded Gunshield?" #Ability { id: "4CD8", source: "Varis Yae Galvus" }
 288.2 "--sync--" #Ability { id: "4CB5", source: "Varis Yae Galvus" }
@@ -85,7 +86,7 @@ hideall "--sync--"
 318.4 "--sync--" #Ability { id: "4CD4", source: "Varis Yae Galvus" }
 318.8 "--sync--" #Ability { id: "4CD5", source: "Varis Yae Galvus" }
 321.5 "--sync--" #Ability { id: "4CD6", source: "Varis Yae Galvus" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 ## Phase 3: Loaded Gunshield, Spread
 500.0 "--sync--" StartsUsing { id: "4CD8", source: "Varis Yae Galvus" }
@@ -102,6 +103,7 @@ hideall "--sync--"
 554.3 "--sync--" StartsUsing { id: "4CD9", source: "Varis Yae Galvus" } window 10,10 jump 700
 554.3 "--sync--" StartsUsing { id: "4CD7", source: "Varis Yae Galvus" } window 10,10 jump 900
 
+#cactbot-timeline-lint-disable-sync-order
 # reinforced lookahead window
 559.3 "Reinforced Gunshield?" #Ability { id: "4CD9", source: "Varis Yae Galvus" }
 568.4 "Altius?" #Ability { id: "4CCA", source: "Varis Yae Galvus" }
@@ -123,7 +125,7 @@ hideall "--sync--"
 598.4 "--sync--" #Ability { id: "4CD4", source: "Varis Yae Galvus" }
 598.8 "--sync--" #Ability { id: "4CD5", source: "Varis Yae Galvus" }
 601.5 "--sync--" #Ability { id: "4CD6", source: "Varis Yae Galvus" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 
 ## Phase 3: Reinforced Gunshield, Block
@@ -139,6 +141,7 @@ hideall "--sync--"
 752.8 "--sync--" StartsUsing { id: "4CD8", source: "Varis Yae Galvus" } window 10,10 jump 500
 752.8 "--sync--" StartsUsing { id: "4CD7", source: "Varis Yae Galvus" } window 10,10 jump 900
 
+#cactbot-timeline-lint-disable-sync-order
 # loaded lookahead window
 757.8 "Loaded Gunshield?" #Ability { id: "4CD8", source: "Varis Yae Galvus" }
 766.7 "--sync--" #Ability { id: "4CB5", source: "Varis Yae Galvus" }
@@ -162,7 +165,7 @@ hideall "--sync--"
 796.9 "--sync--" #Ability { id: "4CD4", source: "Varis Yae Galvus" }
 797.3 "--sync--" #Ability { id: "4CD5", source: "Varis Yae Galvus" }
 800.0 "--sync--" #Ability { id: "4CD6", source: "Varis Yae Galvus" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 
 ## Phase 3: Electrified Gunshield, Knockback
@@ -182,6 +185,7 @@ hideall "--sync--"
 958.7 "--sync--" StartsUsing { id: "4CD8", source: "Varis Yae Galvus" } window 10,10 jump 500
 958.7 "--sync--" StartsUsing { id: "4CD9", source: "Varis Yae Galvus" } window 10,10 jump 700
 
+#cactbot-timeline-lint-disable-sync-order
 # loaded lookahead window
 963.7 "Loaded Gunshield?" #Ability { id: "4CD8", source: "Varis Yae Galvus" }
 972.6 "--sync--" #Ability { id: "4CB5", source: "Varis Yae Galvus" }
@@ -201,7 +205,7 @@ hideall "--sync--"
 985.0 "Magitek Shielding" #Ability { id: "4CDB", source: "Varis Yae Galvus" }
 989.8 "Ventus Est" #Ability { id: "4CC7", source: "Ventus Est" }
 1000.2 "Citius" #Ability { id: "4CF0", source: "Varis Yae Galvus" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 ### Phase 4: Stack Spread Shield
 1200.0 "--untargetable--"

--- a/ui/raidboss/data/05-shb/trial/wol-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/wol-ex.txt
@@ -99,6 +99,7 @@ hideall "Limit Break"
 513.1 "--targetable--"
 517.3 "--middle--" Ability { id: "4F45", source: "Warrior Of Light" }
 
+#cactbot-timeline-lint-disable-sync-order
 # BLM/WHM
 519.6 "--sync--" StartsUsing { id: "4F73", source: "Warrior Of Light" } window 5,5 jump 1519.5
 522.6 "Specter -> BLM/WHM" #Ability { id: "4F73", source: "Warrior Of Light" }
@@ -116,7 +117,7 @@ hideall "Limit Break"
 # SMN/WAR
 519.6 "--sync--" StartsUsing { id: "4EF[34]", source: "Warrior Of Light" } window 40,40 jump 4519.7
 522.6 "Fire/Ice -> SMN/WAR" #Ability { id: "4EF[34]", source: "Warrior Of Light" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 ### Phase 3a: BLM/WHM
 1517.3 "--middle--" Ability { id: "4F45", source: "Warrior Of Light" }
@@ -155,6 +156,7 @@ hideall "Limit Break"
 1651.4 "Elddragon Dive" Ability { id: "4F0B", source: "Warrior Of Light" }
 1661.7 "--middle--" Ability { id: "4F45", source: "Warrior Of Light" }
 
+#cactbot-timeline-lint-disable-sync-order
 # DRK/BRD
 1664.0 "--sync--" StartsUsing { id: "4F3[456]", source: "Warrior Of Light" } window 5,5 jump 7002.2
 1667.0 "Limit -> DRK/BRD" #Ability { id: "4F3[456]", source: "Warrior Of Light" }
@@ -167,7 +169,7 @@ hideall "Limit Break"
 # SMN/WAR
 1664.0 "--sync--" StartsUsing { id: "4EF[34]", source: "Warrior Of Light" } window 40,40 jump 9002.3
 1667.0 "Fire/Ice -> SMN/WAR" #Ability { id: "4EF[34]", source: "Warrior Of Light" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 
 ### Phase 3a: DRK/BRD
@@ -200,6 +202,7 @@ hideall "Limit Break"
 2642.4 "Elddragon Dive" Ability { id: "4F0B", source: "Warrior Of Light" }
 2652.7 "--middle--" Ability { id: "4F45", source: "Warrior Of Light" }
 
+#cactbot-timeline-lint-disable-sync-order
 # BLM/WHM
 2655.0 "--sync--" StartsUsing { id: "4F73", source: "Warrior Of Light" } window 5,5 jump 6002.4
 2658.0 "Specter -> BLM/WHM" #Ability { id: "4F73", source: "Warrior Of Light" }
@@ -212,7 +215,7 @@ hideall "Limit Break"
 # SMN/WAR
 2655.0 "--sync--" StartsUsing { id: "4EF[34]", source: "Warrior Of Light" } window 40,40 jump 9002.3
 2658.0 "Fire/Ice -> SMN/WAR" #Ability { id: "4EF[34]", source: "Warrior Of Light" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 
 ### Phase 3a: NIN
@@ -242,6 +245,7 @@ hideall "Limit Break"
 3642.3 "Elddragon Dive" Ability { id: "4F0B", source: "Warrior Of Light" }
 3652.6 "--middle--" Ability { id: "4F45", source: "Warrior Of Light" }
 
+#cactbot-timeline-lint-disable-sync-order
 # BLM/WHM
 3654.9 "--sync--" StartsUsing { id: "4F73", source: "Warrior Of Light" } window 5,5 jump 6002.4
 3657.9 "Specter -> BLM/WHM" #Ability { id: "4F73", source: "Warrior Of Light" }
@@ -255,7 +259,7 @@ hideall "Limit Break"
 # SMN/WAR
 3654.9 "--sync--" StartsUsing { id: "4EF[34]", source: "Warrior Of Light" } window 40,40 jump 9002.3
 3657.9 "Fire/Ice -> SMN/WAR" #Ability { id: "4EF[34]", source: "Warrior Of Light" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 ### Phase 3a: SMN/WAR
 4517.4 "--middle--" Ability { id: "4F45", source: "Warrior Of Light" }
@@ -289,6 +293,7 @@ hideall "Limit Break"
 4660.9 "Elddragon Dive" Ability { id: "4F0B", source: "Warrior Of Light" }
 4671.2 "--middle--" Ability { id: "4F45", source: "Warrior Of Light" }
 
+#cactbot-timeline-lint-disable-sync-order
 # BLM/WHM
 4673.5 "--sync--" StartsUsing { id: "4F73", source: "Warrior Of Light" } window 5,5 jump 6002.4
 4676.5 "Specter -> BLM/WHM" #Ability { id: "4F73", source: "Warrior Of Light" }
@@ -302,7 +307,7 @@ hideall "Limit Break"
 # NIN
 4673.5 "--sync--" StartsUsing { id: "4EF[56]", source: "Warrior Of Light" } window 40,40 jump 8002.3
 4676.5 "Stone/Holy -> NIN" #Ability { id: "4EF[56]", source: "Warrior Of Light" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 
 ### Phase 3b: BLM/WHM
@@ -331,6 +336,7 @@ hideall "Limit Break"
 6080.9 "The Bitter End" Ability { id: "4F0A", source: "Warrior Of Light" }
 6084.1 "--middle--" Ability { id: "4F45", source: "Warrior Of Light" }
 
+#cactbot-timeline-lint-disable-sync-order
 # DRK/BRD
 6086.4 "--sync--" StartsUsing { id: "4F3[456]", source: "Warrior Of Light" } window 5,5 jump 7002.2
 6089.4 "Limit -> DRK/BRD" #Ability { id: "4F3[456]", source: "Warrior Of Light" }
@@ -343,6 +349,7 @@ hideall "Limit Break"
 # SMN/WAR
 6086.4 "--sync--" StartsUsing { id: "4EF[34]", source: "Warrior Of Light" } window 40,40 jump 9002.3
 6089.4 "Fire/Ice -> SMN/WAR" #Ability { id: "4EF[34]", source: "Warrior Of Light" }
+#cactbot-timeline-lint-enable-sync-order
 
 
 ### Phase 3b: DRK/BRD
@@ -366,6 +373,7 @@ hideall "Limit Break"
 7071.8 "The Bitter End" Ability { id: "4F0A", source: "Warrior Of Light" }
 7079.1 "--middle--" Ability { id: "4F45", source: "Warrior Of Light" }
 
+#cactbot-timeline-lint-disable-sync-order
 # BLM/WHM
 7081.4 "--sync--" StartsUsing { id: "4F73", source: "Warrior Of Light" } window 5,5 jump 6002.4
 7084.4 "Specter -> BLM/WHM" #Ability { id: "4F73", source: "Warrior Of Light" }
@@ -378,7 +386,7 @@ hideall "Limit Break"
 # SMN/WAR
 7081.4 "--sync--" StartsUsing { id: "4EF[34]", source: "Warrior Of Light" } window 40,40 jump 9002.3
 7084.4 "Fire/Ice -> SMN/WAR" #Ability { id: "4EF[34]", source: "Warrior Of Light" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 ### Phase 3b: NIN
 8000.0 "--middle--" Ability { id: "4F45", source: "Warrior Of Light" }
@@ -397,6 +405,7 @@ hideall "Limit Break"
 8071.5 "The Bitter End" Ability { id: "4F0A", source: "Warrior Of Light" }
 8074.7 "--middle--" Ability { id: "4F45", source: "Warrior Of Light" }
 
+#cactbot-timeline-lint-disable-sync-order
 # BLM/WHM
 8077.0 "--sync--" StartsUsing { id: "4F73", source: "Warrior Of Light" } window 5,5 jump 6002.4
 8080.0 "Specter -> BLM/WHM" #Ability { id: "4F73", source: "Warrior Of Light" }
@@ -410,6 +419,7 @@ hideall "Limit Break"
 # SMN/WAR
 8077.0 "--sync--" StartsUsing { id: "4EF[34]", source: "Warrior Of Light" } window 40,40 jump 9002.3
 8080.0 "Fire/Ice -> SMN/WAR" #Ability { id: "4EF[34]", source: "Warrior Of Light" }
+#cactbot-timeline-lint-enable-sync-order
 
 
 ### Phase 3b: SMN/WAR
@@ -434,6 +444,7 @@ hideall "Limit Break"
 9090.2 "The Bitter End" Ability { id: "4F0A", source: "Warrior Of Light" }
 9093.4 "--middle--" Ability { id: "4F45", source: "Warrior Of Light" }
 
+#cactbot-timeline-lint-disable-sync-order
 # BLM/WHM
 9095.7 "--sync--" StartsUsing { id: "4F73", source: "Warrior Of Light" } window 5,5 jump 6002.4
 9098.7 "Specter -> BLM/WHM" #Ability { id: "4F73", source: "Warrior Of Light" }
@@ -447,3 +458,4 @@ hideall "Limit Break"
 # NIN
 9095.7 "--sync--" StartsUsing { id: "4EF[56]", source: "Warrior Of Light" } window 40,40 jump 8002.3
 9098.7 "Stone/Holy -> NIN" #Ability { id: "4EF[56]", source: "Warrior Of Light" }
+#cactbot-timeline-lint-enable-sync-order

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
@@ -105,8 +105,8 @@ hideall "--sync--"
 505.1 "Alpha Sword" #Ability { id: "486B", source: "Cruise Chaser" }
 505.2 "Flarethrower 1" #Ability { id: "486C", source: "Brute Justice" }
 506.1 "Alpha Sword" #Ability { id: "486B", source: "Cruise Chaser" }
-507.4 "Flarethrower 2" #Ability { id: "486C", source: "Brute Justice" }
 507.2 "Alpha Sword" #Ability { id: "486B", source: "Cruise Chaser" }
+507.4 "Flarethrower 2" #Ability { id: "486C", source: "Brute Justice" }
 511.4 "--targetable--"
 521.5 "Chastening Heat" Ability { id: "4A80", source: "Alexander Prime" }
 524.6 "Divine Spear 1" #Ability { id: "4A82", source: "Alexander Prime" }
@@ -165,8 +165,8 @@ hideall "--sync--"
 ### Transition 3: DPS Checks
 699.4 "Summon Alexander" Ability { id: "4A55", source: "Alexander Prime" }
 705.6 "--alex untargetable--"
-706.8 "--adds targetable--"
 705.7 "J Storm + Waves x16" Ability { id: "4876", source: "Brute Justice" } duration 50
+706.8 "--adds targetable--"
 731.7 "Eternal Darkness Enrage" Ability { id: "4875", source: "Cruise Chaser" }
 771.9 "Divine Judgment Enrage" Ability { id: "4879", source: "Alexander Prime" } window 67,5
 787.3 "Divine Judgment" Ability { id: "487A", source: "Alexander" }

--- a/ui/raidboss/data/06-ew/alliance/aglaia.txt
+++ b/ui/raidboss/data/06-ew/alliance/aglaia.txt
@@ -5,7 +5,7 @@ hideall "--sync--"
 hideall "Fan Flames"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~~#
 # BYREGOT #
@@ -32,8 +32,8 @@ hideall "Fan Flames"
 1062.9 "The Builder's Forge" Ability { id: "716A", source: "Byregot" }
 1069.4 "--sync--" Ability { id: "7174", source: "Byregot" }
 1083.3 "Peal of the Hammer" Ability { id: "716F", source: "Byregot" }
-1110.1 "--hammer--"
 1108.3 "--sync--" Ability { id: "7171", source: "Byregot" }
+1110.1 "--hammer--"
 1110.4 "Peal of the Hammer" Ability { id: "716F", source: "Byregot" }
 1127.2 "--hammer--"
 1127.6 "Levinforge" Ability { id: "7172", source: "Byregot" }
@@ -252,11 +252,11 @@ hideall "Fan Flames"
 4804.0 "Spinning Slash" Ability { id: "72C1", source: "Lioness of Aglaia" }
 4815.5 "Roaring Blaze" Ability { id: "72BF", source: "Lioness of Aglaia" }
 
-4526.9 "Spinning Slash" #Ability { id: "72C1", source: "Lioness of Aglaia" }
-4538.4 "Roaring Blaze" #Ability { id: "72BF", source: "Lioness of Aglaia" }
+4826.9 "Spinning Slash" #Ability { id: "72C1", source: "Lioness of Aglaia" }
+4838.4 "Roaring Blaze" #Ability { id: "72BF", source: "Lioness of Aglaia" }
 
-4549.8 "Spinning Slash" #Ability { id: "72C1", source: "Lioness of Aglaia" }
-4561.3 "Roaring Blaze" #Ability { id: "72BF", source: "Lioness of Aglaia" }
+4849.8 "Spinning Slash" #Ability { id: "72C1", source: "Lioness of Aglaia" }
+4861.3 "Roaring Blaze" #Ability { id: "72BF", source: "Lioness of Aglaia" }
 
 
 #~~~~~~~~#
@@ -408,10 +408,8 @@ hideall "Fan Flames"
 
 6095.8 "Far Above, Deep Below" Ability { id: "73A[AB]", source: "Nald'thal" }
 6096.7 "Far-flung Fire?" Ability { id: "73AD", source: "Nald" }
+6102.0 "--sync--" StartsUsing { id: "70E[89]", source: "Nald'thal" } window 10,10 # Possible ~1s delay here
 6102.1 "Deepest Pit?" Ability { id: "73C7", source: "Thal" } duration 4
-
-# Possible ~1s delay here
-6102.0 "--sync--" StartsUsing { id: "70E[89]", source: "Nald'thal" } window 10,10
 6107.0 "As Above, So Below" Ability { id: "70E[89]", source: "Nald'thal" }
 6121.2 "Once Above, Ever Below" Ability { id: ["73BF", "73C0", "741C", "741D"], source: "Nald'thal" }
 
@@ -480,6 +478,7 @@ hideall "Fan Flames"
 # * Wayward Soul -> Fired Up -> Wayward Soul -> Fired Up -> ?
 #   https://www.fflogs.com/reports/cxqYG1L3mFMrpZdQ#fight=last
 
+#cactbot-timeline-lint-disable-sync-order
 # -> initial Wayward Soul block
 7156.0 "--sync--" Ability { id: "710D", source: "Nald'thal" } window 100,100 jump 7998.3
 7161.1 "Wayward Soul?" #Ability { id: "710E", source: "Nald'thal" }
@@ -489,7 +488,7 @@ hideall "Fan Flames"
 7163.5 "Fired Up I?" #Ability { id: "7112", source: "Nald'thal" }
 7169.6 "Fired Up II?" #Ability { id: "7389", source: "Nald'thal" }
 7175.7 "Fired Up III?" #Ability { id: "7419", source: "Nald'thal" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Initial Wayward Soul block, fall into Main loop block
 # This has slightly different timings here (+5/-5 on some abilities) than the loop.

--- a/ui/raidboss/data/06-ew/alliance/euphrosyne.txt
+++ b/ui/raidboss/data/06-ew/alliance/euphrosyne.txt
@@ -5,7 +5,7 @@ hideall "--sync--"
 hideall "Season's Passing"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~~#
 # NOPHICA #
@@ -300,7 +300,7 @@ hideall "Season's Passing"
 3731.1 "Rain of Spears" Ability { id: "7D79", source: "Halone" }
 
 # loop
-3742.2 "--middle--" Ability { id: "7D7C", source: "Halone" } jump 3578.1 window 50,50
+3742.2 "--middle--" Ability { id: "7D7C", source: "Halone" } window 50,50 jump 3578.1
 3756.6 "--sync--" #Ability { id: "7D59", source: "Halone" }
 3756.8 "Tetrapagos 1" #Ability { id: "7D4[ABCD]", source: "Halone" }
 3758.8 "Tetrapagos 2" #Ability { id: "7D4[ABCD]", source: "Halone" }

--- a/ui/raidboss/data/06-ew/alliance/thaleia.txt
+++ b/ui/raidboss/data/06-ew/alliance/thaleia.txt
@@ -4,7 +4,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~~#
 # Thaliak #
@@ -621,6 +621,7 @@ hideall "--sync--"
 # as only some of them have Destructive Bolt stacks attached to them (although
 # it doesn't execute if it is the final mechanic prior to jumping back to Quintessence).
 # This is probably Good Enough (TM).
+#cactbot-timeline-lint-disable-sync-order
 4400.0 "--sync--" StartsUsing { id: "8A3B", source: "Eulogia" } window 0,10000 jump "Solar Fans"
 4400.0 "--sync--" StartsUsing { id: "8A4B", source: "Eulogia" } window 0,10000 jump "Matron's Breath"
 4400.0 "--sync--" StartsUsing { id: ["8A5B", "8A5C"], source: "Eulogia" } window 0,10000 jump "As Above, So Below"
@@ -630,6 +631,7 @@ hideall "--sync--"
 4400.0 "--sync--" StartsUsing { id: "8A37", source: "Eulogia" } window 0,10000 jump "Hydrostasis"
 4400.0 "--sync--" StartsUsing { id: "8A52", source: "Eulogia" } window 0,10000 jump "Byregot's Strike"
 4400.0 "--sync--" Ability { id: "8A08", source: "Eulogia" } window 0,10000 jump "Quintessence"
+#cactbot-timeline-lint-enable-sync-order
 
 5000.0 label "Solar Fans"
 5000.0 "--sync--" StartsUsing { id: "8A3B", source: "Eulogia" }
@@ -656,7 +658,7 @@ hideall "--sync--"
 5237.6 "Destructive Bolt" Ability { id: "8CEC", source: "Eulogia" }
 
 5300.0 label "Torrential Tridents"
-5297.8 "--middle--" Ability { id: "8A02", source: "Eulogia" }
+#5297.8 "--middle--" Ability { id: "8A02", source: "Eulogia" } # unreachable - info only
 5300.0 "--sync--" StartsUsing { id: "8A4E", source: "Eulogia" }
 5302.0 "Torrential Tridents" Ability { id: "8A4E", source: "Eulogia" }
 5302.9 "Landing 1" #Ability { id: "8A4F", source: "Trident" }
@@ -682,7 +684,7 @@ hideall "--sync--"
 5429.2 "First Blush 4" Ability { id: "8A36", source: "Eulogia" }
 
 5500.0 label "Hieroglyphika"
-5497.7 "--middle--" Ability { id: "8A02", source: "Eulogia" }
+#5497.7 "--middle--" Ability { id: "8A02", source: "Eulogia" }  # unreachable - info only
 5500.0 "--sync--" StartsUsing { id: "8A43", source: "Eulogia" }
 5505.0 "Hieroglyphika" Ability { id: "8A43", source: "Eulogia" }
 5522.1 "--sync--" Ability { id: "8A44", source: "Eulogia" }
@@ -690,7 +692,7 @@ hideall "--sync--"
 5537.9 "Destructive Bolt" Ability { id: "8CEC", source: "Eulogia" }
 
 5600.0 label "Hydrostasis"
-5597.8 "--middle--" Ability { id: "8A02", source: "Eulogia" }
+# 5597.8 "--middle--" Ability { id: "8A02", source: "Eulogia" } # unreachable - info only
 5600.0 "--sync--" Ability { id: "8A37", source: "Eulogia" }
 5604.0 "Hydrostasis" Ability { id: "8A37", source: "Eulogia" }
 5612.0 "Time and Tide" Ability { id: "8A32", source: "Eulogia" }

--- a/ui/raidboss/data/06-ew/alliance/thaleia.txt
+++ b/ui/raidboss/data/06-ew/alliance/thaleia.txt
@@ -692,7 +692,7 @@ hideall "--sync--"
 5537.9 "Destructive Bolt" Ability { id: "8CEC", source: "Eulogia" }
 
 5600.0 label "Hydrostasis"
-# 5597.8 "--middle--" Ability { id: "8A02", source: "Eulogia" } # unreachable - info only
+#5597.8 "--middle--" Ability { id: "8A02", source: "Eulogia" } # unreachable - info only
 5600.0 "--sync--" Ability { id: "8A37", source: "Eulogia" }
 5604.0 "Hydrostasis" Ability { id: "8A37", source: "Eulogia" }
 5612.0 "Time and Tide" Ability { id: "8A32", source: "Eulogia" }

--- a/ui/raidboss/data/06-ew/alliance/thaleia.txt
+++ b/ui/raidboss/data/06-ew/alliance/thaleia.txt
@@ -658,7 +658,6 @@ hideall "--sync--"
 5237.6 "Destructive Bolt" Ability { id: "8CEC", source: "Eulogia" }
 
 5300.0 label "Torrential Tridents"
-#5297.8 "--middle--" Ability { id: "8A02", source: "Eulogia" } # unreachable - info only
 5300.0 "--sync--" StartsUsing { id: "8A4E", source: "Eulogia" }
 5302.0 "Torrential Tridents" Ability { id: "8A4E", source: "Eulogia" }
 5302.9 "Landing 1" #Ability { id: "8A4F", source: "Trident" }
@@ -684,7 +683,6 @@ hideall "--sync--"
 5429.2 "First Blush 4" Ability { id: "8A36", source: "Eulogia" }
 
 5500.0 label "Hieroglyphika"
-#5497.7 "--middle--" Ability { id: "8A02", source: "Eulogia" }  # unreachable - info only
 5500.0 "--sync--" StartsUsing { id: "8A43", source: "Eulogia" }
 5505.0 "Hieroglyphika" Ability { id: "8A43", source: "Eulogia" }
 5522.1 "--sync--" Ability { id: "8A44", source: "Eulogia" }
@@ -692,7 +690,6 @@ hideall "--sync--"
 5537.9 "Destructive Bolt" Ability { id: "8CEC", source: "Eulogia" }
 
 5600.0 label "Hydrostasis"
-#5597.8 "--middle--" Ability { id: "8A02", source: "Eulogia" } # unreachable - info only
 5600.0 "--sync--" Ability { id: "8A37", source: "Eulogia" }
 5604.0 "Hydrostasis" Ability { id: "8A37", source: "Eulogia" }
 5612.0 "Time and Tide" Ability { id: "8A32", source: "Eulogia" }

--- a/ui/raidboss/data/06-ew/dungeon/aetherfont.txt
+++ b/ui/raidboss/data/06-ew/dungeon/aetherfont.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 # TODO: verify loops with longer logs?
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~~~~~~#
 # Lyngbakr :U #

--- a/ui/raidboss/data/06-ew/dungeon/aloalo_island.txt
+++ b/ui/raidboss/data/06-ew/dungeon/aloalo_island.txt
@@ -5,7 +5,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~~~~~~~~~~~~~#
 # Quaqua (left path) #
@@ -29,11 +29,9 @@ hideall "--sync--"
 1046.2 "Ringing Quoits" Ability { id: "8B8B", source: "Aetheric Charge" }
 
 1051.5 "--middle--" Ability { id: "8B8F", source: "Quaqua" }
-1057.6 "Arcane Armaments"
-
 1052.6 "--sync--" StartsUsing { id: "8B8C", source: "Quaqua" } window 40,40 jump "quaqua-left-sunny"
 1052.6 "--sync--" StartsUsing { id: "8B90", source: "Quaqua" } window 40,40 jump "quaqua-left-rainy"
-
+1057.6 "Arcane Armaments"
 
 1252.6 label "quaqua-left-sunny"
 1252.6 "--sync--" StartsUsing { id: "8B8C", source: "Quaqua" }
@@ -180,9 +178,9 @@ hideall "--sync--"
 2127.5 "Far Tide/Near Tide" Ability { id: ["8AA0", "8A9E"], source: "Ketuduke" }
 
 2134.2 "--middle--" Ability { id: "8A77", source: "Ketuduke" }
-2146.4 "--sync--" StartsUsing { id: "8A79", source: "Ketuduke" } jump "ketuduke-01"
 2137.0 "--sync--" StartsUsing { id: "8D11", source: "Ketuduke" } jump "ketuduke-02"
 2137.0 "--sync--" StartsUsing { id: "8A92", source: "Ketuduke" } jump "ketuduke-0304"
+2146.4 "--sync--" StartsUsing { id: "8A79", source: "Ketuduke" } jump "ketuduke-01"
 
 # path 01
 2234.2 "--middle--" Ability { id: "8A77", source: "Ketuduke" }
@@ -332,9 +330,10 @@ hideall "--sync--"
 3052.3 "--middle--" Ability { id: "8B8F", source: "Quaqua" }
 3058.4 "Arcane Armaments"
 
+#cactbot-timeline-lint-disable-sync-order
 3053.4 "--sync--" StartsUsing { id: "8B8C", source: "Quaqua" } window 40,40 jump "quaqua-middle-water"
 3053.4 "--sync--" StartsUsing { id: "8B90", source: "Quaqua" } window 40,40 jump "quaqua-middle-poison"
-
+#cactbot-timeline-lint-enable-sync-order
 
 3153.4 label "quaqua-middle-water"
 3153.4 "--sync--" StartsUsing { id: "8B8C", source: "Quaqua" }
@@ -450,18 +449,19 @@ hideall "--sync--"
 4088.9 "Analysis" Ability { id: "887B", source: "Lala" }
 4102.7 "Targeted Light" Ability { id: "8CDC", source: "Lala" }
 
+#cactbot-timeline-lint-disable-sync-order
 4111.0 "--sync--" StartsUsing { id: "8882", source: "Lala" } window 40,40 jump "lala-05"
 4114.0 "Faunal Figure?" #Ability { id: "8882", source: "Lala" }
 
 4111.0 "--sync--" StartsUsing { id: "8880", source: "Lala" } window 40,40 jump "lala-06"
 4114.0 "Floral Figure?" #Ability { id: "8880", source: "Lala" }
 
-4111.0 "--sync--"  StartsUsing { id: "8884", source: "Lala" } window 40,40 jump "lala-07"
+4111.0 "--sync--" StartsUsing { id: "8884", source: "Lala" } window 40,40 jump "lala-07"
 4114.0 "Constructive Figure?" #Ability { id: "8884", source: "Lala" }
 
 4111.0 "--sync--" StartsUsing { id: "8D2C", source: "Lala" } window 40,40 jump "lala-08"
 4114.0 "Volcanic Coordinates (cast)?" #Ability { id: "8D2C", source: "Lala" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 4211.0 label "lala-05"
 4211.0 "--sync--" StartsUsing { id: "8882", source: "Lala" }
@@ -514,7 +514,7 @@ hideall "--sync--"
 
 
 4611.0 label "lala-07"
-4611.0 "--sync--"  StartsUsing { id: "8884", source: "Lala" }
+4611.0 "--sync--" StartsUsing { id: "8884", source: "Lala" }
 4614.0 "Constructive Figure" Ability { id: "8884", source: "Lala" }
 4629.1 "Aero II" Ability { id: "8885", source: "Aloalo Golem" }
 4634.9 "Strategic Strike" Ability { id: "887E", source: "Lala" }
@@ -620,9 +620,10 @@ hideall "--sync--"
 5053.1 "--middle--" Ability { id: "8B8F", source: "Quaqua" }
 5059.3 "Arcane Armaments"
 
+#cactbot-timeline-lint-disable-sync-order
 5054.3 "--sync--" StartsUsing { id: "8B8C", source: "Quaqua" } window 40,40 jump "quaqua-right-fixed"
 5054.3 "--sync--" StartsUsing { id: "8B90", source: "Quaqua" } window 40,40 jump "quaqua-right-untouched"
-
+#cactbot-timeline-lint-enable-sync-order
 
 5154.3 label "quaqua-right-fixed"
 5154.3 "--sync--" StartsUsing { id: "8B8C", source: "Quaqua" }
@@ -637,9 +638,9 @@ hideall "--sync--"
 5194.4 "--middle--" Ability { id: "8B8F", source: "Quaqua" }
 5200.8 "Arcane Pursuit" Ability { id: "8BA4", source: "Quaqua" }
 5214.1 "--cleanse--" Ability { id: "8BAD" }
+5214.9 "--middle--" Ability { id: "8B8F", source: "Quaqua" }
 5216.8 "--cleanse--" Ability { id: "8BAD" }
 
-5214.9 "--middle--" Ability { id: "8B8F", source: "Quaqua" }
 5221.1 "Arcane Pursuit" Ability { id: "8BA4", source: "Quaqua" }
 5237.1 "--cleanse--" Ability { id: "8BA6" }
 5244.1 "--cleanse--" Ability { id: "8BA6" }
@@ -654,10 +655,10 @@ hideall "--sync--"
 5274.9 "--middle--" Ability { id: "8B8F", source: "Quaqua" }
 5281.1 "Arcane Pursuit" Ability { id: "8BA4", source: "Quaqua" }
 5297.1 "--cleanse--" Ability { id: "8BA6" }
-5304.1 "--cleanse--" Ability { id: "8BA6" }
-
 5297.2 "--middle--" Ability { id: "8B8F", source: "Quaqua" }
 5303.3 "Arcane Armaments" Ability { id: "8B8C", source: "Quaqua" }
+5304.1 "--cleanse--" Ability { id: "8BA6" }
+
 5313.6 "Hammer Landing 1" Ability { id: "8B8D", source: "Quaqua" }
 5315.7 "Hammer Landing 2" #Ability { id: "8B8E", source: "Quaqua" }
 5317.7 "Hammer Landing 3" #Ability { id: "8B8E", source: "Quaqua" }
@@ -753,6 +754,7 @@ hideall "--sync--"
 6107.3 "Fire Spread" Ability { id: "8934", source: "Statice" } duration 10
 6116.9 "Aero IV" Ability { id: "8929", source: "Statice" }
 
+#cactbot-timeline-lint-disable-sync-order
 6124.1 "--sync--" StartsUsing { id: "8945", source: "Statice" } window 40,40 jump "statice-09"
 6128.1 "Whoopee Cushion?" #Ability { id: "8945", source: "Statice" }
 
@@ -761,7 +763,7 @@ hideall "--sync--"
 
 6124.1 "--sync--" StartsUsing { id: "8936", source: "Statice" } window 40,40 jump "statice-11"
 6128.1 "Jack-in-the-box?" #Ability { id: "8936", source: "Statice" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 6224.1 label "statice-09"
 6224.1 "--sync--" StartsUsing { id: "8945", source: "Statice" }

--- a/ui/raidboss/data/06-ew/dungeon/alzadaals_legacy.txt
+++ b/ui/raidboss/data/06-ew/dungeon/alzadaals_legacy.txt
@@ -4,7 +4,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~#
 # ABUJAM #

--- a/ui/raidboss/data/06-ew/dungeon/another_aloalo_island-savage.txt
+++ b/ui/raidboss/data/06-ew/dungeon/another_aloalo_island-savage.txt
@@ -10,7 +10,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~~~#
 # KETUDUKE #

--- a/ui/raidboss/data/06-ew/dungeon/another_aloalo_island.txt
+++ b/ui/raidboss/data/06-ew/dungeon/another_aloalo_island.txt
@@ -5,7 +5,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~~~#
 # KETUDUKE #

--- a/ui/raidboss/data/06-ew/dungeon/another_mount_rokkon-savage.txt
+++ b/ui/raidboss/data/06-ew/dungeon/another_mount_rokkon-savage.txt
@@ -10,7 +10,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~~#
 # SHISHIO #

--- a/ui/raidboss/data/06-ew/dungeon/another_mount_rokkon.txt
+++ b/ui/raidboss/data/06-ew/dungeon/another_mount_rokkon.txt
@@ -5,7 +5,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~~#
 # SHISHIO #

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.txt
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.txt
@@ -9,7 +9,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~#
 # SILKIE #

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.txt
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.txt
@@ -4,7 +4,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~#
 # SILKIE #

--- a/ui/raidboss/data/06-ew/dungeon/ktisis_hyperboreia.txt
+++ b/ui/raidboss/data/06-ew/dungeon/ktisis_hyperboreia.txt
@@ -4,7 +4,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~#
 # LYSSA #
@@ -103,8 +103,8 @@ hideall "--sync--"
 
 1158.8 "Inhale" Ability { id: "6484", source: "Ladon Lord" } jump 1074.4
 1161.8 "Pyric Sphere"
-1166.9 "Pyric Sphere"
 1166.3 "--rotate--"
+1166.9 "Pyric Sphere"
 1173.3 "Pyric Breath #1"
 1175.4 "Pyric Breath #2"
 1183.5 "Intimidation"

--- a/ui/raidboss/data/06-ew/dungeon/lapis_manalis.txt
+++ b/ui/raidboss/data/06-ew/dungeon/lapis_manalis.txt
@@ -4,7 +4,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~#
 # Albion #
@@ -17,8 +17,8 @@ hideall "--sync--"
 6.0 "--sync--" Ability { id: "802C", source: "Albion" }
 10.6 "Call of the Mountain" Ability { id: "7A7C", source: "Albion" }
 
-12.9 "Wildlife Crossing 1" MapEffect { flags: "00020001" } window 5,5 duration 15
-26.9 "Wildlife Crossing 2" MapEffect { flags: "00020001" } window 5,5 duration 15
+12.9 "Wildlife Crossing 1" MapEffect { flags: "00020001" } duration 15 window 5,5
+26.9 "Wildlife Crossing 2" MapEffect { flags: "00020001" } duration 15 window 5,5
 41.4 "Albion's Embrace" Ability { id: "7A85", source: "Albion" }
 48.4 "--sync--" Ability { id: "802C", source: "Albion" }
 55.1 "Left Slam/Right Slam" Ability { id: ["802E", "802D"], source: "Albion" }
@@ -31,10 +31,10 @@ hideall "--sync--"
 
 90.2 "Roar of Albion" Ability { id: "7A84", source: "Albion" }
 103.3 "Call of the Mountain" Ability { id: "7A7C", source: "Albion" }
-106.1 "Wildlife Crossing 1" MapEffect { flags: "00020001" } window 5,5 duration 15
+106.1 "Wildlife Crossing 1" MapEffect { flags: "00020001" } duration 15 window 5,5
 108.7 "--sync--" Ability { id: "802C", source: "Albion" }
 115.5 "Left Slam/Right Slam" Ability { id: ["802E", "802D"], source: "Albion" }
-120.0 "Wildlife Crossing 2" MapEffect { flags: "00020001" } window 5,5 duration 15
+120.0 "Wildlife Crossing 2" MapEffect { flags: "00020001" } duration 15 window 5,5
 123.9 "--sync--" Ability { id: "802C", source: "Albion" }
 130.8 "Left Slam/Right Slam" Ability { id: ["802E", "802D"], source: "Albion" }
 141.4 "Albion's Embrace" Ability { id: "7A85", source: "Albion" }
@@ -48,10 +48,10 @@ hideall "--sync--"
 # loop
 175.8 "Roar of Albion" Ability { id: "7A84", source: "Albion" } window 30,30 jump 90.2
 188.9 "Call of the Mountain" #Ability { id: "7A7C", source: "Albion" }
-191.7 "Wildlife Crossing 1" #MapEffect { flags: "00020001" } window 5,5 duration 15
+191.7 "Wildlife Crossing 1" #MapEffect { flags: "00020001" } duration 15 window 5,5
 194.3 "--sync--" #Ability { id: "802C", source: "Albion" }
 201.1 "Left Slam/Right Slam" #Ability { id: ["802E", "802D"], source: "Albion" }
-205.6 "Wildlife Crossing 2" #MapEffect { flags: "00020001" } window 5,5 duration 15
+205.6 "Wildlife Crossing 2" #MapEffect { flags: "00020001" } duration 15 window 5,5
 209.5 "--sync--" #Ability { id: "802C", source: "Albion" }
 216.4 "Left Slam/Right Slam" #Ability { id: ["802E", "802D"], source: "Albion" }
 

--- a/ui/raidboss/data/06-ew/dungeon/mount_rokkon.txt
+++ b/ui/raidboss/data/06-ew/dungeon/mount_rokkon.txt
@@ -25,6 +25,7 @@ hideall "--sync--"
 1052.7 "Seal of the Blossom" Ability { id: "837[5678]", source: "Yozakura the Fleeting" }
 1059.7 "--sync--" Ability { id: "8612", source: "Yozakura the Fleeting" }
 
+#cactbot-timeline-lint-disable-sync-order
 # -> rain path
 1060.9 "--sync--" StartsUsing { id: "837E", source: "Yozakura the Fleeting" } window 50,50 jump 1360.9
 1065.9 "Bunshin?" #Ability { id: "837E", source: "Yozakura the Fleeting" }
@@ -32,7 +33,7 @@ hideall "--sync--"
 # -> wind path
 1060.8 "--sync--" StartsUsing { id: "838F", source: "Yozakura the Fleeting" } window 50,50 jump 1660.8
 1070.1 "Windblossom Whirl?" #Ability { id: "8390", source: "Yozakura the Fleeting" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Rain path
 1359.7 "--sync--" Ability { id: "8612", source: "Yozakura the Fleeting" }
@@ -191,6 +192,7 @@ hideall "--sync--"
 2160.2 "Double Kasumi-giri 1" Ability { id: "858[BCDE]", source: "Moko the Restless" }
 2163.8 "Double Kasumi-giri 2" Ability { id: ["858F", "859[012]"], source: "Moko the Restless" }
 
+#cactbot-timeline-lint-disable-sync-order
 # => path 01
 2169.0 "--sync--" StartsUsing { id: "85A8", source: "Moko the Restless" } window 50,50 jump 2269.0
 2172.0 "Untempered Sword?" #Ability { id: "85A8", source: "Moko the Restless" }
@@ -206,7 +208,7 @@ hideall "--sync--"
 # => path 04
 2169.0 "--sync--" StartsUsing { id: "85A5", source: "Moko the Restless" } window 50,50 jump 3169.0
 2172.0 "Spiritspark?" #Ability { id: "85A5", source: "Moko the Restless" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # path 01
 2231.4 "--middle--" Ability { id: "85AF", source: "Moko the Restless" }
@@ -424,6 +426,7 @@ hideall "--sync--"
 4000.0 "--sync--" SystemLogMessage { id: "7DC", param1: "10DD" } window 10000,0
 4011.6 "Glory Neverlasting" Ability { id: "83A9", source: "Yozakura the Fleeting" }
 
+#cactbot-timeline-lint-disable-sync-order
 # -> door
 4016.7 "--sync--" StartsUsing { id: "8394", source: "Yozakura the Fleeting" } window 20,20 jump 4116.7
 4019.7 "Tatami Trap?" #Ability { id: "8394", source: "Yozakura the Fleeting" }
@@ -431,7 +434,7 @@ hideall "--sync--"
 # -> rope
 4015.7 "--sync--" StartsUsing { id: "8369", source: "Yozakura the Fleeting" } window 20,20 jump 4315.7
 4020.7 "Art of the Windblossom?" #Ability { id: "8369", source: "Yozakura the Fleeting" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # door
 4116.7 "--sync--" StartsUsing { id: "8394", source: "Yozakura the Fleeting" }
@@ -563,6 +566,7 @@ hideall "--sync--"
 # This is inconsistent among timelines, so don't sync.
 5111.1 "--middle--" #Ability { id: "84D3", source: "Gorai the Uncaged" }
 
+#cactbot-timeline-lint-disable-sync-order
 # -> path 05
 5114.3 "--sync--" StartsUsing { id: "84ED", source: "Gorai the Uncaged" } window 30,30 jump 5214.3
 5116.8 "Pure Shock?" #Ability { id: "84ED", source: "Gorai the Uncaged" }
@@ -572,9 +576,9 @@ hideall "--sync--"
 5115.1 "Thundercall?" Ability { id: "84F2", source: "Gorai the Uncaged" }
 
 # -> path 07
-5112.1 "--sync--"  StartsUsing { id: "84F8", source: "Gorai the Uncaged" } window 30,30 jump 5412.1
+5112.1 "--sync--" StartsUsing { id: "84F8", source: "Gorai the Uncaged" } window 30,30 jump 5412.1
 5117.1 "Fighting Spirits?" #Ability { id: "84F8", source: "Gorai the Uncaged" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # path 05
 5211.1 "--middle--" Ability { id: "84D3", source: "Gorai the Uncaged" }
@@ -612,7 +616,7 @@ hideall "--sync--"
 
 # path 07
 5409.9 "--sync--" Ability { id: "84D3", source: "Gorai the Uncaged" }
-5412.1 "--sync--"  StartsUsing { id: "84F8", source: "Gorai the Uncaged" }
+5412.1 "--sync--" StartsUsing { id: "84F8", source: "Gorai the Uncaged" }
 5417.1 "Fighting Spirits" Ability { id: "84F8", source: "Gorai the Uncaged" }
 5426.1 "Worldly Pursuit 1" Ability { id: "84FB", source: "Gorai the Uncaged" }
 5429.9 "Worldly Pursuit 2" Ability { id: "84FC", source: "Gorai the Uncaged" }
@@ -723,6 +727,7 @@ hideall "--sync--"
 6000.0 "--sync--" SystemLogMessage { id: "7DC", param1: "10DE" } window 10000,0
 6012.0 "Glory Neverlasting" Ability { id: "83A9", source: "Yozakura the Fleeting" }
 
+#cactbot-timeline-lint-disable-sync-order
 # -> no dogu
 6016.1 "--sync--" StartsUsing { id: "8368", source: "Yozakura the Fleeting" } window 30,30 jump 6116.1
 6019.1 "Art of the Fireblossom?" #Ability { id: "8368", source: "Yozakura the Fleeting" }
@@ -730,7 +735,7 @@ hideall "--sync--"
 # -> dogu
 6016.1 "--sync--" StartsUsing { id: "8369", source: "Yozakura the Fleeting" } window 30,30 jump 6316.1
 6021.1 "Art of the Windblossom?" Ability { id: "8369", source: "Yozakura the Fleeting" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # no dogu path
 6116.1 "--sync--" StartsUsing { id: "8368", source: "Yozakura the Fleeting" }
@@ -860,6 +865,7 @@ hideall "--sync--"
 7068.5 "Smokeater 3?" #Ability { id: "83D9", source: "Shishio" }
 7093.0 "Haunting Cry" Ability { id: "83E8", source: "Shishio" }
 
+#cactbot-timeline-lint-disable-sync-order
 # -> path 08
 7104.0 "--sync--" StartsUsing { id: "83EE", source: "Feral Thrall" }
 7110.0 "Rush?" Ability { id: "83EE", source: "Feral Thrall" } window 30,30 jump 7210.0
@@ -876,7 +882,7 @@ hideall "--sync--"
 # -> path 11
 7099.0 "--sync--" StartsUsing { id: "872B", source: "Haunting Thrall" } window 30,30 jump 7599.0
 7103.0 "Reisho?" #Ability { id: "872B", source: "Haunting Thrall" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # path 08
 7193.0 "Haunting Cry" Ability { id: "83E8", source: "Shishio" }

--- a/ui/raidboss/data/06-ew/dungeon/smileton.txt
+++ b/ui/raidboss/data/06-ew/dungeon/smileton.txt
@@ -4,7 +4,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~#
 # FACE #

--- a/ui/raidboss/data/06-ew/dungeon/stigma_dreamscape.txt
+++ b/ui/raidboss/data/06-ew/dungeon/stigma_dreamscape.txt
@@ -4,7 +4,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 
 #~~~~~~~~~~~~~#

--- a/ui/raidboss/data/06-ew/dungeon/the_aitiascope.txt
+++ b/ui/raidboss/data/06-ew/dungeon/the_aitiascope.txt
@@ -6,7 +6,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~~~~~~~~~~~~~~~#
 # LIVIA THE UNDETERRED #
@@ -135,18 +135,19 @@ hideall "--sync--"
 # TODO: unclear if once post jump it keeps the pattern of Strophe vs Thundaga first, or if random.
 # 4/4 pulls that saw this all had the same, but that's not quite enough confidence.
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Strophe first, then Thundaga?
-3119.2 "--sync--" StartsUsing { id: "645D", source: "Amon the Undying" } jump 4119.2 window 50,50
+3119.2 "--sync--" StartsUsing { id: "645D", source: "Amon the Undying" } window 50,50 jump 4119.2
 3122.2 "Strophe?" #Ability { id: "645D", source: "Amon the Undying" }
 3128.3 "Antistrophe?" #Ability { id: "645E", source: "Amon the Undying" }
 3137.1 "Epode?" #Ability { id: "645F", source: "Amon the Undying" }
 
 # -> Thundaga first, then Strophe?
-3119.2 "--sync--" StartsUsing { id: "645A", source: "Amon the Undying" } jump 5119.2 window 50,50
+3119.2 "--sync--" StartsUsing { id: "645A", source: "Amon the Undying" } window 50,50 jump 5119.2
 3124.2 "Thundaga Forte (proximity)?" #Ability { id: "645A", source: "Amon the Undying" }
 3130.0 "Thundaga Forte 1?" #Ability { id: "645B", source: "Amon the Undying" }
 3136.0 "Thundaga Forte 2?" #Ability { id: "645C", source: "Amon the Undying" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 ### Strophe -> Thundaga -> shared Eruption section -> (Strophe or Thundaga)
 4119.2 "--sync--" StartsUsing { id: "645D", source: "Amon the Undying" }
@@ -169,18 +170,19 @@ hideall "--sync--"
 4247.0 "Dark Forte" Ability { id: "6464", source: "Amon the Undying" }
 4255.1 "Entr'acte" Ability { id: "6465", source: "Amon the Undying" }
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Strophe first, then Thundaga?
-4267.3 "--sync--" StartsUsing { id: "645D", source: "Amon the Undying" } jump 4119.2 window 50,50
+4267.3 "--sync--" StartsUsing { id: "645D", source: "Amon the Undying" } window 50,50 jump 4119.2
 4270.3 "Strophe?" #Ability { id: "645D", source: "Amon the Undying" }
 4276.4 "Antistrophe?" #Ability { id: "645E", source: "Amon the Undying" }
 4285.2 "Epode?" #Ability { id: "645F", source: "Amon the Undying" }
 
 # -> Thundaga first, then Strophe?
-4267.3 "--sync--" StartsUsing { id: "645A", source: "Amon the Undying" } jump 5119.2 window 50,50
+4267.3 "--sync--" StartsUsing { id: "645A", source: "Amon the Undying" } window 50,50 jump 5119.2
 4272.3 "Thundaga Forte (proximity)?" #Ability { id: "645A", source: "Amon the Undying" }
 4278.1 "Thundaga Forte 1?" #Ability { id: "645B", source: "Amon the Undying" }
 4284.1 "Thundaga Forte 2?" #Ability { id: "645C", source: "Amon the Undying" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 ### Thundaga -> Strophe -> shared Eruption section -> (Strophe or Thundaga)
 5119.2 "--sync--" StartsUsing { id: "645A", source: "Amon the Undying" }
@@ -203,14 +205,16 @@ hideall "--sync--"
 5247.0 "Dark Forte" Ability { id: "6464", source: "Amon the Undying" }
 5255.1 "Entr'acte" Ability { id: "6465", source: "Amon the Undying" }
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Strophe first, then Thundaga?
-5267.3 "--sync--" StartsUsing { id: "645D", source: "Amon the Undying" } jump 4119.2 window 50,50
+5267.3 "--sync--" StartsUsing { id: "645D", source: "Amon the Undying" } window 50,50 jump 4119.2
 5270.3 "Strophe?" #Ability { id: "645D", source: "Amon the Undying" }
 5276.4 "Antistrophe?" #Ability { id: "645E", source: "Amon the Undying" }
 5285.2 "Epode?" #Ability { id: "645F", source: "Amon the Undying" }
 
 # -> Thundaga first, then Strophe?
-5267.3 "--sync--" StartsUsing { id: "645A", source: "Amon the Undying" } jump 5119.2 window 50,50
+5267.3 "--sync--" StartsUsing { id: "645A", source: "Amon the Undying" } window 50,50 jump 5119.2
 5272.3 "Thundaga Forte (proximity)?" #Ability { id: "645A", source: "Amon the Undying" }
 5278.1 "Thundaga Forte 1?" #Ability { id: "645B", source: "Amon the Undying" }
 5284.1 "Thundaga Forte 2?" #Ability { id: "645C", source: "Amon the Undying" }
+#cactbot-timeline-lint-enable-sync-order

--- a/ui/raidboss/data/06-ew/dungeon/the_dead_ends.txt
+++ b/ui/raidboss/data/06-ew/dungeon/the_dead_ends.txt
@@ -4,7 +4,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~~~~~~~~~~~~#
 # CAUSTIC GREBULOFF #

--- a/ui/raidboss/data/06-ew/dungeon/the_fell_court_of_troia.txt
+++ b/ui/raidboss/data/06-ew/dungeon/the_fell_court_of_troia.txt
@@ -4,7 +4,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~~~~~~~~~~#
 # EVIL DREAMER(s) #
@@ -22,7 +22,7 @@ hideall "--sync--"
 1200.0 "--sync--" StartsUsing { id: "73B8", source: "Evil Dreamer" } window 200,0
 1208.0 "Dark Vision" Ability { id: "73B8", source: "Evil Dreamer" }
 
-1200.0 "--sync--" StartsUsing { id: "73B8", source: "Evil Dreamer" } window 200,0
+1400.0 "--sync--" StartsUsing { id: "73B8", source: "Evil Dreamer" } window 200,0
 1408.0 "Dark Vision" Ability { id: "73B8", source: "Evil Dreamer" }
 1408.0 "Void Gravity" Ability { id: "73BA", source: "Evil Dreamer" }
 

--- a/ui/raidboss/data/06-ew/dungeon/the_lunar_subterrane.txt
+++ b/ui/raidboss/data/06-ew/dungeon/the_lunar_subterrane.txt
@@ -5,7 +5,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~~~#
 # DARK ELF #

--- a/ui/raidboss/data/06-ew/dungeon/the_sildihn_subterrane.txt
+++ b/ui/raidboss/data/06-ew/dungeon/the_sildihn_subterrane.txt
@@ -4,7 +4,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 ### Geryon the Steer (left door, 1st boss)
 # -p 74CF:1010.6 74D2:2019.7
@@ -15,6 +15,7 @@ hideall "--sync--"
 1005.6 "--sync--" StartsUsing { id: "74CF", source: "Geryon the Steer" }
 1010.6 "Colossal Strike" Ability { id: "74CF", source: "Geryon the Steer" }
 
+#cactbot-timeline-lint-disable-sync-order
 # -> yes pump
 1019.7 "--sync--" StartsUsing { id: "74C7", source: "Geryon the Steer" } window 20,20 jump 1219.7
 1024.7 "Exploding Catapult?" #Ability { id: "74C7", source: "Geryon the Steer" }
@@ -22,7 +23,7 @@ hideall "--sync--"
 # -> no pump
 1014.7 "--sync--" StartsUsing { id: "74D2", source: "Geryon the Steer" } window 20,20 jump 2014.7
 1019.7 "Subterranean Shudder" #Ability { id: "74D2", source: "Geryon the Steer" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Geryon the Steer (left door, 1st boss, yes pump)
 1219.7 "--sync--" StartsUsing { id: "74C7", source: "Geryon the Steer" }
@@ -155,6 +156,7 @@ hideall "--sync--"
 3060.0 "Subterranean Shudder" Ability { id: "74D2", source: "Geryon the Steer" }
 3067.1 "Exploding Catapult" #Ability { id: "74C7", source: "Geryon the Steer" }
 
+#cactbot-timeline-lint-disable-sync-order
 # -> left handle
 3062.1 "--sync--" MapEffect { flags: "00020001", location: "09" } window 70,70 jump 3262.1
 3076.2 "Intake?" #Ability { id: "74D9", source: "Geryon the Steer" }
@@ -166,6 +168,7 @@ hideall "--sync--"
 # TODO: fix the test_timeline utilities (python doesn't handle this, typescript is broken)
 3076.2 "--sync--" Ability { id: "74D9", source: "Geryon the Steer" } window 70,70 jump 3276.2
 3078.2 "--sync--" Ability { id: "74DA", source: "Geryon the Steer" } window 70,70 jump 4078.2
+#cactbot-timeline-lint-enable-sync-order
 
 # Geryon the Steer (middle door, 1st boss, left handle)
 3260.0 "Subterranean Shudder" Ability { id: "74D2", source: "Geryon the Steer" }
@@ -286,8 +289,6 @@ hideall "--sync--"
 5010.0 "Colossal Strike" Ability { id: "74CF", source: "Geryon the Steer" }
 
 5020.1 "Subterranean Shudder" Ability { id: "74D2", source: "Geryon the Steer" }
-5030.2 "Suddenly Sewage 1" #Ability { id: "74D8", source: "Geryon the Steer" }
-5032.2 "Suddenly Sewage 2" #Ability { id: "74D8", source: "Geryon the Steer" }
 
 # We could probably jump from MapEffect lines here to each branch
 # But for simplicity, just use the "jump to middle" before Gigantomill
@@ -295,7 +296,6 @@ hideall "--sync--"
 5023.2 "--sync--" Ability { id: "74C6", source: "Geryon the Steer" } window 30,30 jump 6023.2
 
 # Geryon the Steer (right door, 1st boss, ceruleum leak)
-5020.1 "Subterranean Shudder" Ability { id: "74D2", source: "Geryon the Steer" }
 5030.2 "Suddenly Sewage 1" #Ability { id: "74D8", source: "Geryon the Steer" }
 5032.2 "Suddenly Sewage 2" #Ability { id: "74D8", source: "Geryon the Steer" }
 5040.2 "Exploding Catapult" Ability { id: "74C7", source: "Geryon the Steer" }
@@ -619,6 +619,7 @@ hideall "--sync--"
 9010.6 "--sync--" StartsUsing { id: "74AE", source: "Shadowcaster Zeless Gah" } window 20,20
 9015.6 "Show of Strength" Ability { id: "74AE", source: "Shadowcaster Zeless Gah" }
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Path 05
 9019.7 "--sync--" StartsUsing { id: "74A2", source: "Shadowcaster Zeless Gah" } window 20,20 jump 10019.7
 9023.7 "Infern Gale?" #Ability { id: "74A2", source: "Shadowcaster Zeless Gah" }
@@ -630,6 +631,7 @@ hideall "--sync--"
 # -> Path 07
 9019.7 "--sync--" StartsUsing { id: "74A7", source: "Shadowcaster Zeless Gah" } window 20,20 jump 12019.7
 9023.7 "Infern Well?" #Ability { id: "74A7", source: "Shadowcaster Zeless Gah" }
+#cactbot-timeline-lint-enable-sync-order
 
 ### Path 05
 # Note: this could be combined with Path 07 with knockback/draw-in replacements

--- a/ui/raidboss/data/06-ew/dungeon/the_tower_of_babil.txt
+++ b/ui/raidboss/data/06-ew/dungeon/the_tower_of_babil.txt
@@ -4,7 +4,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 
 #~~~~~~~~~~#

--- a/ui/raidboss/data/06-ew/dungeon/the_tower_of_zot.txt
+++ b/ui/raidboss/data/06-ew/dungeon/the_tower_of_zot.txt
@@ -4,7 +4,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~~~~#
 # MINDURUVA #

--- a/ui/raidboss/data/06-ew/dungeon/vanaspati.txt
+++ b/ui/raidboss/data/06-ew/dungeon/vanaspati.txt
@@ -4,7 +4,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # .*is no longer sealed
-0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 100000 jump 0
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
 
 #~~~~~~~~~~~~~~~~~~~#
 # Terminus Snatcher #

--- a/ui/raidboss/data/06-ew/raid/p10n.txt
+++ b/ui/raidboss/data/06-ew/raid/p10n.txt
@@ -23,7 +23,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 7.9 "--sync--" StartsUsing { id: "8259", source: "Pand\\u00e6monium" } window 15,15

--- a/ui/raidboss/data/06-ew/raid/p10s.txt
+++ b/ui/raidboss/data/06-ew/raid/p10s.txt
@@ -22,7 +22,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 9.1 "--sync--" StartsUsing { id: "82A5", source: "Pand\\u00e6monium" } window 15,15

--- a/ui/raidboss/data/06-ew/raid/p11n.txt
+++ b/ui/raidboss/data/06-ew/raid/p11n.txt
@@ -22,7 +22,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
@@ -64,7 +64,7 @@ hideall "--sync--"
 193.0 "Dark Perimeter" Ability { id: "81BE", source: "Themis" }
 201.0 "Upheld Ruling (stack -> chariot)" Ability { id: "81B9", source: "Themis" }
 206.7 "Lightburst" Ability { id: "81BD", source: "Themis" }
-216.3 "Styx x5" Ability { id: "81DB", source: "Themis" } window 216.3,10 duration 5
+216.3 "Styx x5" Ability { id: "81DB", source: "Themis" } duration 5 window 216.3,10
 
 # Combine it all to this point
 228.0 "--center--" Ability { id: "8235", source: "Themis" } window 30,30
@@ -138,7 +138,7 @@ hideall "--sync--"
 589.2 "Styx x5" Ability { id: "81DB", source: "Themis" } duration 5
 
 
-599.6 "--center--" Ability { id: "8235", source: "Themis" } jump 391.4 window 30,30
+599.6 "--center--" Ability { id: "8235", source: "Themis" } window 30,30 jump 391.4
 604.6 "Dineis (cast)"
 608.6 "Dineis (puddle 1)"
 610.6 "Dineis (puddle 2)"

--- a/ui/raidboss/data/06-ew/raid/p11s.txt
+++ b/ui/raidboss/data/06-ew/raid/p11s.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 11.0 "--sync--" StartsUsing { id: "822B", source: "Themis" } window 12,10

--- a/ui/raidboss/data/06-ew/raid/p12n.txt
+++ b/ui/raidboss/data/06-ew/raid/p12n.txt
@@ -7,7 +7,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 # Phase 1
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1

--- a/ui/raidboss/data/06-ew/raid/p12s.txt
+++ b/ui/raidboss/data/06-ew/raid/p12s.txt
@@ -3,7 +3,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 ### Phase 1: Athena
 # -ii 8677 8314 8350 82F0 8308 8309 8331 8313

--- a/ui/raidboss/data/06-ew/raid/p1n.txt
+++ b/ui/raidboss/data/06-ew/raid/p1n.txt
@@ -9,7 +9,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 

--- a/ui/raidboss/data/06-ew/raid/p1s.txt
+++ b/ui/raidboss/data/06-ew/raid/p1s.txt
@@ -17,7 +17,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 # First flail set
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
@@ -96,21 +96,22 @@ hideall "--sync--"
 # Cells 2 -> branch
 407.6 "Shining Cells" Ability { id: "6616", source: "Erichthonios" }
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Shackles of Time first?
-417.8 "Shackles of Time?" Ability { id: "661C", source: "Erichthonios" } jump 617.8 window 20,20
+417.8 "Shackles of Time?" Ability { id: "661C", source: "Erichthonios" } window 20,20 jump 617.8
 425.1 "Pitiless Flail of Grace/Pitiless Flail of Purgation?" #Ability { id: "660[EF]", source: "Erichthonios" }
 428.4 "True Flare/True Holy?" #Ability { id: "661[01]", source: "Erichthonios" }
 432.8 "Inevitable Flame/Inevitable Light?" #Ability { id: "6EC[12]", source: "Erichthonios" }
 441.9 "Warder's Wrath?" #Ability { id: "662A", source: "Erichthonios" }
 
 # -> Aetherial Shackles first?
-417.8 "Aetherial Shackles?" Ability { id: "6625", source: "Erichthonios" } jump 1010.8 window 20,20
+417.8 "Aetherial Shackles?" Ability { id: "6625", source: "Erichthonios" } window 20,20 jump 1010.8
 428.9 "Aetherchain?" #Ability { id: "6619", source: "Erichthonios" }
 429.8 "Powerful Fire/Powerful Light?" #Ability { id: "661[AB]", source: "Erichthonios" }
 436.7 "Chain Pain?" #Ability { id: "6627", source: "Erichthonios" }
 438.0 "Powerful Fire/Powerful Light?" #Ability { id: "661[AB]", source: "Erichthonios" }
 447.3 "Warder's Wrath?" #Ability { id: "662A", source: "Erichthonios" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Cells 2, Shackles of Time first
 617.8 "Shackles of Time" Ability { id: "661C", source: "Erichthonios" }

--- a/ui/raidboss/data/06-ew/raid/p2n.txt
+++ b/ui/raidboss/data/06-ew/raid/p2n.txt
@@ -5,7 +5,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 9.3 "--sync--" StartsUsing { id: "680F", source: "Hippokampos" } window 20,20

--- a/ui/raidboss/data/06-ew/raid/p2s.txt
+++ b/ui/raidboss/data/06-ew/raid/p2s.txt
@@ -6,7 +6,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 11.0 "--sync--" StartsUsing { id: "6833", source: "Hippokampos" } window 15,15

--- a/ui/raidboss/data/06-ew/raid/p3n.txt
+++ b/ui/raidboss/data/06-ew/raid/p3n.txt
@@ -3,7 +3,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 # -ii 669F 66A7 66A8 66A0 66A1 66AF 66B0 66B3 6D0C 6DDC 6EDD
 # -ic "Liturgic Bell"

--- a/ui/raidboss/data/06-ew/raid/p3s.txt
+++ b/ui/raidboss/data/06-ew/raid/p3s.txt
@@ -8,7 +8,7 @@ hideall "--sync--"
 
 # Note: 66BF "middle" happens 6.2s after experimental fireplume
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 8.7 "--sync--" StartsUsing { id: "6706", source: "Phoinix" } window 10,10
@@ -30,9 +30,9 @@ hideall "--sync--"
 140.4 "Left Cinderwing/Right Cinderwing" Ability { id: ["6702", "6703"], source: "Phoinix" }
 149.5 "Heat of Condemnation" Ability { id: "6700", source: "Phoinix" }
 157.6 "Experimental Fireplume" Ability { id: ["66BE", "66C0"], source: "Phoinix" }
+162.2 "--untargetable--"
 163.7 "--giant fireplume?--" #Ability { id: "66BF", source: "Phoinix" }
 
-162.2 "--untargetable--"
 172.0 "Trail of Condemnation" Ability { id: ["66FB", "66FC"], source: "Phoinix" }
 173.6 "Flare of Condemnation/Sparks of Condemnation" Ability { id: ["66FE", "66FF"], source: "Phoinix" }
 

--- a/ui/raidboss/data/06-ew/raid/p4n.txt
+++ b/ui/raidboss/data/06-ew/raid/p4n.txt
@@ -17,7 +17,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 10.8 "--sync--" StartsUsing { id: "6A50", source: "Hesperos" } window 20,20

--- a/ui/raidboss/data/06-ew/raid/p4s.txt
+++ b/ui/raidboss/data/06-ew/raid/p4s.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 ### Hesperos I
 #

--- a/ui/raidboss/data/06-ew/raid/p5n.txt
+++ b/ui/raidboss/data/06-ew/raid/p5n.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 10.3 "--sync--" Ability { id: "76D6", source: "Proto-Carbuncle" } window 11,10

--- a/ui/raidboss/data/06-ew/raid/p5s.txt
+++ b/ui/raidboss/data/06-ew/raid/p5s.txt
@@ -7,7 +7,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 9.9 "--sync--" StartsUsing { id: "7720", source: "Proto-Carbuncle" } window 20,20

--- a/ui/raidboss/data/06-ew/raid/p6n.txt
+++ b/ui/raidboss/data/06-ew/raid/p6n.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 10.1 "Aetheric Polyominoid" Ability { id: "7853", source: "Hegemone" } window 11,5

--- a/ui/raidboss/data/06-ew/raid/p6s.txt
+++ b/ui/raidboss/data/06-ew/raid/p6s.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1

--- a/ui/raidboss/data/06-ew/raid/p7n.txt
+++ b/ui/raidboss/data/06-ew/raid/p7n.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 # -ii 77F6 77F7 77FA 77FD 77FF 7800 7804 7806 7807 780A 783E 7841
 
@@ -14,7 +14,7 @@ hideall "--sync--"
 23.4 "Bough of Attis (left/right)" Ability { id: ["77FB", "77FC"], source: "Agdistis" }
 37.6 "Hemitheos's Holy" Ability { id: "7808", source: "Agdistis" }
 44.0 "Hemitheos's Glare III" Ability { id: "77F8", source: "Agdistis" }
-54.1 "Bough of Attis (in)"  Ability { id: "77FE", source: "Agdistis" }
+54.1 "Bough of Attis (in)" Ability { id: "77FE", source: "Agdistis" }
 64.5 "Bough of Attis (out)" Ability { id: "77F9", source: "Agdistis" }
 72.1 "Bough of Attis (left/right)" Ability { id: ["77FB", "77FC"], source: "Agdistis" }
 81.9 "Immortal's Obol" Ability { id: "77F5", source: "Agdistis" }
@@ -53,7 +53,7 @@ hideall "--sync--"
 420.8 "Hemitheos's Holy" Ability { id: "7808", source: "Agdistis" }
 430.6 "Immortal's Obol" Ability { id: "77F5", source: "Agdistis" }
 450.9 "Forbidden Fruit" Ability { id: "7801", source: "Agdistis" }
-464.3 "Bough of Attis (in)"  Ability { id: "77FE", source: "Agdistis" }
+464.3 "Bough of Attis (in)" Ability { id: "77FE", source: "Agdistis" }
 465.7 "Static Moon" Ability { id: "7802", source: "Immature Io" }
 475.9 "Hemitheos's Aero II" Ability { id: "7809", source: "Agdistis" } window 30,30
 489.2 "Forbidden Fruit" Ability { id: "7801", source: "Agdistis" }
@@ -94,7 +94,7 @@ hideall "--sync--"
 1000.0 "--sync--" StartsUsing { id: "7807", source: "Agdistis" }
 1009.8 "Hemitheos's Holy" Ability { id: "7808", source: "Agdistis" }
 1016.2 "Hemitheos's Glare III" Ability { id: "77F8", source: "Agdistis" } window 30,30
-1026.3 "Bough of Attis (in)"  Ability { id: "77FE", source: "Agdistis" }
+1026.3 "Bough of Attis (in)" Ability { id: "77FE", source: "Agdistis" }
 1036.7 "Bough of Attis (out)" Ability { id: "77F9", source: "Agdistis" }
 1044.3 "Bough of Attis (left/right)" Ability { id: ["77FB", "77FC"], source: "Agdistis" }
 1054.1 "Immortal's Obol" Ability { id: "77F5", source: "Agdistis" } window 30,30

--- a/ui/raidboss/data/06-ew/raid/p7s.txt
+++ b/ui/raidboss/data/06-ew/raid/p7s.txt
@@ -5,7 +5,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 13.0 "Spark of Life" Ability { id: "7839", source: "Agdistis" } window 50,50

--- a/ui/raidboss/data/06-ew/raid/p8n.txt
+++ b/ui/raidboss/data/06-ew/raid/p8n.txt
@@ -18,7 +18,7 @@ hideall "--sync--"
 # (cont.) --+                                         +-> Sunforge v2 -+
 #           +-> Gorgon v2 -> Vent v2 -> Quadruped v2 -+                +-> Gorgon v2 -> etc
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 7.0 "--sync--" StartsUsing { id: "7905", source: "Hephaistos" } window 10,10
@@ -35,6 +35,7 @@ hideall "--sync--"
 56.1 "Flameviper" Ability { id: "7908", source: "Hephaistos" }
 # jump to Quadruped v1 or Gorgon v1
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Quadruped v1 branch
 63.3 "--sync--" Ability { id: "7108", source: "Hephaistos" }
 68.5 "Reforged Reflection" Ability { id: "794B", source: "Hephaistos" } window 50,50 jump 168.5
@@ -49,7 +50,7 @@ hideall "--sync--"
 80.8 "Into the Shadows?" #Ability { id: "78FB", source: "Hephaistos" }
 88.8 "--sync--" #Ability { id: "78FC", source: "Gorgon" }
 89.9 "Petrifaction?" #Ability { id: "6723" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Quadruped v1 (Quadruped branch)
 163.3 "--sync--" Ability { id: "7108", source: "Hephaistos" }
@@ -152,6 +153,7 @@ hideall "--sync--"
 699.4 "Flameviper" Ability { id: "7908", source: "Hephaistos" }
 # jump to Quadruped v2 or Gorgon v2
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Quadruped v2 branch
 706.5 "--sync--" Ability { id: "7108", source: "Hephaistos" }
 711.7 "Reforged Reflection" Ability { id: "794B", source: "Hephaistos" } window 50,50 jump 811.7
@@ -166,7 +168,7 @@ hideall "--sync--"
 732.0 "--sync--" #Ability { id: "78FC", source: "Gorgon" }
 732.0 "Gorgospit?" #Ability { id: "6FD7", source: "Illusory Hephaistos" }
 732.0 "Volcanic Torches?" #Ability { id: "71DE", source: "Hephaistos" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 
 # Quadruped v2 (Quadruped2 branch)
@@ -282,6 +284,7 @@ hideall "--sync--"
 1353.6 "Scorching Fang/Sun\'s Pinion" Ability { id: ["78EE", "78EF"], source: "Hephaistos" }
 # jump to Quadruped v2 or Gorgon v2
 
+#cactbot-timeline-lint-disable-sync-order
 # -> Quadruped v2 branch
 1360.8 "--sync--" Ability { id: "7108", source: "Hephaistos" }
 1366.0 "Reforged Reflection" Ability { id: "794B", source: "Hephaistos" } window 50,50 jump 811.7
@@ -296,3 +299,4 @@ hideall "--sync--"
 1386.3 "--sync--" #Ability { id: "78FC", source: "Gorgon" }
 1386.3 "Gorgospit?" #Ability { id: "6FD7", source: "Illusory Hephaistos" }
 1386.3 "Volcanic Torches?" #Ability { id: "71DE", source: "Hephaistos" }
+#cactbot-timeline-lint-enable-sync-order

--- a/ui/raidboss/data/06-ew/raid/p8s.txt
+++ b/ui/raidboss/data/06-ew/raid/p8s.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 ### P8S Part 1
 # -p 7944:12.1
@@ -34,6 +34,7 @@ hideall "--sync--"
 58.7 "--sync--" #Ability { id: "7108", source: "Hephaistos" }
 63.9 "Reforged Reflection"
 
+#cactbot-timeline-lint-disable-sync-order
 # => Snake first branch
 58.7 "--sync--" #Ability { id: "7108", source: "Hephaistos" }
 63.9 "--sync--" Ability { id: "794C", source: "Hephaistos" } window 100,100 jump 163.9
@@ -49,7 +50,7 @@ hideall "--sync--"
 79.3 "Uplift 2?" #Ability { id: "7935", source: "Hephaistos" }
 81.5 "Uplift 3?" #Ability { id: "7935", source: "Hephaistos" }
 83.6 "Uplift 4?" #Ability { id: "7935", source: "Hephaistos" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Snake 1 (Snake first)
 158.7 "--sync--" Ability { id: "7108", source: "Hephaistos" }
@@ -314,8 +315,8 @@ hideall "--sync--"
 5091.7 "--auto--" #Ability { id: "72C2", source: "Hephaistos" }
 5094.8 "--auto--" #Ability { id: "72C2", source: "Hephaistos" }
 5101.9 "Tyrant's Unholy Darkness" Ability { id: "79DD", source: "Hephaistos" }
-5114.1 "--sync--" Ability { id: "79AC", source: "Hephaistos" }
 5106.9 "--auto--" #Ability { id: "72C2", source: "Hephaistos" }
+5114.1 "--sync--" Ability { id: "79AC", source: "Hephaistos" }
 5118.6 "High Concept 1" Ability { id: "710A", source: "Hephaistos" } window 20,20
 5118.6 "--untargetable--"
 5126.3 "Arcane Control" Ability { id: "79B6", source: "Hephaistos" }

--- a/ui/raidboss/data/06-ew/raid/p9n.txt
+++ b/ui/raidboss/data/06-ew/raid/p9n.txt
@@ -10,7 +10,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 7.0 "--sync--" Ability { id: "8115", source: "Kokytos" } window 10,10

--- a/ui/raidboss/data/06-ew/raid/p9s.txt
+++ b/ui/raidboss/data/06-ew/raid/p9s.txt
@@ -7,7 +7,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 7.2 "--sync--" StartsUsing { id: "814C", source: "Kokytos" } window 10,10

--- a/ui/raidboss/data/06-ew/trial/asura.txt
+++ b/ui/raidboss/data/06-ew/trial/asura.txt
@@ -6,7 +6,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 # Note that a number of "extra-wide" sync windows are present.
 # This is a future-proofing measure in case any timeline skips

--- a/ui/raidboss/data/06-ew/trial/barbariccia-ex.txt
+++ b/ui/raidboss/data/06-ew/trial/barbariccia-ex.txt
@@ -6,7 +6,7 @@ hideall "--Reset--"
 hideall "--sync--"
 hideall "Brush with Death"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 10.1 "--sync--" StartsUsing { id: "7570", source: "Barbariccia" } window 11,10

--- a/ui/raidboss/data/06-ew/trial/barbariccia.txt
+++ b/ui/raidboss/data/06-ew/trial/barbariccia.txt
@@ -7,7 +7,7 @@ hideall "--Reset--"
 hideall "--sync--"
 hideall "Brush with Death"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 
@@ -49,7 +49,7 @@ hideall "Brush with Death"
 
 # Phase Change
 219.5 "Curling Iron" Ability { id: "75B2", source: "Barbariccia" }
-225.3 "Voidstrom" Ability { id: "75BD", source: "Barbariccia" } window 10,10 duration 2
+225.3 "Voidstrom" Ability { id: "75BD", source: "Barbariccia" } duration 2 window 10,10
 230.3 "Catabasis" Ability { id: "75E3", source: "Barbariccia" }
 262.4 "Brutal Rush 1" Ability { id: "75C6", source: "Barbariccia" } window 5,5
 264.0 "Brutal Rush 2" #Ability { id: "75C6", source: "Barbariccia" }
@@ -171,4 +171,4 @@ hideall "Brush with Death"
 684.5 "Deadly Twist" Ability { id: "75DC", source: "Barbariccia" }
 690.6 "Boulder Break" Ability { id: "73CF", source: "Barbariccia" }
 690.7 "Knuckle Drum" Ability { id: "7597", source: "Barbariccia" }
-712.7 "Trample" Ability { id: "75DA", source: "Barbariccia" } jump 317.8 window 10,10
+712.7 "Trample" Ability { id: "75DA", source: "Barbariccia" } window 10,10 jump 317.8

--- a/ui/raidboss/data/06-ew/trial/endsinger-ex.txt
+++ b/ui/raidboss/data/06-ew/trial/endsinger-ex.txt
@@ -6,7 +6,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 7.0 "--sync--" StartsUsing { id: "6FF6", source: "The Endsinger" } window 10,10

--- a/ui/raidboss/data/06-ew/trial/endsinger.txt
+++ b/ui/raidboss/data/06-ew/trial/endsinger.txt
@@ -10,7 +10,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 # P1
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1

--- a/ui/raidboss/data/06-ew/trial/golbez-ex.txt
+++ b/ui/raidboss/data/06-ew/trial/golbez-ex.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 9.4 "--sync--" StartsUsing { id: "8464", source: "Golbez" } window 15,15
@@ -231,7 +231,7 @@ hideall "--sync--"
 1430.4 "Abyssal Quasar" Ability { id: "84AB", source: "Golbez" }
 1431.3 "Lingering Spark (cast)" Ability { id: "8468", source: "Golbez" }
 1435.4 "Lingering Spark (explode)" Ability { id: "846A", source: "Golbez" }
-1240.4 "Eventide Fall/Eventide Triad" Ability { id: "848[05]", source: "Golbez" }
+1440.4 "Eventide Fall/Eventide Triad" Ability { id: "848[05]", source: "Golbez" }
 
 1451.4 "Phases of the Shadow (front)" Ability { id: "86E7", source: "Golbez" }
 1453.2 "--sync--" Ability { id: "86E9", source: "Golbez" }

--- a/ui/raidboss/data/06-ew/trial/golbez.txt
+++ b/ui/raidboss/data/06-ew/trial/golbez.txt
@@ -28,7 +28,7 @@ hideall "--Reset--"
 hideall "--sync--"
 hideall "--middle--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 11.0 "--middle--" Ability { id: "84B8", source: "Golbez" } window 12,12
 25.2 "Terrastorm" Ability { id: "8465", source: "Golbez" }

--- a/ui/raidboss/data/06-ew/trial/hydaelyn-ex.txt
+++ b/ui/raidboss/data/06-ew/trial/hydaelyn-ex.txt
@@ -7,7 +7,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 11.0 "--sync--" StartsUsing { id: "65C1", source: "Hydaelyn" } window 15,15

--- a/ui/raidboss/data/06-ew/trial/hydaelyn.txt
+++ b/ui/raidboss/data/06-ew/trial/hydaelyn.txt
@@ -7,7 +7,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 # Phase 1
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
@@ -29,6 +29,7 @@ hideall "--sync--"
 114.1 "Dawn Mantle" Ability { id: "6C0C", source: "Hydaelyn" }
 # -> branch
 
+#cactbot-timeline-lint-disable-sync-order
 # Anthelion branch jump
 120.4 "Anthelion?" Ability { id: "65C8", source: "Hydaelyn" } window 30,30 jump 220.4
 129.5 "Mousa's Scorn?" #Ability { id: "65D6", source: "Hydaelyn" }
@@ -41,7 +42,7 @@ hideall "--sync--"
 # FIXME: are Dawn Mantle/Equinox times slightly different here or is that just one log?
 120.4 "Highest Holy?" Ability { id: "65C7", source: "Hydaelyn" } window 30,30 jump 320.4
 129.5 "Magos's Radiance?" #Ability { id: "65D8", source: "Hydaelyn" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 # Anthelion/Mousa's Scorn -> add phase
 220.4 "Anthelion" Ability { id: "65C8", source: "Hydaelyn" }
@@ -89,6 +90,7 @@ hideall "--sync--"
 1042.8 "Dawn Mantle" Ability { id: "6C0C", source: "Hydaelyn" }
 1052.0 "Crystalline Blizzard III" #Ability { id: "6C5A", source: "Hydaelyn" }
 
+#cactbot-timeline-lint-disable-sync-order
 # -> jump to Parhelic Circle first
 1049.1 "Highest Holy" Ability { id: "65C7", source: "Hydaelyn" } window 30,30 jump 2049.1
 1066.0 "Parhelic Circle?" Ability { id: "65AC", source: "Hydaelyn" }
@@ -97,7 +99,7 @@ hideall "--sync--"
 1049.1 "Anthelion" Ability { id: "65C8", source: "Hydaelyn" } window 30,30 jump 3049.1
 1064.3 "Mousa's Scorn?" #Ability { id: "65D6", source: "Hydaelyn" }
 1075.0 "Parhelion?" #Ability { id: "65B0", source: "Hydaelyn" }
-
+#cactbot-timeline-lint-enable-sync-order
 
 ### Parhelic Circle first
 2034.8 "Crystallize" Ability { id: "659C", source: "Hydaelyn" }
@@ -205,4 +207,3 @@ hideall "--sync--"
 3284.7 "Dawn Mantle" #Ability { id: "6C0C", source: "Hydaelyn" }
 3291.0 "Highest Holy/Anthelion/Equinox" #Ability { id: ["65C3", "65C7", "65C8"], source: "Hydaelyn" }
 3293.9 "Crystalline Blizzard III/Crystalline Stone III" #Ability { id: ["6C5A", "6C59"], source: "Hydaelyn" }
-

--- a/ui/raidboss/data/06-ew/trial/rubicante-ex.txt
+++ b/ui/raidboss/data/06-ew/trial/rubicante-ex.txt
@@ -8,7 +8,7 @@ hideall "--Reset--"
 hideall "--sync--"
 hideall "Infernal Slaughter"
 
-0.0 "--Reset--" ActorControl { command: "40000010" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "40000010" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 7.0 "--sync--" StartsUsing { id: "7D2C", source: "Rubicante" } window 10,20

--- a/ui/raidboss/data/06-ew/trial/rubicante.txt
+++ b/ui/raidboss/data/06-ew/trial/rubicante.txt
@@ -9,7 +9,7 @@ hideall "--sync--"
 hideall "Arcane Revelation"
 hideall "Infernal Slaughter"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 7.0 "--sync--" StartsUsing { id: "7CEA", source: "Rubicante" } window 10,10
@@ -54,7 +54,7 @@ hideall "Infernal Slaughter"
 1022.2 "Shattering Heat" Ability { id: "7CD5", source: "Flamesent" }
 
 # Phase 2 (Flamerake & Sweeping Immolation)
-1986.4 "--sync--"  StartsUsing { id: "7CD2", source: "Rubicante" } window 1000,0
+1986.4 "--sync--" StartsUsing { id: "7CD2", source: "Rubicante" } window 1000,0
 1986.4 "--targetable--"
 2000.0 "Blazing Rapture" Ability { id: "7CD2", source: "Rubicante" }
 2013.4 "--untargetable--"

--- a/ui/raidboss/data/06-ew/trial/sephirot-un.txt
+++ b/ui/raidboss/data/06-ew/trial/sephirot-un.txt
@@ -5,7 +5,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 7.1 "Triple Trial" Ability { id: "7693", source: "Sephirot" } window 7.1,5

--- a/ui/raidboss/data/06-ew/trial/sophia-un.txt
+++ b/ui/raidboss/data/06-ew/trial/sophia-un.txt
@@ -23,7 +23,7 @@ hideall "--sync--"
 41.4 "Arms Of Wisdom?" Ability { id: "7DBE", source: "Sophia" } # May be skipped depending on DPS
 
 # This section will be reached either at 56.0, or at the time she is pushed to 90%
-56.0 "--clones appear--" AddedCombatant { name: "Aion Teleos" }  window 56,5
+56.0 "--clones appear--" AddedCombatant { name: "Aion Teleos" } window 56,5
 63.6 "Thunder II/III" Ability { id: ["7DA6", "7DAA"], source: "Sophia" }
 63.6 "--sync--" Ability { id: "7DA5", source: "Aion Teleos" } window 30,2.5
 69.7 "Aero III" Ability { id: "7DA8", source: "Sophia" }
@@ -69,7 +69,7 @@ hideall "--sync--"
 361.5 "Dischordant Cleansing" # Ability { id: ["7DAD", "7DAF"], source: "Sophia" }
 361.5 "Cintamani x2" duration 3 # Ability { id: "7DBF", source: "Sophia" }
 370.8 "Arms Of Wisdom" Ability { id: "7DBE", source: "Sophia" } window 30,5
-379.0 "--clones appear--" AddedCombatant { name: "Aion Teleos" }  window 60,20
+379.0 "--clones appear--" AddedCombatant { name: "Aion Teleos" } window 60,20
 382.0 "Cintamani x3" duration 6 # Ability { id: "7DBF", source: "Sophia" }
 393.3 "--sync--" Ability { id: "7DA5", source: "Aion Teleos" }
 393.3 "Thunder II/III" Ability { id: ["7DA6", "7DAA"], source: "Sophia" }
@@ -104,8 +104,8 @@ hideall "--sync--"
 567.0 "Quasar Tethers" Ability { id: "7D9B", source: "Sophia" }
 568.3 "Dischordant Cleansing" # Ability { id: ["7DAD", "7DAF"], source: "Sophia" }
 575.7 "Quasar (Tilt)" # Ability { id: "7E46", source: "Sophia" }
+577.5 "--clones appear--" AddedCombatant { name: "Aion Teleos" } window 60,5
 581.5 "Cintamani x3" duration 6 # Ability { id: "7DBF", source: "Sophia" }
-577.5 "--clones appear--" AddedCombatant { name: "Aion Teleos" }  window 60,5
 592.8 "Arms Of Wisdom" Ability { id: "7DBE", source: "Sophia" }
 599.9 "--sync--" Ability { id: "7DA5", source: "Aion Teleos" } window 10,2.5
 599.9 "Thunder II/III" Ability { id: ["7DA6", "7DAA"], source: "Sophia" }

--- a/ui/raidboss/data/06-ew/trial/ultima-un.txt
+++ b/ui/raidboss/data/06-ew/trial/ultima-un.txt
@@ -5,7 +5,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 
@@ -169,9 +169,12 @@ hideall "--sync--"
 667.3 "Ceruleum Vent" Ability { id: "6EEF", source: "The Ultima Weapon" }
 670.7 "Viscous Aetheroplasm?" #Ability { id: "6EEE", source: "The Ultima Weapon" }
 
+#cactbot-timeline-lint-disable-sync-order
 # From here, the late Cyclone/EruptionHoming Lasers blocks are added.
 669.9 "--sync--" StartsUsing { id: "6F00", source: "The Ultima Weapon" } window 15,15 jump 697.3 # Radiant Plume
 671.0 "--sync--" StartsUsing { id: "6F03", source: "The Ultima Weapon" } window 15,15 jump 797.3 # Eruption
+#cactbot-timeline-lint-enable-sync-order
+
 672.6 "Radiant Plume?"
 673.7 "Eruption x5?"
 675.4 "Crimson Cyclone?"

--- a/ui/raidboss/data/06-ew/trial/zodiark-ex.txt
+++ b/ui/raidboss/data/06-ew/trial/zodiark-ex.txt
@@ -8,7 +8,7 @@ hideall "Triple Esoteric Ray"
 hideall "Infernal Stream"
 hideall "Infernal Torrent"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 10.8 "Kokytos" Ability { id: "6C60", source: "Zodiark" } window 11.3,5

--- a/ui/raidboss/data/06-ew/trial/zodiark.txt
+++ b/ui/raidboss/data/06-ew/trial/zodiark.txt
@@ -16,7 +16,7 @@ hideall "Triple Esoteric Ray"
 # Note: Opheos Eidolon sometimes comes from Zodiark/Behemoth and not Python,
 # maybe a race condition in FFXIV ACT Plugin?
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 7.1 "--sync--" StartsUsing { id: "6C27", source: "Zodiark" } window 10,10

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.txt
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.txt
@@ -9,7 +9,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 ### Phase 1: Adelphel, Grinnaux and Charibert
 
@@ -251,9 +251,9 @@ hideall "--sync--"
 3050.1 "Cauterize" Ability { id: "6B8D", source: "Darkscale" }
 3050.2 "Altar Flare 3" #Ability { id: "63E5", source: "Ser Charibert" }
 3050.3 "Empty Dimension" Ability { id: "62DA", source: "Ser Grinnaux" }
+3051.4 "--targetable--"
 3051.7 "Altar Flare 4" #Ability { id: "63E5", source: "Ser Charibert" }
 
-3051.4 "--targetable--"
 3057.4 "Ancient Quaga" Ability { id: "63C6", source: "King Thordan" }
 3067.8 "Heavenly Heel" Ability { id: "63C7", source: "King Thordan" }
 3071.0 "Ascalon's Might 1" #Ability { id: "63C5", source: "King Thordan" }

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
@@ -6,7 +6,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 100000 jump 0
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 ### P1: Beetle
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
@@ -216,11 +216,11 @@ hideall "--sync--"
 824.7 "--untargetable--"
 
 839.0 "Subject Simulation F" Ability { id: "7F2F", source: "Omega-M" }
-840.4 "Program Loop" Ability { id: "7B98", source: "Omega" }
 840.0 "--sync--" Ability { id: "7B14", source: "Omega-M" }
+840.4 "Program Loop" Ability { id: "7B98", source: "Omega" }
 841.1 "--sync--" Ability { id: "7B16", source: "Omega-M" }
-844.0 "Wave Cannon" Ability { id: "7B73", source: "Omega" }
 843.8 "Hyper Pulse" Ability { id: "7B72", source: "Right Arm Unit" }
+844.0 "Wave Cannon" Ability { id: "7B73", source: "Omega" }
 845.1 "--sync--" Ability { id: "7F30", source: "Omega-M" }
 848.7 "--sync--" Ability { id: "7B15", source: "Omega" }
 849.3 "--sync--" Ability { id: "7B20", source: "Omega-M" }

--- a/ui/raidboss/timeline_parser.ts
+++ b/ui/raidboss/timeline_parser.ts
@@ -15,6 +15,14 @@ import { LooseTimelineTrigger, TriggerAutoConfig } from '../../types/trigger';
 
 import defaultOptions, { RaidbossOptions, TimelineConfig } from './raidboss_options';
 
+// syncKeywords must appear on a sync line in the order specified
+const syncKewordsOrder = [
+  'duration',
+  'window',
+  'jump',
+  'forcejump',
+];
+
 const isLogDefinitionTypes = (type: string): type is LogDefinitionTypes => {
   return type in logDefinitions;
 };
@@ -185,6 +193,10 @@ export class TimelineParser {
   private labelToTime: { [name: string]: number } = {};
   // Map of encountered syncs to the label they are jumping to.
   private labelToSync: { [name: string]: Sync[] } = {};
+  // Run linting checks while parsing timeline file
+  private runLint = false;
+  private lastSyncTime = 0;
+  private ignoreSyncOrder = false;
 
   constructor(
     text: string,
@@ -193,10 +205,12 @@ export class TimelineParser {
     styles?: TimelineStyle[],
     options?: RaidbossOptions,
     zoneId?: number,
+    runLint?: boolean,
   ) {
     this.options = options ?? defaultOptions;
     this.perTriggerAutoConfig = this.options.PerTriggerAutoConfig;
     this.replacements = replacements;
+    this.runLint = runLint ?? false;
 
     this.timelineConfig = typeof zoneId === 'number'
       ? this.options.PerZoneTimelineConfig[zoneId] ?? {}
@@ -240,10 +254,20 @@ export class TimelineParser {
     for (let line of lines) {
       ++lineNumber;
       line = line.trim();
+
+      // before ignoring comments, check if it's a lint override instruction
+      if (line.includes('#cactbot-timeline-lint-disable-sync-order'))
+        this.ignoreSyncOrder = true;
+      else if (line.includes('#cactbot-timeline-lint-enable-sync-order'))
+        this.ignoreSyncOrder = false;
+
       // Drop comments and empty lines.
       if (!line || regexes.comment.test(line))
         continue;
       const originalLine = line;
+
+      if (this.runLint)
+        this.checkForLint(line, lineNumber);
 
       let match = regexes.ignore.exec(line);
       if (match && match['groups']) {
@@ -735,5 +759,167 @@ export class TimelineParser {
     });
 
     return translatedLines;
+  }
+
+  private checkForLint(
+    line: string,
+    lineNumber: number,
+  ): void {
+    // First, reduce all double-quoted strings to just "".  We don't check/lint string contents,
+    // and this avoids various problems like inadvertently matching double-spaces inside a string,
+    // or the use of a {} regex occurence modifier causing errors in identifying line groups.
+    line = line.replace(/"[^"]*?"/g, '""');
+
+    if (line.trim() !== line) {
+      this.errors.push({
+        lineNumber: lineNumber,
+        error: 'Line has leading or trailing whitespace',
+      });
+    }
+
+    // Remove in-line comments from further lint checks
+    // full comment lines are already ignored before parse() calls this func
+    line = line.replace(/#.*$/, '').trim();
+    if (line.length === 0)
+      return;
+
+    // There should be no remaining allowable double-spacing within the line
+    if (line.match(/ {2}.+/)) {
+      this.errors.push({
+        lineNumber: lineNumber,
+        error: 'Line has double spaces',
+      });
+    }
+
+    // Capture each part of the line (separated by spaces).
+    // Anything encapsulated by double-quotes or braces will be treated as a single element.
+    const lineParts = line.match(/"[^"]*"|\{[^}]*\}|[^ ]+/g);
+    if (lineParts === null || lineParts[0] === undefined) {
+      this.errors.push({
+        lineNumber: lineNumber,
+        error: 'Not a valid timeline entry.  Cannot continue linting.',
+      });
+      return;
+    }
+
+    const first = lineParts[0];
+    if (first === 'hideall') {
+      // parse() throws errors if a hideall line has an invalid format
+      return;
+    }
+
+    // At this point, if `first` is not a time, it's not a valid timeline entry
+    const time = parseFloat(first);
+    if (isNaN(time)) {
+      this.errors.push({
+        lineNumber: lineNumber,
+        error: 'Not a valid config entry, comment, or timeline entry',
+      });
+      return;
+    }
+
+    // Ensure that the time is either an integer or has a single digit after the decimal
+    if (!Number.isInteger(time) && !/^\d+\.\d$/.test(time.toString())) {
+      this.errors.push({
+        lineNumber: lineNumber,
+        error: 'Sync time must be an integer or have one decimal place',
+      });
+    }
+
+    // Enforce chronological order of sync lines
+    if (!this.ignoreSyncOrder) {
+      if (time < this.lastSyncTime)
+        this.errors.push({
+          lineNumber: lineNumber,
+          error:
+            `Misordered entry: sync time of ${time.toString()} (prior entry: ${this.lastSyncTime.toString()})`,
+        });
+      this.lastSyncTime = time;
+    }
+
+    const second = lineParts[1];
+    if (second === undefined) {
+      this.errors.push({
+        lineNumber: lineNumber,
+        error: 'Sync time specified with no other parameters',
+      });
+      return;
+    }
+    // parse() throws errors if the label line is invalidly formatted.
+    if (second === 'label')
+      return;
+
+    // This is a normal timeline entry
+
+    // Some entries may only have a time and name with nothing else.
+    // They may also have a duration keyword (and only that keyword).
+    // parse() throws errors if a no-sync line has invalid args
+    if (lineParts.length === 2)
+      return;
+    else if (lineParts[2] === 'duration' && lineParts.length === 4)
+      return;
+
+    // From this point, we should expect [time] [name] [type] [NetRegex]
+    // parse() throws errors if that's not the case
+    // So just check keyword ordering (everything after), and 'window' format.
+    const keywords = lineParts.slice(4);
+    if (keywords.length === 0)
+      return;
+
+    const keywordList = keywords.filter((_, i) => i % 2 === 0);
+    for (let i = 0; i < keywordList.length - 1; i++) {
+      const thisKeyword = keywordList[i];
+      if (thisKeyword === undefined)
+        throw new UnreachableCode();
+
+      if (!syncKewordsOrder.includes(thisKeyword)) {
+        this.errors.push({
+          lineNumber: lineNumber,
+          error: `Found invalid keyword: ${thisKeyword}`,
+        });
+        return;
+      }
+
+      // check that `window` is in a [number],[number] format
+      if (thisKeyword === 'window') {
+        const windowKwIdx = keywords.indexOf('window');
+        const windowArgs = keywords[windowKwIdx + 1];
+        if (windowArgs === undefined) {
+          this.errors.push({
+            lineNumber: lineNumber,
+            error: `Invalid parameter for 'window' keyword`,
+          });
+          return;
+        }
+        if (!/^\d+(\.\d)?,\d+(\.\d)?$/.test(windowArgs)) {
+          this.errors.push({
+            lineNumber: lineNumber,
+            error: `Invalid 'window' (${windowArgs}): must be in [number],[number] format.`,
+          });
+          return;
+        }
+      }
+
+      const nextKeyword = keywordList[i + 1];
+      if (nextKeyword === undefined)
+        break;
+
+      if (!syncKewordsOrder.includes(nextKeyword)) {
+        this.errors.push({
+          lineNumber: lineNumber,
+          error: `Cannot check keyword order - found invalid next keyword: ${nextKeyword}`,
+        });
+        return;
+      }
+
+      if (syncKewordsOrder.indexOf(thisKeyword) > syncKewordsOrder.indexOf(nextKeyword)) {
+        this.errors.push({
+          lineNumber: lineNumber,
+          error: `Improper keyword order: ${nextKeyword} must precede ${thisKeyword}`,
+        });
+        return;
+      }
+    }
+    return;
   }
 }

--- a/ui/raidboss/timeline_parser.ts
+++ b/ui/raidboss/timeline_parser.ts
@@ -195,7 +195,9 @@ export class TimelineParser {
   private labelToSync: { [name: string]: Sync[] } = {};
   // Run linting checks while parsing timeline file
   private runLint = false;
+  // Track the last sync time during linting to ensure proper order
   private lastSyncTime = 0;
+  // Override to stop checking sync order during linting
   private ignoreSyncOrder = false;
 
   constructor(
@@ -860,7 +862,6 @@ export class TimelineParser {
       return;
 
     // From this point, we should expect [time] [name] [type] [NetRegex]
-    // parse() throws errors if that's not the case
     // So just check keyword ordering (everything after), and 'window' format.
     const keywords = lineParts.slice(4);
     if (keywords.length === 0)


### PR DESCRIPTION
Per discussion in #96 and with @JLGarber , this adds some timeline linting to `mocha` (which necessitated actually fixing the lint.... and there was a *lot*).

Sorry for the sheer volume of files changed, but the vast majority are just one or a couple of lines with routine changes like excess whitespace removal, reordering syncs that were out of order, removing duplicates, fixing a few obvious typos, etc.  There were, however, a couple of Omega timelines that had branching/jumps that were out of sync with our current practice, so I revised them to be in chron order rather than just ignoring sync order for the whole file.

The scope of the linting is covered in the updated `TImelineGuide.md`, but at a high level, the major changes are:
- Enforcing all syncs to be in chronological order.
  -   Note: this can be disabled for a particular block of entries by using `#cactbot-timeline-lint-disable-sync-order`, followed by `#cactbot-timeline-lint-enable-sync-order`.  This should ideally be limited to situations where the timeline includes branching with some fake lookaheads -- basically, where it's easier for readability to have a couple blocks of overlapping times.
- Requiring keywords (`duration`, `window`, etc.) to come after the `[LogLine]` and `NetRegex` values on sync lines.
- Requiring keywords (if used) to be in the following order: `duration`, `window`, `jump`/`forcejump`.
- Requiring any use of `window` to specify both a lookbehind and lookahead (e.g. `[number],[number]`), rather than just a single param as was often done previously.

Comments/feedback welcome.