### PR TITLE
raidemulator: Fix bug with keepalive timers

### DIFF
--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimeline.ts
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimeline.ts
@@ -44,6 +44,21 @@ export default class RaidEmulatorTimeline extends Timeline {
     this._OnUpdateTimer(currentLogTime);
   }
 
+  public override _OnUpdateTimer(currentTime: number): void {
+    // The base `Timeline` class's `_RemoveExpiredTimers` has a hardcoded `Date.now()` reference
+    // for keepalive timers.
+    // There's not really a good way to handle this logic otherwise due to not having any other
+    // time base to reference against.
+    // So we treat any `currentTime` value greater than the last log line of the current encounter
+    // as if it was the current timestamp
+    const lastLogTimestamp = this.emulator?.currentEncounter?.encounter
+      .logLines.slice(-1)[0]?.timestamp;
+    if (lastLogTimestamp && currentTime > lastLogTimestamp)
+      currentTime = this.emulator?.currentLogTime ?? currentTime;
+
+    super._OnUpdateTimer(currentTime);
+  }
+
   override _ScheduleUpdate(_fightNow: number): void {
     // Override
   }


### PR DESCRIPTION
This bug is caused by the following:

https://github.com/OverlayPlugin/cactbot/blob/3d9771aebbd4f810fb39fdcc040df7970bfd296a/ui/raidboss/timeline.ts#L411-L413

None of the other `Date.now()` references in `timeline.ts` have an impact for raidemulator due to being overridden already.

This is evidenced by the following debug output from a DSR log file provided in Discord:

![image](https://github.com/OverlayPlugin/cactbot/assets/6119598/834d9969-e8ed-47c0-b8a5-506b5c16b4b1)
