### PR TITLE
resources: rename logdef types

### DIFF
--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -2,7 +2,7 @@ import { PluginCombatantState } from '../types/event';
 import { NetFieldsReverse } from '../types/net_fields';
 import { NetParams } from '../types/net_props';
 
-export type LogDefinition<K extends LogDefinitionTypes> = {
+export type LogDefinition<K extends LogDefinitionName> = {
   // The log line id, as a decimal string, minimum two characters.
   type: LogDefinitions[K]['type'];
   // The informal name of this log line (must match the key that the LogDefinition is a value for).
@@ -47,21 +47,21 @@ export type LogDefinition<K extends LogDefinitionTypes> = {
 };
 
 export type LogDefFieldIdx<
-  K extends LogDefinitionTypes,
+  K extends LogDefinitionName,
 > = Extract<LogDefinitions[K]['fields'][keyof LogDefinitions[K]['fields']], number>;
 
-type PlayerIdMap<K extends LogDefinitionTypes> = {
+type PlayerIdMap<K extends LogDefinitionName> = {
   [P in LogDefFieldIdx<K> as number]?: LogDefFieldIdx<K> | null;
 };
 
-export type LogDefFieldName<K extends LogDefinitionTypes> = Extract<
+export type LogDefFieldName<K extends LogDefinitionName> = Extract<
   keyof LogDefinitions[K]['fields'],
   string
 >;
 
 // Specifies a fieldName key with one or more possible values and a `canAnonyize` override
 // if that field and value are present on the log line. See 'GameLog' for an example.
-type LogDefSubFields<K extends LogDefinitionTypes> = {
+type LogDefSubFields<K extends LogDefinitionName> = {
   [P in LogDefFieldName<K>]?: {
     [fieldValue: string]: {
       name: string;
@@ -80,7 +80,7 @@ type LogDefSubFields<K extends LogDefinitionTypes> = {
 //   included. If `include:` = 'filter', `filters` must be present; otherwise, it must be omitted.
 // `combatantIdFields:` are field indices containing combatantIds. If specified, these fields
 //   will be checked for ignored combatants (e.g. pets) during log filtering.
-export type AnalysisOptions<K extends LogDefinitionTypes> = {
+export type AnalysisOptions<K extends LogDefinitionName> = {
   include: 'none' | 'never';
   filters?: undefined;
   combatantIdFields?: undefined;
@@ -1577,19 +1577,16 @@ const assertLogDefinitions: LogDefinitionMap = latestLogDefinitions;
 console.assert(assertLogDefinitions);
 
 export type LogDefinitions = typeof latestLogDefinitions;
-// TODO: `LogDefinitionTypes` should be renamed to `LogDefinitionName` to match current naming
-// conventions (e.g. `type` = numeric id, `name` = string name), and `LogDefinitionTypeCode` should
-// then be renamed to `LogDefinitionType`. This is probably a future PR, given the various imports.
-export type LogDefinitionTypes = keyof LogDefinitions;
-export type LogDefinitionTypeCode = LogDefinitions[LogDefinitionTypes]['type'];
-export type LogDefinitionMap = { [K in LogDefinitionTypes]: LogDefinition<K> };
+export type LogDefinitionName = keyof LogDefinitions;
+export type LogDefinitionType = LogDefinitions[LogDefinitionName]['type'];
+export type LogDefinitionMap = { [K in LogDefinitionName]: LogDefinition<K> };
 export type LogDefinitionVersions = keyof typeof logDefinitionsVersions;
 
 type RepeatingFieldsNarrowingType = { readonly repeatingFields: unknown };
 
 export type RepeatingFieldsTypes = keyof {
   [
-    type in LogDefinitionTypes as LogDefinitions[type] extends RepeatingFieldsNarrowingType ? type
+    type in LogDefinitionName as LogDefinitions[type] extends RepeatingFieldsNarrowingType ? type
       : never
   ]: null;
 };
@@ -1601,7 +1598,7 @@ export type RepeatingFieldsDefinitions = {
 };
 
 export type ParseHelperField<
-  Type extends LogDefinitionTypes,
+  Type extends LogDefinitionName,
   Fields extends NetFieldsReverse[Type],
   Field extends keyof Fields,
 > = {
@@ -1615,7 +1612,7 @@ export type ParseHelperField<
   possibleKeys?: string[];
 };
 
-export type ParseHelperFields<T extends LogDefinitionTypes> = {
+export type ParseHelperFields<T extends LogDefinitionName> = {
   [field in keyof NetFieldsReverse[T]]: ParseHelperField<T, NetFieldsReverse[T], field>;
 };
 

--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -3,8 +3,8 @@ import { NetParams } from '../types/net_props';
 import { CactbotBaseRegExp } from '../types/net_trigger';
 
 import {
+  LogDefinitionName,
   logDefinitionsVersions,
-  LogDefinitionTypes,
   LogDefinitionVersions,
   ParseHelperFields,
   RepeatingFieldsDefinitions,
@@ -50,7 +50,7 @@ export const actorControlType = {
 } as const;
 
 const defaultParams = <
-  T extends LogDefinitionTypes,
+  T extends LogDefinitionName,
   V extends LogDefinitionVersions,
 >(type: T, version: V, include?: string[]): Partial<ParseHelperFields<T>> => {
   const logType = logDefinitionsVersions[version][type];
@@ -105,7 +105,7 @@ const defaultParams = <
 };
 
 type RepeatingFieldsMap<
-  TBase extends LogDefinitionTypes,
+  TBase extends LogDefinitionName,
   TKey extends RepeatingFieldsTypes = TBase extends RepeatingFieldsTypes ? TBase : never,
 > = {
   [name in RepeatingFieldsDefinitions[TKey]['repeatingFields']['names'][number]]:
@@ -114,7 +114,7 @@ type RepeatingFieldsMap<
 }[];
 
 type RepeatingFieldsMapTypeCheck<
-  TBase extends LogDefinitionTypes,
+  TBase extends LogDefinitionName,
   F extends keyof NetFields[TBase],
   TKey extends RepeatingFieldsTypes = TBase extends RepeatingFieldsTypes ? TBase : never,
 > = F extends RepeatingFieldsDefinitions[TKey]['repeatingFields']['label']
@@ -122,19 +122,19 @@ type RepeatingFieldsMapTypeCheck<
   never;
 
 type RepeatingFieldsMapType<
-  T extends LogDefinitionTypes,
+  T extends LogDefinitionName,
   F extends keyof NetFields[T],
 > = T extends RepeatingFieldsTypes ? RepeatingFieldsMapTypeCheck<T, F>
   : never;
 
-type ParseHelperType<T extends LogDefinitionTypes> =
+type ParseHelperType<T extends LogDefinitionName> =
   & {
     [field in keyof NetFields[T]]?: string | readonly string[] | RepeatingFieldsMapType<T, field>;
   }
   & { capture?: boolean };
 
 const isRepeatingField = <
-  T extends LogDefinitionTypes,
+  T extends LogDefinitionName,
 >(
   repeating: boolean | undefined,
   value: string | readonly string[] | RepeatingFieldsMap<T> | undefined,
@@ -153,7 +153,7 @@ const isRepeatingField = <
   return true;
 };
 
-const parseHelper = <T extends LogDefinitionTypes>(
+const parseHelper = <T extends LogDefinitionName>(
   params: ParseHelperType<T> | undefined,
   funcName: string,
   fields: Partial<ParseHelperFields<T>>,

--- a/resources/regexes.ts
+++ b/resources/regexes.ts
@@ -3,8 +3,8 @@ import { NetParams } from '../types/net_props';
 import { CactbotBaseRegExp } from '../types/net_trigger';
 
 import logDefinitions, {
+  LogDefinitionName,
   logDefinitionsVersions,
-  LogDefinitionTypes,
   LogDefinitionVersions,
   ParseHelperFields,
   RepeatingFieldsDefinitions,
@@ -18,7 +18,7 @@ const matchWithColonsDefault = '(?:[^:]|: )*?';
 const fieldsWithPotentialColons = ['effect', 'ability'];
 
 const defaultParams = <
-  T extends LogDefinitionTypes,
+  T extends LogDefinitionName,
   V extends LogDefinitionVersions,
 >(type: T, version: V, include?: string[]): Partial<ParseHelperFields<T>> => {
   const logType = logDefinitionsVersions[version][type];
@@ -73,7 +73,7 @@ const defaultParams = <
 };
 
 type RepeatingFieldsMap<
-  TBase extends LogDefinitionTypes,
+  TBase extends LogDefinitionName,
   TKey extends RepeatingFieldsTypes = TBase extends RepeatingFieldsTypes ? TBase : never,
 > = {
   [name in RepeatingFieldsDefinitions[TKey]['repeatingFields']['names'][number]]:
@@ -82,7 +82,7 @@ type RepeatingFieldsMap<
 }[];
 
 type RepeatingFieldsMapTypeCheck<
-  TBase extends LogDefinitionTypes,
+  TBase extends LogDefinitionName,
   F extends keyof NetFields[TBase],
   TKey extends RepeatingFieldsTypes = TBase extends RepeatingFieldsTypes ? TBase : never,
 > = F extends RepeatingFieldsDefinitions[TKey]['repeatingFields']['label']
@@ -90,19 +90,19 @@ type RepeatingFieldsMapTypeCheck<
   never;
 
 type RepeatingFieldsMapType<
-  T extends LogDefinitionTypes,
+  T extends LogDefinitionName,
   F extends keyof NetFields[T],
 > = T extends RepeatingFieldsTypes ? RepeatingFieldsMapTypeCheck<T, F>
   : never;
 
-type ParseHelperType<T extends LogDefinitionTypes> =
+type ParseHelperType<T extends LogDefinitionName> =
   & {
     [field in keyof NetFields[T]]?: string | readonly string[] | RepeatingFieldsMapType<T, field>;
   }
   & { capture?: boolean };
 
 const isRepeatingField = <
-  T extends LogDefinitionTypes,
+  T extends LogDefinitionName,
 >(
   repeating: boolean | undefined,
   value: string | readonly string[] | RepeatingFieldsMap<T> | undefined,
@@ -121,7 +121,7 @@ const isRepeatingField = <
   return true;
 };
 
-const parseHelper = <T extends LogDefinitionTypes>(
+const parseHelper = <T extends LogDefinitionName>(
   params: ParseHelperType<T> | undefined,
   defKey: T,
   fields: Partial<ParseHelperFields<T>>,

--- a/types/net_fields.d.ts
+++ b/types/net_fields.d.ts
@@ -1,4 +1,4 @@
-import { LogDefinitions, LogDefinitionTypes } from '../resources/netlog_defs';
+import { LogDefinitionName, LogDefinitions } from '../resources/netlog_defs';
 
 // This type helper reverses the keys and values of a given type, e.g this:
 // {1: 'a'}
@@ -11,11 +11,11 @@ type Reverse<T extends { [f: string]: number }> = {
 };
 
 export type NetFields = {
-  [type in LogDefinitionTypes]: LogDefinitions[type]['fields'];
+  [type in LogDefinitionName]: LogDefinitions[type]['fields'];
 };
 
 export type NetFieldsReverse = {
-  [type in LogDefinitionTypes]: Reverse<LogDefinitions[type]['fields']>;
+  [type in LogDefinitionName]: Reverse<LogDefinitions[type]['fields']>;
 };
 
 export type NetAnyFields = NetFields[keyof NetFields];

--- a/types/net_props.d.ts
+++ b/types/net_props.d.ts
@@ -1,5 +1,5 @@
 import {
-  LogDefinitionTypes,
+  LogDefinitionName,
   RepeatingFieldsDefinitions,
   RepeatingFieldsTypes,
 } from '../resources/netlog_defs';
@@ -24,7 +24,7 @@ type RepeatingFieldsExtract<
 };
 
 type RepeatingFieldsParams<
-  type extends LogDefinitionTypes,
+  type extends LogDefinitionName,
   repeatingType extends RepeatingFieldsTypes = type extends RepeatingFieldsTypes ? type : never,
 > = repeatingType extends RepeatingFieldsTypes ? RepeatingFieldsExtract<repeatingType>
   : never;
@@ -35,7 +35,7 @@ type Params<T extends string> = Partial<
 >;
 
 type RepeatingFieldsParamsExtract<
-  type extends LogDefinitionTypes,
+  type extends LogDefinitionName,
 > = type extends RepeatingFieldsTypes ? RepeatingFieldsParams<type> & Params<NetProps[type]> :
   never;
 

--- a/ui/raidboss/timeline_parser.ts
+++ b/ui/raidboss/timeline_parser.ts
@@ -1,7 +1,7 @@
 import JSON5 from 'json5';
 
 import { Lang } from '../../resources/languages';
-import logDefinitions, { LogDefinitionTypes } from '../../resources/netlog_defs';
+import logDefinitions, { LogDefinitionName } from '../../resources/netlog_defs';
 import { buildNetRegexForTrigger } from '../../resources/netregexes';
 import { UnreachableCode } from '../../resources/not_reached';
 import Regexes from '../../resources/regexes';
@@ -15,7 +15,7 @@ import { LooseTimelineTrigger, TriggerAutoConfig } from '../../types/trigger';
 
 import defaultOptions, { RaidbossOptions, TimelineConfig } from './raidboss_options';
 
-const isLogDefinitionTypes = (type: string): type is LogDefinitionTypes => {
+const isLogDefinitionName = (type: string): type is LogDefinitionName => {
   return type in logDefinitions;
 };
 
@@ -44,7 +44,7 @@ const isTimelineNetParams = (value: unknown): value is TimelineNetParams => {
   return true;
 };
 
-const isValidNetParams = <T extends LogDefinitionTypes>(
+const isValidNetParams = <T extends LogDefinitionName>(
   type: T,
   params: Record<string, unknown>,
 ): params is NetParams[T] => {
@@ -489,7 +489,7 @@ export class TimelineParser {
     line = line.replace(syncCommand.netRegexType, '').trim();
 
     const netRegexType = syncCommand.netRegexType;
-    if (!isLogDefinitionTypes(netRegexType)) {
+    if (!isLogDefinitionName(netRegexType)) {
       this.errors.push({
         lineNumber: lineNumber,
         line: originalLine,

--- a/util/gen_log_guide.ts
+++ b/util/gen_log_guide.ts
@@ -2,7 +2,7 @@ import path from 'path';
 
 import markdownMagic from 'markdown-magic';
 
-import logDefinitions, { LogDefinitionTypes } from '../resources/netlog_defs';
+import logDefinitions, { LogDefinitionName } from '../resources/netlog_defs';
 import NetRegexes, { buildRegex as buildNetRegex } from '../resources/netregexes';
 import { UnreachableCode } from '../resources/not_reached';
 import Regexes, { buildRegex } from '../resources/regexes';
@@ -46,7 +46,7 @@ type ExcludedLineDocs =
   | 'Version'
   | 'Error';
 
-type LineDocTypes = Exclude<LogDefinitionTypes, ExcludedLineDocs>;
+type LineDocTypes = Exclude<LogDefinitionName, ExcludedLineDocs>;
 
 type LineDocRegex = {
   network: string;

--- a/util/logtools/anonymizer.ts
+++ b/util/logtools/anonymizer.ts
@@ -4,8 +4,8 @@ import logDefinitions, {
   LogDefFieldIdx,
   LogDefFieldName,
   LogDefinition,
-  LogDefinitionTypeCode,
-  LogDefinitionTypes,
+  LogDefinitionName,
+  LogDefinitionType,
 } from '../../resources/netlog_defs';
 import { UnreachableCode } from '../../resources/not_reached';
 
@@ -41,7 +41,7 @@ export default class Anonymizer {
     }
   }
 
-  isLogDefinitionFieldIdx<K extends LogDefinitionTypes>(
+  isLogDefinitionFieldIdx<K extends LogDefinitionName>(
     fieldId: number | null | undefined,
     name: K,
   ): fieldId is LogDefFieldIdx<K> {
@@ -50,18 +50,18 @@ export default class Anonymizer {
       : (Object.values(logDefinitions[name].fields) as number[]).includes(fieldId);
   }
 
-  isLogDefinitionField<K extends LogDefinitionTypes>(
+  isLogDefinitionField<K extends LogDefinitionName>(
     field: string,
     name: K,
   ): field is LogDefFieldName<K> {
     return Object.keys(logDefinitions[name].fields).includes(field);
   }
 
-  isLogDefinitionType(type: string | undefined): type is LogDefinitionTypeCode {
+  isLogDefinitionType(type: string | undefined): type is LogDefinitionType {
     return Object.values(logDefinitions).some((d) => d.type === type);
   }
 
-  isLogDefinition<K extends LogDefinitionTypes>(def: { name: K }): def is LogDefinition<K> {
+  isLogDefinition<K extends LogDefinitionName>(def: { name: K }): def is LogDefinition<K> {
     return isEqual(def, logDefinitions[def.name]);
   }
 
@@ -70,7 +70,7 @@ export default class Anonymizer {
   }
 
   processLogDefs(): ReindexedLogDefs {
-    const remap: { [type: string]: LogDefinition<LogDefinitionTypes> } = {};
+    const remap: { [type: string]: LogDefinition<LogDefinitionName> } = {};
     for (const def of Object.values(logDefinitions)) {
       if (!this.isLogDefinition(def))
         throw new UnreachableCode();

--- a/util/logtools/splitter.ts
+++ b/util/logtools/splitter.ts
@@ -2,9 +2,9 @@ import { isEqual } from 'lodash';
 
 import logDefinitions, {
   LogDefinition,
+  LogDefinitionName,
   LogDefinitions,
-  LogDefinitionTypeCode,
-  LogDefinitionTypes,
+  LogDefinitionType,
 } from '../../resources/netlog_defs';
 import NetRegexes, { buildRegex } from '../../resources/netregexes';
 import { UnreachableCode } from '../../resources/not_reached';
@@ -37,9 +37,9 @@ export default class Splitter {
   private rsvSubstitutionMap: { [key: string]: string } = {};
 
   // log types to include/filter for analysis; defined in netlog_defs
-  private includeAllTypes: LogDefinitionTypeCode[] = [];
-  private includeFilterTypes: LogDefinitionTypeCode[] = [];
-  private filtersRegex: { [type: string]: CactbotBaseRegExp<LogDefinitionTypes>[] } = {};
+  private includeAllTypes: LogDefinitionType[] = [];
+  private includeFilterTypes: LogDefinitionType[] = [];
+  private filtersRegex: { [type: string]: CactbotBaseRegExp<LogDefinitionName>[] } = {};
 
   // hardcoded list of abilities to ignore for analysis filtering
   private ignoredAbilities: string[] = [];
@@ -68,7 +68,7 @@ export default class Splitter {
   }
 
   parseFilter(
-    name: LogDefinitionTypes,
+    name: LogDefinitionName,
     def: LogDefinition<typeof name>,
     filter: NetParams[typeof name],
   ): void {
@@ -78,11 +78,11 @@ export default class Splitter {
       this.includeFilterTypes.push(def.type);
   }
 
-  isLogDefinitionType(type: string | undefined): type is LogDefinitionTypeCode {
+  isLogDefinitionType(type: string | undefined): type is LogDefinitionType {
     return Object.values(logDefinitions).some((d) => d.type === type);
   }
 
-  isLogDefinition<K extends LogDefinitionTypes>(def: { name: K }): def is LogDefinition<K> {
+  isLogDefinition<K extends LogDefinitionName>(def: { name: K }): def is LogDefinition<K> {
     return isEqual(def, logDefinitions[def.name]);
   }
 
@@ -91,7 +91,7 @@ export default class Splitter {
   }
 
   processAnalysisOptions(): ReindexedLogDefs {
-    const remap: { [type: string]: LogDefinition<LogDefinitionTypes> } = {};
+    const remap: { [type: string]: LogDefinition<LogDefinitionName> } = {};
     for (const def of Object.values(logDefinitions)) {
       if (!this.isLogDefinition(def))
         throw new UnreachableCode();
@@ -113,7 +113,7 @@ export default class Splitter {
     return remap;
   }
 
-  decodeRsv(line: string, type: LogDefinitionTypeCode): string {
+  decodeRsv(line: string, type: LogDefinitionType): string {
     let fieldsToSubstitute = this.logTypes[type].possibleRsvFields;
     if (fieldsToSubstitute === undefined)
       return line;
@@ -137,7 +137,7 @@ export default class Splitter {
   // Default is false, since the analysis filter is restrictive by design
   // `type` is optional, so that it can be called with global/lastInclude lines where
   // we aren't pre-parsing the type of each line.
-  analysisFilter(line: string, type?: LogDefinitionTypeCode): boolean {
+  analysisFilter(line: string, type?: LogDefinitionType): boolean {
     if (type === undefined) {
       const lineType = line.split('|')[0];
       if (!this.isLogDefinitionType(lineType))


### PR DESCRIPTION
As mentioned in the TODO in `netlog_defs`, this renames `LogDefinitionTypes`=> `LogDefinitionName`, and `LogDefinitionTypeCode` => `LogDefinitionType` (along with all imports and uses of these types).

This better aligns the type names with the syntax used in `latestLogDefinitions`, e.g. `type` as a numeric line identifier, and `name` as a friendly-name line identifier.