### PR TITLE
build: Bump version to 0.31.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cactbot",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cactbot",
-      "version": "0.31.3",
+      "version": "0.31.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@fast-csv/parse": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cactbot",
-  "version": "0.31.3",
-  "releaseSummary": "bug squash, i18n, ci",
+  "version": "0.31.4",
+  "releaseSummary": "cn/ko 6.5",
   "releaseInDraft": "false",
   "license": "Apache-2.0",
   "type": "module",

--- a/plugin/CactbotEventSource/Properties/AssemblyInfo.cs
+++ b/plugin/CactbotEventSource/Properties/AssemblyInfo.cs
@@ -21,5 +21,5 @@ using System.Runtime.InteropServices;
 // - Revision
 // GitHub has only 3 version components, so Revision should always be 0.
 // CactbotOverlay and CactbotEventSource version should match.
-[assembly: AssemblyVersion("0.31.3.0")]
-[assembly: AssemblyFileVersion("0.31.3.0")]
+[assembly: AssemblyVersion("0.31.4.0")]
+[assembly: AssemblyFileVersion("0.31.4.0")]

--- a/plugin/CactbotOverlay/Properties/AssemblyInfo.cs
+++ b/plugin/CactbotOverlay/Properties/AssemblyInfo.cs
@@ -20,5 +20,5 @@ using System.Runtime.InteropServices;
 // - Build Number
 // - Revision
 // GitHub has only 3 version components, so Revision should always be 0.
-[assembly: AssemblyVersion("0.31.3.0")]
-[assembly: AssemblyFileVersion("0.31.3.0")]
+[assembly: AssemblyVersion("0.31.4.0")]
+[assembly: AssemblyFileVersion("0.31.4.0")]


### PR DESCRIPTION
We apparently never did a version bump after the cn 6.5 mem sigs/resources were added...😳