### PR TITLE
util: refactor splitter pt. 2 (auto-updater)

### DIFF
--- a/.github/logdef_update_pr_template.md
+++ b/.github/logdef_update_pr_template.md
@@ -1,0 +1,19 @@
+> [!CAUTION]
+> ***NOTE TO REVIEWERS:***
+> Due to GitHub limitations, you ***must*** close & re-open this PR before merging to ensure pre-merge workflows (e.g. linters) are correctly triggered.**
+
+This PR was auto-generated based on a recent repo commit to either `resources/netlog_defs.ts` or to a file in `ui/raidboss/data`.
+
+It updates the analysis filter criteria to ensure all log line types currently being used by raidboss triggers/timelines are included in the log splitter's analysis filter (unless actively suppressed).
+
+This update was triggered after finding the below uses of certain log line types. Please carefully review these uses to determine if including all log lines of these types in the analysis filter is appropriate.
+
+You can instead change the `include` property to `'filter'` (and add `filters:`), or to `'never'` to suppress the log line type from the filter. Changes can be pushed to the PR branch before merging this PR. 
+
+
+{{ .changelist }}
+
+
+> [!CAUTION]
+> ***REMINDER:***
+> Please don't forget to close & re-open this PR before merging to ensure pre-merge workflows are correctly triggered!

--- a/.github/workflows/update_logdefs.yml
+++ b/.github/workflows/update_logdefs.yml
@@ -1,0 +1,44 @@
+# Runs on any merge commit that changes `netlog_defs` or raidboss triggers/timelines
+# Ensures `netlog_defs` analysis filters include all currently-in-use log lines (unless suppressed)
+name: Update Log Defs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'resources/netlog_defs.ts'
+      - 'ui/raidboss/data/**'
+
+jobs:
+  update-logdefs:
+    name: Update Analysis Filters
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'OverlayPlugin/cactbot' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: ./.github/actions/setup-js-env
+
+      - name: Run update script
+        id: script
+        run: |
+          npm run update-logdefs
+
+      - name: Render PR Template
+        id: template
+        uses: chuhlomin/render-template@v1.9
+        with:
+          template: .github/logdef_update_pr_template.md
+          vars: |
+            changelist: "${{ steps.script.outputs.changelist }}"
+
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: 'update netlog_defs filters'
+          title: 'resources: Update netlog_defs filters (auto-generated)'
+          body: ${{ steps.template.outputs.result }}
+          branch: 'update-logdefs'

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "lodash": "^4.14.170"
       },
       "devDependencies": {
+        "@actions/core": "^1.10.1",
         "@actions/exec": "^1.1.1",
         "@actions/github": "^5.0.0",
         "@actions/http-client": "^1.0.11",
@@ -96,7 +97,27 @@
         "webpack-merge": "^5.8.0"
       },
       "engines": {
-        "node": ">=18.10.0 <18.19"
+        "node": ">=20.10.0"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
+      "dev": true,
+      "dependencies": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@actions/core/node_modules/@actions/http-client": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.1.tgz",
+      "integrity": "sha512-KhC/cZsq7f8I4LfZSJKgCvEwfkE8o1538VoBeoGzokVLLnbFDEAdFD3UhoMklxo2un9NJVBdANOresx7vTHlHw==",
+      "dev": true,
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^5.25.4"
       }
     },
     "node_modules/@actions/exec": {
@@ -1958,6 +1979,15 @@
       "version": "14.18.16",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.16.tgz",
       "integrity": "sha512-X3bUMdK/VmvrWdoTkz+VCn6nwKwrKCFTHtqwBIaQJNx4RUIBBUFXM00bqPz/DsDd+Icjmzm6/tyYZzeGVqb6/Q=="
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.7",
@@ -15609,6 +15639,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "dev": true,
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -16731,6 +16773,28 @@
     }
   },
   "dependencies": {
+    "@actions/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
+      "dev": true,
+      "requires": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@actions/http-client": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.1.tgz",
+          "integrity": "sha512-KhC/cZsq7f8I4LfZSJKgCvEwfkE8o1538VoBeoGzokVLLnbFDEAdFD3UhoMklxo2un9NJVBdANOresx7vTHlHw==",
+          "dev": true,
+          "requires": {
+            "tunnel": "^0.0.6",
+            "undici": "^5.25.4"
+          }
+        }
+      }
+    },
     "@actions/exec": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
@@ -18042,6 +18106,12 @@
           "integrity": "sha512-X3bUMdK/VmvrWdoTkz+VCn6nwKwrKCFTHtqwBIaQJNx4RUIBBUFXM00bqPz/DsDd+Icjmzm6/tyYZzeGVqb6/Q=="
         }
       }
+    },
+    "@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.7",
@@ -28258,6 +28328,15 @@
         "has-bigints": "^1.0.2",
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
+      }
+    },
+    "undici": {
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "dev": true,
+      "requires": {
+        "@fastify/busboy": "^2.0.0"
       }
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -44,11 +44,13 @@
     "query": "npm run util -- query",
     "process-triggers": "node --loader=ts-node/esm util/process_triggers_folder.ts",
     "generate-log-guide": "node --loader=ts-node/esm util/gen_log_guide.ts",
+    "update-logdefs": "node --loader=ts-node/esm util/update_logdefs.ts",
     "validate-versions": "node --loader=ts-node/esm util/validate_versions.ts",
     "release": "node --loader=ts-node/esm util/do_release.ts",
     "version": "node --loader=ts-node/esm util/bump_version.ts"
   },
   "devDependencies": {
+    "@actions/core": "^1.10.1",
     "@actions/exec": "^1.1.1",
     "@actions/github": "^5.0.0",
     "@actions/http-client": "^1.0.11",

--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -42,7 +42,9 @@ export type LogDefinition<K extends LogDefinitionName> = {
     primaryKey: string;
     possibleKeys: readonly string[];
   };
-  // See `AnalysisOptions` type below. Omitting this prop is the same as `{ include: 'none' }`.
+  // See `AnalysisOptions` type. Omitting this property means no log lines will be included;
+  // however, if raidboss triggers are found using this line type, an automated workflow will
+  // create this property and set `include: 'all'`. To suppress this, use `include: 'never``.
   analysisOptions?: AnalysisOptions<K>;
 };
 
@@ -74,14 +76,15 @@ type LogDefSubFields<K extends LogDefinitionName> = {
 // `include:` specifies the level of inclusion:
 //   - 'all' will include all lines with no filtering.
 //   - 'filter' will include only those lines that match at least one of the specified `filters`.
-//   - 'none' and 'never' are similar, but 'never' is an override; unlike 'none', the automated
-//      workflow will not replace it with 'all' upon finding active triggers using this line type.
+//   - 'never' is an override; just like if the property were omitted, no log lines will be included
+//      in the filter; however, if 'never' is used, the automated workflow will not attempt to
+//      change it to 'all' upon finding active triggers using this line type.
 // `filters:` contains Netregex-style filter criteria. Lines satisfying at least one filter will be
 //   included. If `include:` = 'filter', `filters` must be present; otherwise, it must be omitted.
 // `combatantIdFields:` are field indices containing combatantIds. If specified, these fields
 //   will be checked for ignored combatants (e.g. pets) during log filtering.
 export type AnalysisOptions<K extends LogDefinitionName> = {
-  include: 'none' | 'never';
+  include: 'never';
   filters?: undefined;
   combatantIdFields?: undefined;
 } | {
@@ -804,6 +807,9 @@ const latestLogDefinitions = {
     },
     canAnonymize: true,
     firstOptionalField: undefined,
+    analysisOptions: {
+      include: 'never',
+    },
   },
   NameToggle: {
     type: '34',
@@ -825,6 +831,9 @@ const latestLogDefinitions = {
     },
     canAnonymize: true,
     firstOptionalField: undefined,
+    analysisOptions: {
+      include: 'never',
+    },
   },
   Tether: {
     type: '35',

--- a/ui/raidboss/timeline_parser.ts
+++ b/ui/raidboss/timeline_parser.ts
@@ -185,6 +185,8 @@ export class TimelineParser {
   private labelToTime: { [name: string]: number } = {};
   // Map of encountered syncs to the label they are jumping to.
   private labelToSync: { [name: string]: Sync[] } = {};
+  // Used in subclass (update_logdefs), but defined here due to being utilized during construction
+  public entries: Partial<Record<LogDefinitionName, number[]>> | undefined;
 
   constructor(
     text: string,
@@ -498,6 +500,8 @@ export class TimelineParser {
       return line;
     }
 
+    this.parseType(netRegexType, lineNumber);
+
     line = line.replace(syncCommand.netRegex, '').trim();
 
     let params: unknown;
@@ -651,6 +655,12 @@ export class TimelineParser {
       e.duration = parseFloat(durationCommand.seconds);
     }
     return line;
+  }
+
+  // This no-op is intended to be overridden by subclasses, like the one in update_logdefs.ts.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public parseType(type: LogDefinitionName, lineNumber: number): void {
+    /* no-op */
   }
 
   private GetReplacedText(text: string): string {

--- a/ui/raidboss/timeline_parser.ts
+++ b/ui/raidboss/timeline_parser.ts
@@ -218,6 +218,8 @@ export class TimelineParser {
       });
     }
 
+    // TODO: This is a workaround for now, but whenever this class is refactored,
+    // responsibility for callilng parse() should be moved up to the instantiating code.
     if (!waitForParse)
       this.parse(text, triggers, styles ?? [], uniqueId);
   }

--- a/ui/raidboss/timeline_parser.ts
+++ b/ui/raidboss/timeline_parser.ts
@@ -185,8 +185,6 @@ export class TimelineParser {
   private labelToTime: { [name: string]: number } = {};
   // Map of encountered syncs to the label they are jumping to.
   private labelToSync: { [name: string]: Sync[] } = {};
-  // Used in subclass (update_logdefs), but defined here due to being utilized during construction
-  public entries: Partial<Record<LogDefinitionName, number[]>> | undefined;
 
   constructor(
     text: string,
@@ -195,6 +193,7 @@ export class TimelineParser {
     styles?: TimelineStyle[],
     options?: RaidbossOptions,
     zoneId?: number,
+    waitForParse?: boolean,
   ) {
     this.options = options ?? defaultOptions;
     this.perTriggerAutoConfig = this.options.PerTriggerAutoConfig;
@@ -219,10 +218,11 @@ export class TimelineParser {
       });
     }
 
-    this.parse(text, triggers, styles ?? [], uniqueId);
+    if (!waitForParse)
+      this.parse(text, triggers, styles ?? [], uniqueId);
   }
 
-  private parse(
+  protected parse(
     text: string,
     triggers: LooseTimelineTrigger[],
     styles: TimelineStyle[],

--- a/util/logtools/web_splitter.ts
+++ b/util/logtools/web_splitter.ts
@@ -30,10 +30,7 @@ const pageText = {
     cn: '对日志进行匿名化处理',
   },
   analysisFilterInput: {
-    en: 'Filter Log for Analysis',
-    de: 'Filter Log für Analysen',
-    fr: 'Filtrer le log pour analyse',
-    cn: '过滤日志进行分析',
+    en: 'Apply Analysis Filter (Dev Only)',
   },
   exportSelectedInput: {
     en: 'Export Selected',

--- a/util/update_logdefs.ts
+++ b/util/update_logdefs.ts
@@ -46,18 +46,14 @@ type FileMatch = {
 type FileMatches = Partial<Record<LogDefinitionName, FileMatch[]>>;
 
 class TimelineTypeExtractor extends TimelineParser {
-  private contents = '';
   public entries: Partial<Record<LogDefinitionName, number[]>> = {};
 
   constructor(contents: string) {
     // construct parent with waitForParse = true, because `entries` is initialized
     // after parent construction, but is populated by parse() method in parent
     super(contents, [], [], undefined, undefined, undefined, true);
-    this.contents = contents;
-  }
-
-  public callParse() {
-    this.parse(this.contents, [], [], 0);
+    // we've initialized entries now, so call parse()
+    this.parse(contents, [], [], 0);
   }
 
   public override parseType(type: LogDefinitionName, lineNumber: number) {
@@ -333,9 +329,7 @@ class LogDefUpdater {
 
   parseTimelineFile(file: string): void {
     const contents = fs.readFileSync(file).toString();
-    const extractor = new TimelineTypeExtractor(contents);
-    extractor.callParse();
-    const entries = extractor.entries;
+    const entries = new TimelineTypeExtractor(contents).entries;
 
     if (entries === undefined) {
       console.error(`ERROR: Could not find timeline sync entries in ${file}`);

--- a/util/update_logdefs.ts
+++ b/util/update_logdefs.ts
@@ -17,8 +17,7 @@ import { walkDirSync } from './file_utils';
 // If the property is absent, this script will create it and set it to 'all'.
 
 // If the type should be ignored by this script (despite being used), `include` can instead be set
-// to 'never' -- which is identical to 'none' but suppresses this script's functionality.
-// Alternatively, the type can be set to 'filter' if only certain lines of that type should be
+// to 'never'. Alternatively, set the type to 'filter' if only certain lines of that type should be
 // included in the analysis filter. See `netlog_defs.ts` for more information.
 
 // This script can be run via CLI as `npm run update-logdefs`.  If run via GitHub Actions (after a

--- a/util/update_logdefs.ts
+++ b/util/update_logdefs.ts
@@ -1,0 +1,367 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import * as core from '@actions/core';
+
+import logDefinitions, { LogDefinitionName } from '../resources/netlog_defs';
+
+import { walkDirSync } from './file_utils';
+
+// This script parses all raidboss triggers and timelines, finds log line types used in them,
+// and compares against `netlog_defs.ts` to find any types that are not presently being included
+// in the log splitter's analysis filter (based on the `analysisOptions.include` property).
+// If the property is absent, this script will create it and set it to 'all'.
+
+// If the type should be ignored by this script (despite being used), `include` can instead be set
+// to 'never' -- which is identical to 'none' but suppresses this script's functionality.
+// Alternatively, the type can be set to 'filter' if only certain lines of that type should be
+// included in the analysis filter. See `netlog_defs.ts` for more information.
+
+// This script can be run via CLI as `npm run update-logdefs`.  If run via GitHub Actions (after a
+// triggering merge commit), the workflow will automatically create a PR to merge any changes.
+
+// TODO: This could be expanded to check for oopsy triggers as well, but those are complex to parse
+// and there is low likelihood of a type being used in oopsy while not being used in any trigger or
+// timeline; and an even lower likelihood of that type being useful for future log analysis.
+
+const isGithubRunner = process.env.GITHUB_ACTIONS === 'true';
+const sha = process.env.GITHUB_SHA ?? 'main';
+const repo = process.env.GITHUB_REPOSITORY ?? 'OverlayPlugin/cactbot';
+const baseUrl = `https://github.com/${repo}/blob`;
+const raidbossRelDir = 'ui/raidboss/data';
+const netLogDefsFile = 'resources/netlog_defs.ts';
+
+// TODO: Perhaps these keywords should be imported? (Also used in mocha tests.)
+const timelineKeywords = [
+  'duration',
+  'window',
+  'jump',
+  'forcejump',
+];
+
+type FileList = {
+  timelines: string[];
+  triggers: string[];
+};
+
+type FileMatch = {
+  filename: string;
+  line: number;
+};
+
+type FileMatches = Partial<Record<LogDefinitionName, FileMatch[]>>;
+
+class LogDefUpdater {
+  private scriptFile = '';
+  private projectRoot = '';
+  private fileList: FileList;
+  // List of log line names that do not have any analysisOptions in netlog_defs
+  private logDefsNoInclude: LogDefinitionName[] = [];
+  // List of log line names that have analysisOptions.include = 'never'
+  // We don't update these, but collect usage so we can console.log() a notice about it
+  private logDefsNeverInclude: LogDefinitionName[] = [];
+  // Matches of non-included log line types found in triggers & timelines
+  // Keep them separate so we can slightly tweak the PR body output for each
+  private triggerMatches: FileMatches = {};
+  private timelineMatches: FileMatches = {};
+  // List of log line names that are being added to the analysis filter
+  private logDefsToUpdate: LogDefinitionName[] = [];
+
+  constructor() {
+    this.scriptFile = fileURLToPath(import.meta.url);
+    this.projectRoot = path.resolve(path.dirname(this.scriptFile), '..');
+
+    this.logDefsNoInclude = Object.values(logDefinitions).filter((def) =>
+      !('analysisOptions' in def)
+    ).map((def) => def.name);
+
+    this.logDefsNeverInclude = Object.values(logDefinitions).filter((def) =>
+      ('analysisOptions' in def) && def.analysisOptions.include === 'never'
+    ).map((def) => def.name);
+
+    this.fileList = this.getFileList();
+  }
+
+  isLogDefinitionName(type: string | undefined): type is LogDefinitionName {
+    return type !== undefined && type in logDefinitions;
+  }
+
+  buildRefUrl(file: string, line: number, sha: string, addExtraLine: boolean): string {
+    return addExtraLine
+      // for triggers, return an extra line in the URL to also display the trigger's netregex
+      ? `${baseUrl}/${sha}/${file}#L${line}-L${line + 1}`
+      // for timelines, the netregex is on the same line, so no need to include the extra line
+      : `${baseUrl}/${sha}/${file}#L${line}`;
+  }
+
+  buildPullRequestBodyContent(): string {
+    let output = '';
+    for (const type of this.logDefsNoInclude) {
+      const triggerMatches = this.triggerMatches[type] ?? [];
+      const timelineMatches = this.timelineMatches[type] ?? [];
+      if (triggerMatches.length === 0 && timelineMatches.length === 0)
+        continue;
+      output += `\n## \`${type}\`\n`;
+      triggerMatches.forEach((m) => {
+        output += `${this.buildRefUrl(m.filename, m.line, sha, true)}\n`;
+      });
+      timelineMatches.forEach((m) => {
+        output += `${this.buildRefUrl(m.filename, m.line, sha, false)}\n`;
+      });
+    }
+    return output;
+  }
+
+  processAndLogResults(): void {
+    // log results to the console for both CLI & GH workflow execution
+    for (const type of this.logDefsNoInclude) {
+      const matches = [
+        ...this.triggerMatches[type] ?? [],
+        ...this.timelineMatches[type] ?? [],
+      ];
+      if (matches.length === 0)
+        continue;
+
+      console.log(`** ${type} **`);
+      console.log(`Found non-included log line type in active use:`);
+
+      matches.forEach((m) => {
+        console.log(`  - ${m.filename}:${m.line}`);
+      });
+
+      console.log(`LOG DEFS UPDATED: ${type} is being added to the analysis filter.\n`);
+      this.logDefsToUpdate.push(type);
+    }
+
+    // Log a notice for 'never' log line types, just so we're aware of the usage count for each.
+    // In theory, these are set to 'never' because we really don't care about them for analysis,
+    // but a periodic reminder to re-evaluate never hurts.
+    for (const type of this.logDefsNeverInclude) {
+      const numMatches = (this.triggerMatches[type]?.length ?? 0) +
+        (this.timelineMatches[type]?.length ?? 0);
+      if (numMatches > 0) {
+        console.log(`** ${type} **`);
+        console.log(
+          `Found ${numMatches} active use(s) of suppressed ('never') log line type.`,
+        );
+        console.log(
+          `${type} will not be added to the analysis filter, but please consider whether updates are needed.\n`,
+        );
+      }
+    }
+  }
+
+  getFileList(): FileList {
+    const fileList: FileList = {
+      timelines: [],
+      triggers: [],
+    };
+
+    walkDirSync(path.posix.join(this.projectRoot, raidbossRelDir), (filepath) => {
+      if (/\/raidboss_manifest.txt/.test(filepath)) {
+        return;
+      }
+      if (/\/raidboss\/data\/.*\.txt/.test(filepath)) {
+        fileList.timelines.push(filepath);
+        return;
+      }
+      if (/\/raidboss\/data\/.*\.[jt]s/.test(filepath)) {
+        fileList.triggers.push(filepath);
+        return;
+      }
+    });
+
+    return fileList;
+  }
+
+  parseTriggerFile(file: string): void {
+    const contents = fs.readFileSync(file).toString();
+    const lines = contents.split(/\r*\n/);
+    const fileRegex = {
+      inTrSet: /^const triggerSet: TriggerSet<Data> = {/,
+      inTrArr: /^ {2}triggers: \[/,
+      inTrObj: /^ {4}\{/,
+      trType: /^ {6}type: '(?<type>[^']+)',$/,
+      outTrObj: /^ {4}\},/,
+      outTrArr: /^ {2}\],/,
+    };
+
+    let lineNum = 0;
+    let foundTriggers = false;
+    let insideTriggerSet = false;
+    let insideTriggersArr = false;
+    let insideTriggerObj = false;
+    let foundType = false;
+
+    for (const line of lines) {
+      ++lineNum;
+
+      if (line.match(fileRegex.inTrSet))
+        insideTriggerSet = true;
+      else if (insideTriggerSet && line.match(fileRegex.inTrArr)) {
+        foundTriggers = true;
+        insideTriggersArr = true;
+      } else if (insideTriggersArr && line.match(fileRegex.inTrObj))
+        insideTriggerObj = true;
+      else if (insideTriggerObj && !foundType) {
+        const match = fileRegex.trType.exec(line);
+        const type = match?.groups?.type;
+        if (type !== undefined) {
+          foundType = true;
+          if (!this.isLogDefinitionName(type)) {
+            console.error(`ERROR: Missing log def for ${type} in ${file} (line: ${lineNum})`);
+            continue;
+          } else if (
+            this.logDefsNoInclude.includes(type) ||
+            this.logDefsNeverInclude.includes(type)
+          )
+            (this.triggerMatches[type] ??= []).push({
+              filename: file.replace(`${this.projectRoot}/`, ''),
+              line: lineNum,
+            });
+        }
+      } else if (foundType && line.match(fileRegex.outTrObj)) {
+        insideTriggerObj = false;
+        foundType = false;
+      } else if (insideTriggersArr && line.match(fileRegex.outTrArr))
+        break;
+    }
+
+    if (!foundTriggers)
+      console.error(`ERROR: Could not find triggers in ${file}`);
+  }
+
+  parseTimelineFile(file: string): void {
+    const contents = fs.readFileSync(file).toString();
+    const lines = contents.split(/\r*\n/);
+    const fileRegex = {
+      ignoreLine: /^(#|hideall).*$/,
+      entrySeparator: /"[^"]*"|\{[^}]*\}|[^ ]+/g,
+    };
+    // TODO: Should this live somewhere else as an export?
+    const noSyncKeywords = ['label'];
+
+    let lineNum = 0;
+    for (const line of lines) {
+      ++lineNum;
+      if (
+        line.match(fileRegex.ignoreLine) ||
+        line.length === 0
+      ) {
+        continue;
+      }
+
+      // Capture each part of the line (separated by spaces).
+      // Anything encapsulated by double-quotes or braces will be treated as a single element.
+      const bareLine = line.replace(/"[^"]*?"/g, '""').replace(/#.*$/, '').trim();
+      const lineParts = bareLine.match(fileRegex.entrySeparator);
+      if (lineParts === null) {
+        continue;
+      }
+
+      const [time, name, type] = lineParts;
+      if (time === undefined || isNaN(parseFloat(time)))
+        console.error(`ERROR: Could not parse timeline in ${file} at line ${lineNum}`);
+      else if (
+        // We only care about sync entries with a netregex param
+        // So if this is a no-sync entry or a sync with keywords only, skip it
+        name === undefined ||
+        noSyncKeywords.includes(name) ||
+        type === undefined ||
+        timelineKeywords.includes(type)
+      )
+        continue;
+      else if (!this.isLogDefinitionName(type))
+        console.error(`ERROR: Missing log def for ${type} in ${file} (line: ${lineNum})`);
+      else if (
+        this.logDefsNoInclude.includes(type) ||
+        this.logDefsNeverInclude.includes(type)
+      )
+        (this.timelineMatches[type] ??= []).push({
+          filename: file.replace(`${this.projectRoot}/`, ''),
+          line: lineNum,
+        });
+    }
+  }
+
+  updateNetLogDefsFile(): void {
+    if (this.logDefsNoInclude.length === 0)
+      return;
+
+    const contents = fs.readFileSync(path.posix.join(this.projectRoot, netLogDefsFile)).toString();
+    const lines = contents.split(/\r*\n/);
+    const fileRegex = {
+      inConst: /^const latestLogDefinitions = {/,
+      inLogDef: /^ {2}(\w+): \{/,
+      outLogDef: /^ {2}\},/,
+      outConst: /^} as const;/,
+    };
+
+    const output: string[] = [];
+    let foundConst = false;
+    let insideConst = false;
+    let insideLogDef = false;
+    let updateThisLogDef = false;
+
+    for (const line of lines) {
+      // initial processing - haven't found the logdefs yet
+      if (!foundConst) {
+        if (line.match(fileRegex.inConst)) {
+          foundConst = true;
+          insideConst = true;
+        }
+        output.push(line);
+        continue;
+      }
+
+      // we're done updating, so just write the rest of the file
+      if (!insideConst) {
+        output.push(line);
+        continue;
+      }
+
+      // looking for the next logdef
+      if (!insideLogDef) {
+        const logDefName = line.match(fileRegex.inLogDef)?.[1];
+        if (logDefName !== undefined && this.isLogDefinitionName(logDefName)) {
+          insideLogDef = true;
+          if (this.logDefsToUpdate.includes(logDefName))
+            updateThisLogDef = true;
+        }
+      } else if (line.match(fileRegex.outLogDef)) {
+        // at the end of the logdef; update it now if needed
+        insideLogDef = false;
+        if (updateThisLogDef) {
+          const objToAdd = `    analysisOptions: {\r\n      include: 'all',\r\n    },`;
+          output.push(objToAdd);
+          updateThisLogDef = false;
+        }
+      } else if (insideConst && line.match(fileRegex.outConst))
+        insideConst = false;
+
+      output.push(line);
+    }
+
+    fs.writeFileSync(path.posix.join(this.projectRoot, netLogDefsFile), output.join('\r\n'));
+  }
+
+  doUpdate(): void {
+    console.log('Processing trigger files...');
+    this.fileList.triggers.forEach((f) => this.parseTriggerFile(f));
+
+    console.log('Processing timeline files...');
+    this.fileList.timelines.forEach((f) => this.parseTimelineFile(f));
+
+    console.log('File processing complete.\r\n');
+
+    this.processAndLogResults();
+    this.updateNetLogDefsFile();
+
+    if (isGithubRunner)
+      core.setOutput('changelist', this.buildPullRequestBodyContent());
+  }
+}
+
+const updater = new LogDefUpdater();
+updater.doUpdate();

--- a/util/update_logdefs.ts
+++ b/util/update_logdefs.ts
@@ -307,7 +307,7 @@ class LogDefUpdater {
       }
 
       // if we found the id but not the regex, just capture the two lines after the id line
-      regexLine === 0 ? idLine + 2 : regexLine;
+      regexLine = regexLine === 0 ? idLine + 2 : regexLine;
 
       if (!this.isLogDefinitionName(type)) {
         console.error(`ERROR: Missing log def for ${type} in ${file} (line: ${idLine})`);

--- a/util/update_logdefs.ts
+++ b/util/update_logdefs.ts
@@ -303,8 +303,7 @@ class LogDefUpdater {
           console.error(`ERROR: Could not find trigger '${id}' in ${file}`);
           continue;
         } else
-          // not going to include any other lines in the excerpt
-          regexLine = undefined;
+          regexLine = undefined; // don't try to add lines to the excerpt
       }
 
       // if we found the id but not the regex, just capture the two lines after the id line
@@ -336,7 +335,9 @@ class LogDefUpdater {
 
     for (const [type, lineNums] of Object.entries(entries)) {
       if (!this.isLogDefinitionName(type))
-        console.error(`ERROR: Missing log def for ${type} in ${file} (line: ${lineNums[0] ?? '?'})`);
+        console.error(
+          `ERROR: Missing log def for ${type} in ${file} (line: ${lineNums[0] ?? '?'})`,
+        );
       else if (
         this.logDefsNoInclude.includes(type) ||
         this.logDefsNeverInclude.includes(type)

--- a/util/update_logdefs.ts
+++ b/util/update_logdefs.ts
@@ -219,7 +219,7 @@ class LogDefUpdater {
             idLine = lineNum;
           else
             break;
-        } else if (idLine > 0 && line.includes('netRegex: {') !== null) {
+        } else if (idLine > 0 && line.includes('netRegex: {')) {
           regexLine = lineNum;
           break;
         }
@@ -281,7 +281,7 @@ class LogDefUpdater {
             idLine = lineNum;
           else
             break;
-        } else if (idLine > 0 && line.includes('netRegex: {') !== null) {
+        } else if (idLine > 0 && line.includes('netRegex: {')) {
           regexLine = lineNum;
           break;
         }


### PR DESCRIPTION
Part 2 of the work on #94 (see #109 for more info).

~~This is built on the type-name changes in #127, so that should be merged first (and the changes in `94fd33e` can be ignored, as I will rebase them out before merging).~~

This also sets both `ActorControl` and `NameToggle` to `include: 'never'`.  Both are used ubiquitously in timelines (83 and 60 files, respectively) as wipe regex and to sync --untargetable-- and --targetable-- entries, and since those use cases are handled automatically by timeline tools, I wouldn't think they would have much utility via analysis filtering (although open to leaving them in if others feel differently?).  I'm mostly disabling them from the filter in this PR to avoid massively cluttering the auto-generated PR that will follow.  Speaking of which...

When this is merged, I expect an auto-generated PR to flag uses of (and attempt to add `include: 'all'` to):
  - `RemovedCombatant` (used in 3 triggers, 2 timelines)
  - `NetworkCancelAbility` (used in 2 timelines)
  - `WasDefeated` (used in 3 triggers, 1 timeline)
  - `NetworkEffectResult` (used in 1 trigger)
  - `StartsUsingExtra` (used in 2 triggers)

That said, I think we can save discussion & changes to those for the auto-generated PR.