### PR TITLE
ci: add check for "point-zero" timeline lint

### DIFF
--- a/test/helper/test_timeline.ts
+++ b/test/helper/test_timeline.ts
@@ -46,12 +46,17 @@ class TimelineParserLint extends TimelineParser {
   private ignoreSyncOrder = false;
   // Capture lint errors separately from TimelineParser's errors so we can do a separate unit test
   public lintErrors: LintError[] = [];
+  // TEMPORARY: To control scpe of linting & file changes; will remove in future PR
+  public _CURR_FILE = '';
+  private _EXPAC_FILTER = ['05-shb', '06-ew'];
 
   constructor(
     text: string,
     triggers: LooseTimelineTrigger[],
+    filename: string, // TEMPORARY: Remove when all files are linted
   ) {
     super(text, [], triggers); // calls TimelineParser's parse() method
+    this._CURR_FILE = filename; // TEMPORARY: Remove when all files are linted
     this.lintTimelineFile(text);
   }
 
@@ -196,6 +201,10 @@ class TimelineParserLint extends TimelineParser {
       const thisKeyword = keywords[i];
       if (thisKeyword === undefined)
         throw new UnreachableCode();
+
+      // TEMPORARY: Remove when all files are linted
+      if (!this._EXPAC_FILTER.some((e) => this._CURR_FILE.includes(e)))
+        return;
 
       if (!syncKewordsOrder.includes(thisKeyword)) {
         this.lintErrors.push({
@@ -410,6 +419,7 @@ const testTimelineFiles = (timelineFiles: string[]): void => {
           timeline = new TimelineParserLint(
             timelineText,
             triggerSet.timelineTriggers ?? [],
+            timelineFile, // TEMPORARY: Remove when all files are linted
           );
         });
         // This test loads an individual raidboss timeline and makes sure

--- a/ui/raidboss/data/03-hw/trial/sophia-ex.txt
+++ b/ui/raidboss/data/03-hw/trial/sophia-ex.txt
@@ -30,7 +30,7 @@ hideall "--sync--"
 # Intermission.
 # Divine Spark can be pushed and thus is not synced.
 # Gnostic Rant and Infusion are purely HP-based pushes.
-110.6 "Cloudy Heavens" Ability { id: "19BE", source: "Sophia" } window 110.6
+110.6 "Cloudy Heavens" Ability { id: "19BE", source: "Sophia" } window 110.6,0
 111.6 "--untargetable--"
 111.6 "--adds spawn--"
 120.9 "Horizontal Kenoma/Vertical Kenoma" Ability { id: ["19BB", "19BC"], source: "The First Demiurge" }

--- a/ui/raidboss/data/03-hw/trial/zurvan-ex.txt
+++ b/ui/raidboss/data/03-hw/trial/zurvan-ex.txt
@@ -41,7 +41,7 @@ hideall "--sync--"
 95.3 "Metal Cutter" Ability { id: "1C70", source: "Zurvan" }
 102.4 "Wave Cannon (avoid)" Ability { id: "1C73", source: "Zurvan" }
 
-108.5 "Metal Cutter" Ability { id: "1C70", source: "Zurvan" } jump 80.0
+108.5 "Metal Cutter" Ability { id: "1C70", source: "Zurvan" } jump 80
 113.6 "Metal Cutter"
 118.7 "Metal Cutter"
 123.8 "Metal Cutter"

--- a/ui/raidboss/data/05-shb/alliance/the_puppets_bunker.txt
+++ b/ui/raidboss/data/05-shb/alliance/the_puppets_bunker.txt
@@ -121,7 +121,7 @@ hideall "--sync--"
 
 1103.7 "Maneuver: Long-Barreled Laser" Ability { id: "5212", source: "Light Artillery Unit" }
 1119.6 "Maneuver: Volt Array" Ability { id: "5211", source: "Light Artillery Unit" }
-1129.9 "Authorization: No Restrictions" Ability { id: "520E", source: "Light Artillery Unit" } window 50,50 jump 1036.0
+1129.9 "Authorization: No Restrictions" Ability { id: "520E", source: "Light Artillery Unit" } window 50,50 jump 1036
 1135.6 "Surface Missile Impact" #Ability { id: "520F", source: "Light Artillery Unit" }
 1137.6 "Homing Missile Impact" #Ability { id: "5210", source: "Light Artillery Unit" }
 1153.7 "Initiate Self-Destruct" #Ability { id: "5215", source: "Light Artillery Unit" }

--- a/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.txt
+++ b/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.txt
@@ -344,7 +344,7 @@ hideall "--sync--"
 4780.7 "Cruelty" Ability { id: "6013", source: "Red Girl" }
 
 # loop
-4788.8 "Generate: Barrier" Ability { id: "6005", source: "Red Girl" } window 100,100 jump 4581.0
+4788.8 "Generate: Barrier" Ability { id: "6005", source: "Red Girl" } window 100,100 jump 4581
 4798.9 "Point: Black" #Ability { id: "6020", source: "Black Lance" }
 4798.9 "Point: White" #Ability { id: "601F", source: "White Lance" }
 4805.0 "Generate: Barrier" #Ability { id: "6005", source: "Red Girl" }

--- a/ui/raidboss/data/05-shb/dungeon/heroes_gauntlet.txt
+++ b/ui/raidboss/data/05-shb/dungeon/heroes_gauntlet.txt
@@ -37,7 +37,7 @@ hideall "--sync--"
 141.0 "Coward's Cunning" Ability { id: "4FD7", source: "Chicken Knife" }
 145.6 "Spectral Gust" Ability { id: "53CF", source: "Spectral Thief" }
 
-148.8 "Papercutter" Ability { id: "4FD[12]", source: "Spectral Thief" } jump 69.0
+148.8 "Papercutter" Ability { id: "4FD[12]", source: "Spectral Thief" } jump 69
 163.0 "Spectral Dream"
 168.2 "Chicken Knife"
 175.3 "Shadowdash"

--- a/ui/raidboss/data/05-shb/eureka/bozjan_southern_front.txt
+++ b/ui/raidboss/data/05-shb/eureka/bozjan_southern_front.txt
@@ -358,7 +358,7 @@ hideall "--sync--"
 
 # Loop!
 61100.7 "Ready x4" duration 6.1 #Ability { id: "5191", source: "Lyon The Beast King" }
-61110.7 "Obey" Ability { id: "517D", source: "Dawon" } window 90,90 jump 61012.0
+61110.7 "Obey" Ability { id: "517D", source: "Dawon" } window 90,90 jump 61012
 61112.8 "Swooping Frenzy"
 61115.6 "Frigid/Fervid Pulse"
 61118.0 "Swooping Frenzy"

--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.txt
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.txt
@@ -397,7 +397,7 @@ hideall "--sync--"
 # Probably a loop, but you shouldn't see this charge, let alone the previous one.
 6367.8 "Hot Charge 1" Ability { id: "5773", source: "Dahu" }
 6372.6 "Hot Charge 2?" Ability { id: "5773", source: "Dahu" }
-6374.4 "--sync--" StartsUsing { id: "5774", source: "Dahu" } window 100,100 jump 6228.0
+6374.4 "--sync--" StartsUsing { id: "5774", source: "Dahu" } window 100,100 jump 6228
 6379.4 "Firebreathe" Ability { id: "5774", source: "Dahu" }
 6398.6 "Reverberating Roar" #Ability { id: "576D", source: "Dahu" }
 6407.7 "Reverberating Roar" #Ability { id: "576D", source: "Dahu" }

--- a/ui/raidboss/data/05-shb/eureka/zadnor.txt
+++ b/ui/raidboss/data/05-shb/eureka/zadnor.txt
@@ -426,7 +426,7 @@ hideall "--sync--"
 25824.2 "--lasers--" Ability { id: "5CBC", source: "The Diablo Armament" }
 25828.2 "--line stack--" Ability { id: "5CBE", source: "The Diablo Armament" }
 
-25842.2 "Void Systems Overload" Ability { id: "6314", source: "The Diablo Armament" } window 100,100 jump 25805.0
+25842.2 "Void Systems Overload" Ability { id: "6314", source: "The Diablo Armament" } window 100,100 jump 25805
 25852.3 "Pillar Of Shamash" Ability { id: "5CB9", source: "The Diablo Armament" }
 25853.8 "Pillar Of Shamash" Ability { id: "5CBA", source: "The Diablo Armament" }
 25855.3 "Pillar Of Shamash" Ability { id: "5CBB", source: "The Diablo Armament" }

--- a/ui/raidboss/data/05-shb/raid/e11s.txt
+++ b/ui/raidboss/data/05-shb/raid/e11s.txt
@@ -171,8 +171,8 @@ hideall "--sync--"
 725.7 "Burnished Glory" Ability { id: "56A4", source: "Fatebreaker" }
 
 728.2 "--center--" Ability { id: "5908", source: "Fatebreaker" } window 30,30
-737.2 "Cycle Of Faith" Ability { id: "568A", source: "Fatebreaker" } jump 900.0
-737.2 "--sync--" Ability { id: "569A", source: "Fatebreaker" } jump 800.0
+737.2 "Cycle Of Faith" Ability { id: "568A", source: "Fatebreaker" } jump 900
+737.2 "--sync--" Ability { id: "569A", source: "Fatebreaker" } jump 800
 737.3 "Elemental Break"
 739.8 "Sinsight/Sinsmite/Sinsmoke"
 741.7 "Burnt Strike"
@@ -193,8 +193,8 @@ hideall "--sync--"
 825.7 "Burnished Glory" Ability { id: "56A4", source: "Fatebreaker" }
 
 828.2 "--center--" Ability { id: "5908", source: "Fatebreaker" } window 30,30
-837.2 "Cycle Of Faith" Ability { id: "5692", source: "Fatebreaker" } jump 700.0
-837.2 "--sync--" Ability { id: "568A", source: "Fatebreaker" } jump 900.0
+837.2 "Cycle Of Faith" Ability { id: "5692", source: "Fatebreaker" } jump 700
+837.2 "--sync--" Ability { id: "568A", source: "Fatebreaker" } jump 900
 837.3 "Elemental Break"
 839.8 "Sinsight/Sinsmite/Sinsmoke"
 841.7 "Burnt Strike"

--- a/ui/raidboss/data/05-shb/raid/e12n.txt
+++ b/ui/raidboss/data/05-shb/raid/e12n.txt
@@ -25,7 +25,7 @@ hideall "--sync--"
 118.1 "Conflag Strike" Ability { id: "585D", source: "Eden's Promise" }
 128.7 "Ferostorm" Ability { id: "585E", source: "Eden's Promise" }
 140.1 "Maleficium" Ability { id: "5872", source: "Eden's Promise" }
-145.9 "--sync--" Ability { id: "585A", source: "Eden's Promise" } window 145.9
+145.9 "--sync--" Ability { id: "585A", source: "Eden's Promise" } window 145.9,0
 148.4 "--untargetable--"
 
 # Intermission. Can be pushed, unknown threshold, maybe 70% HP?
@@ -57,8 +57,8 @@ hideall "--sync--"
 
 
 568.6 "Stock" Ability { id: "5860", source: "Eden's Promise" } window 15,30
-578.3 "Junction Shiva?" Ability { id: "5862", source: "Eden's Promise" } jump 700.0
-578.3 "Junction Titan?" Ability { id: "5863", source: "Eden's Promise" } jump 800.0
+578.3 "Junction Shiva?" Ability { id: "5862", source: "Eden's Promise" } jump 700
+578.3 "Junction Titan?" Ability { id: "5863", source: "Eden's Promise" } jump 800
 589.0 "Diamond Dust?"
 589.0 "Earthen Fury?"
 594.0 "Impact 1?"
@@ -93,8 +93,8 @@ hideall "--sync--"
 738.2 "--sync--" Ability { id: "5879", source: "Eden's Promise" }
 747.6 "Release" Ability { id: "5861", source: "Eden's Promise" }
 
-756.6 "--sync--" Ability { id: "5879", source: "Eden's Promise" } jump 900.0
-761.5 "Stock?" Ability { id: "5860", source: "Eden's Promise" } jump 1000.0
+756.6 "--sync--" Ability { id: "5879", source: "Eden's Promise" } jump 900
+761.5 "Stock?" Ability { id: "5860", source: "Eden's Promise" } jump 1000
 766.2 "Cast?"
 770.2 "Formless Judgment?"
 776.9 "Cast?"
@@ -116,8 +116,8 @@ hideall "--sync--"
 836.9 "--sync--" Ability { id: "5879", source: "Eden's Promise" }
 846.3 "Release" Ability { id: "5861", source: "Eden's Promise" }
 
-855.3 "--sync--" Ability { id: "5879", source: "Eden's Promise" } jump 900.0
-860.2 "Stock?" Ability { id: "5860", source: "Eden's Promise" } jump 1000.0
+855.3 "--sync--" Ability { id: "5879", source: "Eden's Promise" } jump 900
+860.2 "Stock?" Ability { id: "5860", source: "Eden's Promise" } jump 1000
 864.9 "Cast?"
 868.9 "Formless Judgment?"
 875.6 "Cast?"
@@ -131,8 +131,8 @@ hideall "--sync--"
 928.0 "Maleficium" Ability { id: "5872", source: "Eden's Promise" } window 15,15
 
 940.9 "Stock" Ability { id: "5860", source: "Eden's Promise" }
-950.5 "Junction Shiva?" Ability { id: "5862", source: "Eden's Promise" } window 15,15 jump 700.0
-950.5 "Junction Titan?" Ability { id: "5863", source: "Eden's Promise" } window 15,15 jump 800.0
+950.5 "Junction Shiva?" Ability { id: "5862", source: "Eden's Promise" } window 15,15 jump 700
+950.5 "Junction Titan?" Ability { id: "5863", source: "Eden's Promise" } window 15,15 jump 800
 961.2 "Diamond Dust?"
 961.2 "Earthen Fury?"
 966.2 "Impact 1?"
@@ -148,8 +148,8 @@ hideall "--sync--"
 1020.9 "Release" Ability { id: "5861", source: "Eden's Promise" }
 
 1034.8 "Stock" Ability { id: "5860", source: "Eden's Promise" }
-1044.4 "Junction Shiva?" Ability { id: "5862", source: "Eden's Promise" } jump 700.0
-1044.4 "Junction Titan?" Ability { id: "5863", source: "Eden's Promise" } jump 800.0
+1044.4 "Junction Shiva?" Ability { id: "5862", source: "Eden's Promise" } jump 700
+1044.4 "Junction Titan?" Ability { id: "5863", source: "Eden's Promise" } jump 800
 1055.1 "Diamond Dust?"
 1055.1 "Earthen Fury?"
 1060.1 "Impact 1?"

--- a/ui/raidboss/data/05-shb/raid/e1n.txt
+++ b/ui/raidboss/data/05-shb/raid/e1n.txt
@@ -79,7 +79,7 @@ hideall "Vice And Virtue"
 476.9 "Eden's Flare" Ability { id: "3D97", source: "Eden Prime" }
 488.4 "Eden's Gravity" Ability { id: "3D94", source: "Eden Prime" }
 
-502.0 "Vice And Virtue" Ability { id: "44E4", source: "Eden Prime" } window 100,100 jump 360.0
+502.0 "Vice And Virtue" Ability { id: "44E4", source: "Eden Prime" } window 100,100 jump 360
 502.7 "Vice Of Vanity"
 512.5 "Spear Of Paradise"
 514.0 "Heavensunder"

--- a/ui/raidboss/data/05-shb/raid/e1s.txt
+++ b/ui/raidboss/data/05-shb/raid/e1s.txt
@@ -87,4 +87,4 @@ hideall "--sync--"
 
 
 ### Enrage
-900.0 "Fragor Maximus (Enrage)" StartsUsing { id: "45E4", source: "Eden Prime" } duration 10.0 window 500,0
+900.0 "Fragor Maximus (Enrage)" StartsUsing { id: "45E4", source: "Eden Prime" } duration 10 window 500,0

--- a/ui/raidboss/data/05-shb/raid/e5n.txt
+++ b/ui/raidboss/data/05-shb/raid/e5n.txt
@@ -62,7 +62,7 @@ hideall "--sync--"
 382.0 "Volt Strike" Ability { id: "4CF2", source: "Ramuh" }
 388.5 "Gallop" Ability { id: "4B96", source: "Will Of Ixion" }
 389.1 "Volt Strike" Ability { id: "4CF2", source: "Ramuh" }
-399.5 "Crippling Blow" Ability { id: "4BA3", source: "Ramuh" } window 30,30 jump 272.0
+399.5 "Crippling Blow" Ability { id: "4BA3", source: "Ramuh" } window 30,30 jump 272
 
 412.7 "Stratospear Summons"
 417.6 "Impact"

--- a/ui/raidboss/data/05-shb/raid/e7n.txt
+++ b/ui/raidboss/data/05-shb/raid/e7n.txt
@@ -89,7 +89,7 @@ hideall "--sync--"
 667.6 "False Twilight" Ability { id: "4C59", source: "The Idol Of Darkness" }
 667.7 "Light's Course" # Ability { id: "4C40", source: "Unforgiven Idolatry" }
 671.6 "Stygian Sword" Ability { id: "4C55", source: "The Idol Of Darkness" } window 30,30
-676.6 "Silver Sledge" Ability { id: "4C54", source: "The Idol Of Darkness" } jump 541.0
+676.6 "Silver Sledge" Ability { id: "4C54", source: "The Idol Of Darkness" } jump 541
 
 685.6 "Unjoined Aspect"
 690.8 "Betwixt Worlds"

--- a/ui/raidboss/data/05-shb/trial/wol-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/wol-ex.txt
@@ -108,7 +108,7 @@ hideall "Limit Break"
 # DRK/BRD
 519.6 "--sync--" StartsUsing { id: "4F3[456]", source: "Warrior Of Light" } window 5,5 jump 2519.6
 522.6 "Limit -> DRK/BRD" #Ability { id: "4F3[456]", source: "Warrior Of Light" }
-534.0 "--sync--" StartsUsing { id: "4F43", source: "Warrior Of Light" } window 40,40 jump 2534.0
+534.0 "--sync--" StartsUsing { id: "4F43", source: "Warrior Of Light" } window 40,40 jump 2534
 
 # NIN
 519.6 "--sync--" StartsUsing { id: "4EF[56]", source: "Warrior Of Light" } window 40,40 jump 3519.6

--- a/ui/raidboss/data/06-ew/dungeon/alzadaals_legacy.txt
+++ b/ui/raidboss/data/06-ew/dungeon/alzadaals_legacy.txt
@@ -15,7 +15,7 @@ hideall "--sync--"
 # Undersea Entrance will be sealed off
 0.0 "--sync--" SystemLogMessage { id: "7DC", param1: "103E" } window 0,1
 11.0 "Big Wave" Ability { id: "6F60", source: "Ambujam" } window 11,5
-20.8 "Tentacle Dig" Ability { id: "6F55", source: "Ambujam" } window 20.8
+20.8 "Tentacle Dig" Ability { id: "6F55", source: "Ambujam" } window 20.8,0
 33.0 "--sync--" Ability { id: "6F5B", source: "Scarlet Tentacle" }
 33.4 "Toxin Shower" Ability { id: "6F5C", source: "Ambujam" }
 39.2 "--sync--" Ability { id: "6F56", source: "Ambujam" } window 39.2,10

--- a/ui/raidboss/data/06-ew/dungeon/alzadaals_legacy.txt
+++ b/ui/raidboss/data/06-ew/dungeon/alzadaals_legacy.txt
@@ -15,7 +15,7 @@ hideall "--sync--"
 # Undersea Entrance will be sealed off
 0.0 "--sync--" SystemLogMessage { id: "7DC", param1: "103E" } window 0,1
 11.0 "Big Wave" Ability { id: "6F60", source: "Ambujam" } window 11,5
-20.8 "Tentacle Dig" Ability { id: "6F55", source: "Ambujam" } window 20.8,0
+20.8 "Tentacle Dig" Ability { id: "6F55", source: "Ambujam" } window 20.8,10
 33.0 "--sync--" Ability { id: "6F5B", source: "Scarlet Tentacle" }
 33.4 "Toxin Shower" Ability { id: "6F5C", source: "Ambujam" }
 39.2 "--sync--" Ability { id: "6F56", source: "Ambujam" } window 39.2,10

--- a/ui/raidboss/data/06-ew/dungeon/mount_rokkon.txt
+++ b/ui/raidboss/data/06-ew/dungeon/mount_rokkon.txt
@@ -194,7 +194,7 @@ hideall "--sync--"
 
 #cactbot-timeline-lint-disable-sync-order
 # => path 01
-2169.0 "--sync--" StartsUsing { id: "85A8", source: "Moko the Restless" } window 50,50 jump 2269.0
+2169.0 "--sync--" StartsUsing { id: "85A8", source: "Moko the Restless" } window 50,50 jump 2269
 2172.0 "Untempered Sword?" #Ability { id: "85A8", source: "Moko the Restless" }
 
 # => path 02
@@ -202,11 +202,11 @@ hideall "--sync--"
 2173.5 "Moonless Night?" #Ability { id: "85AB", source: "Moko the Restless" }
 
 # => path 03
-2169.0 "--sync--" StartsUsing { id: "85A1", source: "Moko the Restless" } window 50,50 jump 2869.0
+2169.0 "--sync--" StartsUsing { id: "85A1", source: "Moko the Restless" } window 50,50 jump 2869
 2172.0 "Tengu-yobi?" #Ability { id: "85A1", source: "Moko the Restless" }
 
 # => path 04
-2169.0 "--sync--" StartsUsing { id: "85A5", source: "Moko the Restless" } window 50,50 jump 3169.0
+2169.0 "--sync--" StartsUsing { id: "85A5", source: "Moko the Restless" } window 50,50 jump 3169
 2172.0 "Spiritspark?" #Ability { id: "85A5", source: "Moko the Restless" }
 #cactbot-timeline-lint-enable-sync-order
 
@@ -868,19 +868,19 @@ hideall "--sync--"
 #cactbot-timeline-lint-disable-sync-order
 # -> path 08
 7104.0 "--sync--" StartsUsing { id: "83EE", source: "Feral Thrall" }
-7110.0 "Rush?" Ability { id: "83EE", source: "Feral Thrall" } window 30,30 jump 7210.0
+7110.0 "Rush?" Ability { id: "83EE", source: "Feral Thrall" } window 30,30 jump 7210
 
 # -> path 09
 7093.9 "--sync--" StartsUsing { id: "83E9", source: "Shishio" } window 30,30 jump 7293.9
 7098.9 "Focused Tremor?" #Ability { id: "83E9", source: "Shishio" }
 
 # -> path 10
-7097.0 "--sync--" StartsUsing { id: "83F0", source: "Devilish Thrall" } window 30,30 jump 7397.0
+7097.0 "--sync--" StartsUsing { id: "83F0", source: "Devilish Thrall" } window 30,30 jump 7397
 7105.0 "Left Swipe?" #Ability { id: "83F1", source: "Devilish Thrall" }
 7105.0 "Right Swipe?" #Ability { id: "83F0", source: "Devilish Thrall" }
 
 # -> path 11
-7099.0 "--sync--" StartsUsing { id: "872B", source: "Haunting Thrall" } window 30,30 jump 7599.0
+7099.0 "--sync--" StartsUsing { id: "872B", source: "Haunting Thrall" } window 30,30 jump 7599
 7103.0 "Reisho?" #Ability { id: "872B", source: "Haunting Thrall" }
 #cactbot-timeline-lint-enable-sync-order
 

--- a/ui/raidboss/data/06-ew/dungeon/the_aitiascope.txt
+++ b/ui/raidboss/data/06-ew/dungeon/the_aitiascope.txt
@@ -47,7 +47,7 @@ hideall "--sync--"
 1218.8 "Aglaea Shot 1" Ability { id: "6445", source: "Livia the Undeterred" }
 1229.0 "Aglaea Shot 2" Ability { id: "6447", source: "Aethershot" }
 
-1240.0 "Odi et Amo" Ability { id: "644B", source: "Livia the Undeterred" } window 50,50 jump 1079.0
+1240.0 "Odi et Amo" Ability { id: "644B", source: "Livia the Undeterred" } window 50,50 jump 1079
 1244.9 "Ignis Amoris" #Ability { id: "644C", source: "Livia the Undeterred" }
 1250.1 "Ignis Odi" #Ability { id: "644D", source: "Livia the Undeterred" }
 1255.4 "Disparagement" #Ability { id: "644A", source: "Livia the Undeterred" }

--- a/ui/raidboss/data/06-ew/dungeon/the_lunar_subterrane.txt
+++ b/ui/raidboss/data/06-ew/dungeon/the_lunar_subterrane.txt
@@ -123,7 +123,7 @@ hideall "--sync--"
 2315.1 "Pound Sand" Ability { id: "868B", source: "Damcyan Antlion" }
 2324.2 "Sandblast" Ability { id: "87FD", source: "Damcyan Antlion" }
 
-2330.3 "--north--" Ability { id: "8808", source: "Damcyan Antlion" } window 50,50 forcejump 2270.0
+2330.3 "--north--" Ability { id: "8808", source: "Damcyan Antlion" } window 50,50 forcejump 2270
 
 
 # ALL ENCOUNTER ABILITIES

--- a/ui/raidboss/data/06-ew/dungeon/the_tower_of_babil.txt
+++ b/ui/raidboss/data/06-ew/dungeon/the_tower_of_babil.txt
@@ -60,7 +60,7 @@ hideall "--sync--"
 331.0 "--sync--" Ability { id: "61DD", source: "Barnabas" }
 332.4 "Electromagnetic Release" Ability { id: "62F1", source: "Barnabas" }
 
-342.7 "Thundercall" Ability { id: "62ED", source: "Barnabas" } window 42.7,5 jump 400.0
+342.7 "Thundercall" Ability { id: "62ED", source: "Barnabas" } window 42.7,5 jump 400
 349.2 "Rolling Scrapline"
 349.5 "Shock"
 359.8 "Shocking Force"
@@ -129,7 +129,7 @@ hideall "--sync--"
 1312.0 "Magitek Explosive" Ability { id: "62F8", source: "Lugae" }
 1323.0 "Explosion" Ability { id: "62F9", source: "Magitek Explosive" }
 
-1335.3 "Magitek Chakram" Ability { id: "62F3", source: "Lugae" } jump 1200.0
+1335.3 "Magitek Chakram" Ability { id: "62F3", source: "Lugae" } jump 1200
 1343.8 "Magitek Chakram"
 1346.3 "Mighty Blow"
 1354.9 "Mighty Blow"

--- a/ui/raidboss/data/06-ew/raid/p11s.txt
+++ b/ui/raidboss/data/06-ew/raid/p11s.txt
@@ -72,7 +72,7 @@ hideall "--sync--"
 
 395.4 "--middle--" Ability { id: "867F", source: "Themis" }
 402.5 "Dark Current (cast)" Ability { id: "8204", source: "Themis" }
-410.6 "Dark Current x8" duration 7 Ability { id: "8209", source: "Themis" }
+410.6 "Dark Current x8" Ability { id: "8209", source: "Themis" } duration 7
 412.5 "Blinding Light" Ability { id: "8229", source: "Themis" }
 
 426.6 "Jury Overruling" Ability { id: ["81E6", "81E7"], source: "Themis" }

--- a/ui/raidboss/data/06-ew/raid/p2n.txt
+++ b/ui/raidboss/data/06-ew/raid/p2n.txt
@@ -59,7 +59,7 @@ hideall "--sync--"
 371.8 "Murky Depths" Ability { id: "680F", source: "Hippokampos" }
 383.1 "Doubled Impact" Ability { id: "680E", source: "Hippokampos" }
 
-392.3 "--middle--" Ability { id: "6835", source: "Hippokampos" } window 50,50 jump 201.0
+392.3 "--middle--" Ability { id: "6835", source: "Hippokampos" } window 50,50 jump 201
 399.7 "Sewage Deluge" #Ability { id: "67F6", source: "Hippokampos" }
 418.2 "Tainted Flood" #Ability { id: "6809", source: "Hippokampos" }
 426.1 "Spoken Cataract" #Ability { id: ["67F7", "67F8", "67F9", "67FD"], source: "Hippokampos" }

--- a/ui/raidboss/data/06-ew/raid/p3n.txt
+++ b/ui/raidboss/data/06-ew/raid/p3n.txt
@@ -31,7 +31,7 @@ hideall "--sync--"
 118.0 "Trail of Condemnation" Ability { id: "66AD", source: "Phoinix" } window 118.0,10
 126.8 "--adds targetable--"
 127.0 "Blazing Rain" Ability { id: "66A2", source: "Phoinix" }
-135.1 "Blazing Rain" Ability { id: "66A2", source: "Phoinix" } jump 127.0
+135.1 "Blazing Rain" Ability { id: "66A2", source: "Phoinix" } jump 127
 143.2 "Blazing Rain"
 151.3 "Blazing Rain"
 159.4 "Blazing Rain"

--- a/ui/raidboss/data/06-ew/trial/golbez-ex.txt
+++ b/ui/raidboss/data/06-ew/trial/golbez-ex.txt
@@ -49,8 +49,8 @@ hideall "--sync--"
 
 
 144.4 "--sync--" Ability { id: "8475", source: "Golbez" }
-159.5 "Azdaja's Shadow" Ability { id: "8478", source: "Golbez" } jump 200.0
-159.5 "--sync--" Ability { id: "8479", source: "Golbez" } jump 300.0
+159.5 "Azdaja's Shadow" Ability { id: "8478", source: "Golbez" } jump 200
+159.5 "--sync--" Ability { id: "8479", source: "Golbez" } jump 300
 164.7 "Flames of Eventide 1"
 167.8 "Flames of Eventide 2"
 170.9 "Flames of Eventide 3"
@@ -70,7 +70,7 @@ hideall "--sync--"
 224.2 "Phases of the Shadow (back)" Ability { id: "86EF", source: "Golbez" }
 225.4 "Rising Beacon (out)" Ability { id: "86EC", source: "Golbez" }
 228.1 "Immolating Shade (light parties)" Ability { id: "8496", source: "Golbez" }
-228.7 "--north--" Ability { id: "84B8", source: "Golbez" } forcejump 400.0
+228.7 "--north--" Ability { id: "84B8", source: "Golbez" } forcejump 400
 
 # in -> spread variation
 
@@ -85,7 +85,7 @@ hideall "--sync--"
 324.2 "Phases of the Shadow (back)" Ability { id: "86EF", source: "Golbez" }
 325.4 "Rising Ring (under)" Ability { id: "86ED", source: "Golbez" }
 328.1 "Burning Shade (spread)" Ability { id: "8494", source: "Golbez" }
-328.7 "--north--" Ability { id: "84B8", source: "Golbez" } forcejump 400.0
+328.7 "--north--" Ability { id: "84B8", source: "Golbez" } forcejump 400
 
 
 # knockback phase
@@ -96,8 +96,8 @@ hideall "--sync--"
 413.5 "Double Meteor" Ability { id: "878C", source: "Golbez" }
 415.1 "Cauterize" Ability { id: "84A2", source: "Shadow Dragon" }
 418.7 "--sync--" Ability { id: "8475", source: "Golbez" }
-436.8 "Azdaja's Shadow" Ability { id: "8478", source: "Golbez" } jump 500.0
-436.8 "--sync--" Ability { id: "8479", source: "Golbez" } jump 700.0
+436.8 "Azdaja's Shadow" Ability { id: "8478", source: "Golbez" } jump 500
+436.8 "--sync--" Ability { id: "8479", source: "Golbez" } jump 700
 
 # repeated for timeline rolling
 
@@ -115,7 +115,7 @@ hideall "--sync--"
 511.4 "Flames of Eventide 3" Ability { id: "847B", source: "Golbez" }
 513.4 "--middle--" Ability { id: "84B8", source: "Golbez" }
 518.5 "Void Stardust (preview)" Ability { id: "84A4", source: "Golbez" }
-524.6 "Void Stardust" duration 2.3 Ability { id: "84A6", source: "Golbez" }
+524.6 "Void Stardust" Ability { id: "84A6", source: "Golbez" } duration 2.3
 530.4 "Abyssal Quasar" Ability { id: "84AB", source: "Golbez" }
 535.4 "Eventide Fall?" Ability { id: "8485", source: "Golbez" }
 540.4 "Eventide Triad?" Ability { id: "8480", source: "Golbez" }
@@ -131,7 +131,7 @@ hideall "--sync--"
 573.5 "Phases of the Shadow (back)" Ability { id: "86EF", source: "Golbez" }
 574.7 "Rising Beacon (out)" Ability { id: "86EC", source: "Golbez" }
 576.8 "--sync--" Ability { id: "8475", source: "Golbez" }
-577.2 "Immolating Shade (light parties)" Ability { id: "8496", source: "Golbez" } forcejump 1000.0
+577.2 "Immolating Shade (light parties)" Ability { id: "8496", source: "Golbez" } forcejump 1000
 
 
 # Mini-phase 2, exaflares -> pairs -> role stacks or light parties -> in then spread
@@ -142,7 +142,7 @@ hideall "--sync--"
 711.4 "Flames of Eventide 3" Ability { id: "847B", source: "Golbez" }
 713.4 "--middle--" Ability { id: "84B8", source: "Golbez" }
 718.5 "Void Stardust (preview)" Ability { id: "84A4", source: "Golbez" }
-724.6 "Void Stardust" duration 2.3 Ability { id: "84A6", source: "Golbez" }
+724.6 "Void Stardust" Ability { id: "84A6", source: "Golbez" } duration 2.3
 730.4 "Abyssal Quasar" Ability { id: "84AB", source: "Golbez" }
 735.4 "Eventide Fall?" Ability { id: "8485", source: "Golbez" }
 740.4 "Eventide Triad?" Ability { id: "8480", source: "Golbez" }
@@ -158,7 +158,7 @@ hideall "--sync--"
 773.5 "Phases of the Shadow (back)" Ability { id: "86EF", source: "Golbez" }
 774.7 "Rising Ring (under)" Ability { id: "86ED", source: "Golbez" }
 776.8 "--sync--" Ability { id: "8475", source: "Golbez" }
-777.2 "Burning Shade (spread)" Ability { id: "8494", source: "Golbez" } forcejump 1000.0
+777.2 "Burning Shade (spread)" Ability { id: "8494", source: "Golbez" } forcejump 1000
 
 # terrastorm + light parties
 
@@ -187,8 +187,8 @@ hideall "--sync--"
 1071.0 "--sync--" Ability { id: "86DD", source: "Golbez" }
 1072.7 "Phases of the Blade (back)" Ability { id: "86F2", source: "Golbez" }
 1082.1 "Binding Cold" Ability { id: "84B3", source: "Golbez" }
-1098.2 "Azdaja's Shadow" Ability { id: "8478", source: "Golbez" } jump 1200.0
-1098.2 "--sync--" Ability { id: "8479", source: "Golbez" } jump 1400.0
+1098.2 "Azdaja's Shadow" Ability { id: "8478", source: "Golbez" } jump 1200
+1098.2 "--sync--" Ability { id: "8479", source: "Golbez" } jump 1400
 
 # repeated for timeline rolling
 
@@ -206,7 +206,7 @@ hideall "--sync--"
 1211.4 "Flames of Eventide 3" Ability { id: "847B", source: "Golbez" }
 1213.4 "--middle--" Ability { id: "84B8", source: "Golbez" }
 1218.5 "Void Stardust (preview)" Ability { id: "84A4", source: "Golbez" }
-1224.6 "Void Stardust" duration 2.3 Ability { id: "84A6", source: "Golbez" }
+1224.6 "Void Stardust" Ability { id: "84A6", source: "Golbez" } duration 2.3
 1230.4 "Abyssal Quasar" Ability { id: "84AB", source: "Golbez" }
 1231.3 "Lingering Spark (cast)" Ability { id: "8468", source: "Golbez" }
 1235.4 "Lingering Spark (explode)" Ability { id: "846A", source: "Golbez" }
@@ -217,7 +217,7 @@ hideall "--sync--"
 1254.9 "Phases of the Shadow (back)" Ability { id: "86EF", source: "Golbez" }
 1256.1 "Rising Beacon (out)" Ability { id: "86EC", source: "Golbez" }
 1258.2 "--sync--" Ability { id: "8475", source: "Golbez" }
-1258.6 "Immolating Shade (light parties)" Ability { id: "8496", source: "Golbez" } forcejump 1600.0
+1258.6 "Immolating Shade (light parties)" Ability { id: "8496", source: "Golbez" } forcejump 1600
 
 # Mini-phase 3, exaflares -> pairs -> role stacks or light parties -> in then spread
 
@@ -227,7 +227,7 @@ hideall "--sync--"
 1411.4 "Flames of Eventide 3" Ability { id: "847B", source: "Golbez" }
 1413.4 "--middle--" Ability { id: "84B8", source: "Golbez" }
 1418.5 "Void Stardust (preview)" Ability { id: "84A4", source: "Golbez" }
-1424.6 "Void Stardust" duration 2.3 Ability { id: "84A6", source: "Golbez" }
+1424.6 "Void Stardust" Ability { id: "84A6", source: "Golbez" } duration 2.3
 1430.4 "Abyssal Quasar" Ability { id: "84AB", source: "Golbez" }
 1431.3 "Lingering Spark (cast)" Ability { id: "8468", source: "Golbez" }
 1435.4 "Lingering Spark (explode)" Ability { id: "846A", source: "Golbez" }
@@ -238,7 +238,7 @@ hideall "--sync--"
 1454.9 "Phases of the Shadow (back)" Ability { id: "86EF", source: "Golbez" }
 1456.1 "Rising Ring (under)" Ability { id: "86ED", source: "Golbez" }
 1458.2 "--sync--" Ability { id: "8475", source: "Golbez" }
-1458.6 "Burning Shade (spread)" Ability { id: "8494", source: "Golbez" } forcejump 1600.0
+1458.6 "Burning Shade (spread)" Ability { id: "8494", source: "Golbez" } forcejump 1600
 
 # knockback phase
 
@@ -268,8 +268,8 @@ hideall "--sync--"
 1676.0 "--sync--" Ability { id: "86DD", source: "Golbez" }
 1677.7 "Phases of the Blade (back)" Ability { id: "86F2", source: "Golbez" }
 1687.1 "Binding Cold" Ability { id: "84B3", source: "Golbez" }
-1703.6 "Azdaja's Shadow" Ability { id: "8478", source: "Golbez" } jump 1800.0
-1703.6 "--sync--" Ability { id: "8479", source: "Golbez" } jump 1900.0
+1703.6 "Azdaja's Shadow" Ability { id: "8478", source: "Golbez" } jump 1800
+1703.6 "--sync--" Ability { id: "8479", source: "Golbez" } jump 1900
 
 # repeated for timeline rolling
 1708.8 "Flames of Eventide 1" #Ability { id: "847B", source: "Golbez" }
@@ -293,7 +293,7 @@ hideall "--sync--"
 1822.5 "--sync--" Ability { id: "86E9", source: "Golbez" }
 1824.2 "Phases of the Shadow (back)" Ability { id: "86EF", source: "Golbez" }
 1825.4 "Rising Beacon (out)" Ability { id: "86EC", source: "Golbez" }
-1828.1 "Immolating Shade (light parties)" Ability { id: "8496", source: "Golbez" } forcejump 2000.0
+1828.1 "Immolating Shade (light parties)" Ability { id: "8496", source: "Golbez" } forcejump 2000
 
 # in -> spread variation
 
@@ -307,7 +307,7 @@ hideall "--sync--"
 1922.5 "--sync--" Ability { id: "86E9", source: "Golbez" }
 1924.2 "Phases of the Shadow (back)" Ability { id: "86EF", source: "Golbez" }
 1925.4 "Rising Ring (under)" Ability { id: "86ED", source: "Golbez" }
-1928.1 "Burning Shade (spread)" Ability { id: "8494", source: "Golbez" } forcejump 2000.0
+1928.1 "Burning Shade (spread)" Ability { id: "8494", source: "Golbez" } forcejump 2000
 
 # final segment
 2000.0 "Burning/Immolating Shade"

--- a/ui/raidboss/data/06-ew/trial/sophia-un.txt
+++ b/ui/raidboss/data/06-ew/trial/sophia-un.txt
@@ -35,7 +35,7 @@ hideall "--sync--"
 # Intermission.
 # Divine Spark can be pushed and thus is not synced.
 # Gnostic Rant and Infusion are purely HP-based pushes.
-110.6 "Cloudy Heavens" Ability { id: "7DB8", source: "Sophia" } window 110.6
+110.6 "Cloudy Heavens" Ability { id: "7DB8", source: "Sophia" } window 110.6,0
 111.6 "--untargetable--"
 111.6 "--adds spawn--"
 120.9 "Horizontal Kenoma/Vertical Kenoma" Ability { id: ["7DB5", "7DB6"], source: "The First Demiurge" }

--- a/ui/raidboss/data/06-ew/trial/sophia-un.txt
+++ b/ui/raidboss/data/06-ew/trial/sophia-un.txt
@@ -35,7 +35,7 @@ hideall "--sync--"
 # Intermission.
 # Divine Spark can be pushed and thus is not synced.
 # Gnostic Rant and Infusion are purely HP-based pushes.
-110.6 "Cloudy Heavens" Ability { id: "7DB8", source: "Sophia" } window 110.6,0
+110.6 "Cloudy Heavens" Ability { id: "7DB8", source: "Sophia" } window 110.6
 111.6 "--untargetable--"
 111.6 "--adds spawn--"
 120.9 "Horizontal Kenoma/Vertical Kenoma" Ability { id: ["7DB5", "7DB6"], source: "The First Demiurge" }

--- a/ui/raidboss/data/06-ew/trial/ultima-un.txt
+++ b/ui/raidboss/data/06-ew/trial/ultima-un.txt
@@ -285,7 +285,7 @@ hideall "--sync--"
 
 # Enrage appears to be at 10:30.
 # Ultima Weapon teleports to the center and casts Ultima.
-9989.3 "--sync--" StartsUsing { id: "6EFB", source: "The Ultima Weapon" } window 10000
+9989.3 "--sync--" StartsUsing { id: "6EFB", source: "The Ultima Weapon" } window 10000,0
 10000.0 "Ultima Enrage" Ability { id: "6EFB", source: "The Ultima Weapon" }
 
 

--- a/ui/raidboss/data/06-ew/trial/zurvan-un.txt
+++ b/ui/raidboss/data/06-ew/trial/zurvan-un.txt
@@ -46,7 +46,7 @@ hideall "--sync--"
 95.3 "Metal Cutter" Ability { id: "8579", source: "Zurvan" }
 102.4 "Wave Cannon (avoid)" Ability { id: "857C", source: "Zurvan" }
 
-108.5 "Metal Cutter" Ability { id: "8579", source: "Zurvan" } jump 80.0
+108.5 "Metal Cutter" Ability { id: "8579", source: "Zurvan" } jump 80
 113.6 "Metal Cutter"
 118.7 "Metal Cutter"
 123.8 "Metal Cutter"

--- a/ui/raidboss/data/06-ew/trial/zurvan-un.txt
+++ b/ui/raidboss/data/06-ew/trial/zurvan-un.txt
@@ -46,7 +46,7 @@ hideall "--sync--"
 95.3 "Metal Cutter" Ability { id: "8579", source: "Zurvan" }
 102.4 "Wave Cannon (avoid)" Ability { id: "857C", source: "Zurvan" }
 
-108.5 "Metal Cutter" Ability { id: "8579", source: "Zurvan" } jump 80
+108.5 "Metal Cutter" Ability { id: "8579", source: "Zurvan" } jump 80.0
 113.6 "Metal Cutter"
 118.7 "Metal Cutter"
 123.8 "Metal Cutter"


### PR DESCRIPTION
Addresses @JLGarber 's comment in #106 about linting for "xx.0" float parameters for keyword values in timelines that should just be ints.

(Also fixes an inadvertent bug that was causing a few mis-ordered keywords to not be linted properly.)

Given that this will again touch a decent number of old timelines (although not as many as #106), I've temporarily added a control to limit the lint scope, and this PR only includes changes to EW+ShB timelines (+sophia_ex and zurvan_ex due to sync-files).  Will do follow-on PRs for SB (there are a lot) and ARR+HW before the expac control filter is removed.
