### PR TITLE
util: refactor/automate log splitter (1 of 3)

### DIFF
--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -1568,9 +1568,6 @@ const latestLogDefinitions = {
   },
 } as const;
 
-// TODO: There doesn't seem to be a strong need to have this const or the related type, as
-// we only maintain one set of log definitiions at a time.  Along with the TODO below, this
-// could probably be cleaned up in a future PR.
 export const logDefinitionsVersions = {
   'latest': latestLogDefinitions,
 } as const;

--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -1561,6 +1561,10 @@ const latestLogDefinitions = {
     },
     canAnonymize: true,
     firstOptionalField: undefined,
+    analysisOptions: {
+      include: 'all',
+      combatantIdFields: 2,
+    },
   },
 } as const;
 

--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -58,7 +58,7 @@ export type LogDefinition = {
     // Netregex-style filter criteria; log lines satisfying at least one filter will be included.
     // If `includeforAnalysis`='filter', this prop must be present; otherwise, it must be omitted.
     analysisFilter?: NetParams[K] | readonly NetParams[K][];
-    // Indexes with combatantIds that will be checked for ignored NPCs in the log analysis filter.
+    // Indexes with combatantIds that will be checked for ignored NPCs during analysis filtering.
     // Only valid if `includeForAnalysis` is 'filter' or 'all'.
     filterCombatantIdFields?: number | readonly number[];
   };
@@ -166,7 +166,7 @@ const latestLogDefinitions = {
     lastInclude: true,
     canAnonymize: true,
     firstOptionalField: undefined,
-    includeForAnalysis: 'none',
+    includeForAnalysis: 'all',
   },
   ChangedPlayer: {
     type: '02',
@@ -381,7 +381,7 @@ const latestLogDefinitions = {
     firstOptionalField: undefined,
     includeForAnalysis: 'filter',
     analysisFilter: { sourceId: '4.{7}' }, // NPC casts only
-    filterCombatantIdFields: 2,
+    filterCombatantIdFields: [2, 6],
   },
   Ability: {
     type: '21',
@@ -433,7 +433,7 @@ const latestLogDefinitions = {
     firstOptionalField: undefined,
     includeForAnalysis: 'filter',
     analysisFilter: { sourceId: '4.{7}' }, // NPC abilities only
-    filterCombatantIdFields: 2,
+    filterCombatantIdFields: [2, 6],
   },
   NetworkAOEAbility: {
     type: '22',
@@ -485,7 +485,7 @@ const latestLogDefinitions = {
     firstOptionalField: undefined,
     includeForAnalysis: 'filter',
     analysisFilter: { sourceId: '4.{7}' }, // NPC abilities only
-    filterCombatantIdFields: 2,
+    filterCombatantIdFields: [2, 6],
   },
   NetworkCancelAbility: {
     type: '23',
@@ -613,7 +613,7 @@ const latestLogDefinitions = {
         effectId: ['B9A', '808'], // known effectIds of interest
       },
     ],
-    filterCombatantIdFields: 5,
+    filterCombatantIdFields: [5, 7],
   },
   HeadMarker: {
     type: '27',
@@ -702,7 +702,18 @@ const latestLogDefinitions = {
     },
     canAnonymize: true,
     firstOptionalField: undefined,
-    includeForAnalysis: 'none', // BUG: Fixed in next commit
+    includeForAnalysis: 'filter',
+    analysisFilter: [
+      // effect from environment/NPC applied to player
+      {
+        sourceId: '[E4].{7}',
+        targetId: '1.{7}',
+      },
+      {
+        effectId: ['B9A', '808'], // known effectIds of interest
+      },
+    ],
+    filterCombatantIdFields: [5, 7],
   },
   NetworkGauge: {
     type: '31',
@@ -804,6 +815,7 @@ const latestLogDefinitions = {
     firstUnknownField: 9,
     firstOptionalField: undefined,
     includeForAnalysis: 'all',
+    filterCombatantIdFields: [2, 4],
   },
   LimitBreak: {
     type: '36',
@@ -931,7 +943,7 @@ const latestLogDefinitions = {
     canAnonymize: true,
     firstOptionalField: undefined,
     lastInclude: true,
-    includeForAnalysis: 'none',
+    includeForAnalysis: 'all',
   },
   SystemLogMessage: {
     type: '41',
@@ -949,7 +961,7 @@ const latestLogDefinitions = {
     },
     canAnonymize: true,
     firstOptionalField: undefined,
-    includeForAnalysis: 'none',
+    includeForAnalysis: 'all',
   },
   StatusList3: {
     type: '42',
@@ -1168,7 +1180,7 @@ const latestLogDefinitions = {
     },
     canAnonymize: true,
     firstOptionalField: undefined,
-    includeForAnalysis: 'none',
+    includeForAnalysis: 'all',
   },
   CombatantMemory: {
     type: '261',
@@ -1198,7 +1210,27 @@ const latestLogDefinitions = {
       primaryKey: 'key',
       possibleKeys: combatantMemoryKeys,
     },
-    includeForAnalysis: 'none',
+    includeForAnalysis: 'filter',
+    // TODO: This is an initial attempt to capture field changes that are relevant to analysis,
+    // but this will likely need to be refined over time
+    analysisFilter: [
+      {
+        id: '4.{7}',
+        type: 'Change',
+        pair: [{ key: 'ModelStatus', value: '.*' }],
+      },
+      {
+        id: '4.{7}',
+        type: 'Change',
+        pair: [{ key: 'WeaponId', value: '.*' }],
+      },
+      {
+        id: '4.{7}',
+        type: 'Change',
+        pair: [{ key: 'TransformationId', value: '.*' }],
+      },
+    ],
+    filterCombatantIdFields: 3,
   },
   RSVData: {
     type: '262',
@@ -1300,6 +1332,7 @@ const latestLogDefinitions = {
     canAnonymize: true,
     firstOptionalField: undefined,
     includeForAnalysis: 'all',
+    filterCombatantIdFields: 2,
   },
   BattleTalk2: {
     type: '267',
@@ -1322,6 +1355,7 @@ const latestLogDefinitions = {
     canAnonymize: true,
     firstOptionalField: undefined,
     includeForAnalysis: 'all',
+    filterCombatantIdFields: 2,
   },
   Countdown: {
     type: '268',
@@ -1408,6 +1442,7 @@ const latestLogDefinitions = {
     canAnonymize: true,
     firstOptionalField: undefined,
     includeForAnalysis: 'all',
+    filterCombatantIdFields: 2,
   },
   SpawnNpcExtra: {
     type: '272',
@@ -1428,6 +1463,7 @@ const latestLogDefinitions = {
     canAnonymize: true,
     firstOptionalField: undefined,
     includeForAnalysis: 'all',
+    filterCombatantIdFields: 2,
   },
   ActorControlExtra: {
     type: '273',
@@ -1450,6 +1486,7 @@ const latestLogDefinitions = {
     canAnonymize: true,
     firstOptionalField: undefined,
     includeForAnalysis: 'all',
+    filterCombatantIdFields: 2,
   },
   ActorControlSelfExtra: {
     type: '274',
@@ -1488,24 +1525,22 @@ console.assert(assertLogDefinitions);
 // no filter is present. Also verify that combatantId filters are set only for 'filter' or 'all'.
 type LogDefinitionWithFilters = {
   [K in LogDefinitionTypes]: typeof latestLogDefinitions[K]['includeForAnalysis'] extends 'filter'
-  ? {
-    includeForAnalysis: 'filter';
-    analysisFilter: NetParams[K] | readonly NetParams[K][];
-    filterCombatantIdFields?: number | readonly number[];
-  }
-  : typeof latestLogDefinitions[K]['includeForAnalysis'] extends 'all'
-  ? {
-    includeForAnalysis: 'all';
-    filterCombatantIdFields?: number | readonly number[];
-    analysisFilter?: undefined;
-  }
-  : typeof latestLogDefinitions[K]['includeForAnalysis'] extends 'none' | 'never'
-  ? {
-    includeForAnalysis: 'none' | 'never';
-    analysisFilter?: undefined;
-    filterCombatantIdFields?: undefined;
-  }
-  : never;
+    ? {
+      includeForAnalysis: 'filter';
+      analysisFilter: NetParams[K] | readonly NetParams[K][];
+      filterCombatantIdFields?: number | readonly number[];
+    }
+    : typeof latestLogDefinitions[K]['includeForAnalysis'] extends 'all' ? {
+        includeForAnalysis: 'all';
+        filterCombatantIdFields?: number | readonly number[];
+        analysisFilter?: undefined;
+      }
+    : typeof latestLogDefinitions[K]['includeForAnalysis'] extends 'none' | 'never' ? {
+        includeForAnalysis: 'none' | 'never';
+        analysisFilter?: undefined;
+        filterCombatantIdFields?: undefined;
+      }
+    : never;
 };
 const assertLogDefinitionsWithFilters: LogDefinitionWithFilters = latestLogDefinitions;
 console.assert(assertLogDefinitionsWithFilters);

--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -127,7 +127,7 @@ type RepeatingFieldsMapType<
 > = T extends RepeatingFieldsTypes ? RepeatingFieldsMapTypeCheck<T, F>
   : never;
 
-export type ParseHelperType<T extends LogDefinitionTypes> =
+type ParseHelperType<T extends LogDefinitionTypes> =
   & {
     [field in keyof NetFields[T]]?: string | readonly string[] | RepeatingFieldsMapType<T, field>;
   }

--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -127,7 +127,7 @@ type RepeatingFieldsMapType<
 > = T extends RepeatingFieldsTypes ? RepeatingFieldsMapTypeCheck<T, F>
   : never;
 
-type ParseHelperType<T extends LogDefinitionTypes> =
+export type ParseHelperType<T extends LogDefinitionTypes> =
   & {
     [field in keyof NetFields[T]]?: string | readonly string[] | RepeatingFieldsMapType<T, field>;
   }


### PR DESCRIPTION
This is a start on #94.  The approach I'm taking is outlined there, with one change -- instead of using a separate file (`used_log_types`) to track which line types should pass the filter, this adds relevant props directly to `netlog_defs`, and the splitter parses its ruleset from there.  (I also added some typing enforcement.)  I think this is a better approach, given that we already have a number of props there related to anonymizing.

To help with reviewability, I'm breaking this into three 3 PRs:

1. This one - which adds the filter props to `netlog_defs` and refactors `splitter`.
    - `8bb1ee5` is intended to have parity with current functionality, e.g., you should be able to run a log through the live splitter and a local version based on this commit and see exactly the same output.  Should help validate the refactoring changes.
    - `87f9b47` updates some of the filtering criteria and fixes a couple bugs.  This will give different output than the current live version, but the changes should be smaller and easier to review/comment on.  Very open to feedback on these changes.
    
2. Add a workflow + script that will run on merged commits to `main`, checking all raidboss triggers/timelines and updating netlog_defs (specifically, setting `analysisOptions.include` to `all`) if new trigger types are found.  Any changes will be committed to a new branch and a PR auto-opened for review (which any contributor can modify before merging -- e.g., if filters should be applied, or if it should just be set to `never` and the script should ignore it going forward.)

3. Add unit testing to ensure that `splitter` is correctly filtering log lines based on the `netlog_defs` criteria.  (I'm still noodling on the best way to implement this -- whether to just have a dummy log that it parses and compares against `splitter`, or whether to grab the example log lines from `LogGuide`, add a few more, and use those, or whether to do something else entirely.  Open to suggestions on that.  But I'm not locked on an approach yet, so saving that for last.)

(Also closes #93.  To filter the large volume of 0x105 lines, the analysis filter will only capture an NPC with a changed WeaponId, ModelStatus, or TransformationId.  Open to adjusting this now or in the future, but this seemed like a reasonable way to grab things that are used now/likely of interest without opening the floodgates.)