### PR TITLE
util: anonymizer support for 'possible' playerid fields

### DIFF
--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -29,7 +29,8 @@ export type LogDefinition<K extends LogDefinitionName> = {
   subFields?: LogDefSubFields<K>;
   // Map of field indices to anonymize, in the format: playerId: (optional) playerName.
   playerIds?: PlayerIdMap<K>;
-  // A list of field indices that may (or may not) contain player ids & will be anonymized.
+  // A list of field indices that may contains player ids and, if so, will be anonymized.
+  // If an index is listed here and in `playerIds`, it will be treated as a possible id field.
   possiblePlayerIds?: readonly LogDefFieldIdx<K>[];
   // A list of field indices that are ok to be blank (or have invalid ids).
   blankFields?: readonly LogDefFieldIdx<K>[];

--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -29,6 +29,8 @@ export type LogDefinition<K extends LogDefinitionName> = {
   subFields?: LogDefSubFields<K>;
   // Map of field indices to anonymize, in the format: playerId: (optional) playerName.
   playerIds?: PlayerIdMap<K>;
+  // A list of field indices that may (or may not) contain player ids & will be anonymized.
+  possiblePlayerIds?: readonly LogDefFieldIdx<K>[];
   // A list of field indices that are ok to be blank (or have invalid ids).
   blankFields?: readonly LogDefFieldIdx<K>[];
   // This field index (and all after) will be treated as optional when creating capturing regexes.
@@ -829,6 +831,7 @@ const latestLogDefinitions = {
       data2: 6,
       data3: 7,
     },
+    possiblePlayerIds: [4, 5, 6, 7],
     canAnonymize: true,
     firstOptionalField: undefined,
     analysisOptions: {
@@ -1573,6 +1576,7 @@ const latestLogDefinitions = {
     playerIds: {
       2: null,
     },
+    possiblePlayerIds: [4, 5, 6, 7],
     canAnonymize: true,
     firstOptionalField: undefined,
     analysisOptions: {
@@ -1600,6 +1604,7 @@ const latestLogDefinitions = {
     playerIds: {
       2: null,
     },
+    possiblePlayerIds: [4, 5, 6, 7, 8, 9],
     canAnonymize: true,
     firstOptionalField: undefined,
     analysisOptions: {

--- a/util/logtools/anonymizer.ts
+++ b/util/logtools/anonymizer.ts
@@ -13,6 +13,11 @@ import FakeNameGenerator from './fake_name_generator';
 import { Notifier } from './notifier';
 import { ReindexedLogDefs } from './splitter';
 
+// TODO: Anonymizer currently finds/replaces player ids (potentially paired with a player name).
+// There are a few edge cases (Countdown/CountdownCancel) where a player name may apepar
+// with no corresponding id (e.g. a blank id). We don't currently handle that scenario given the
+// non-likelihood of occurence, but this could be handled in the future.
+
 // TODO: is the first byte of ids always flags, such that "..000000" is always empty?
 const emptyIds = ['E0000000', '80000000'];
 export default class Anonymizer {

--- a/util/logtools/anonymizer.ts
+++ b/util/logtools/anonymizer.ts
@@ -146,7 +146,7 @@ export default class Anonymizer {
       return splitLine.join('|');
 
     // Anonymize fields.
-    for (const [idIdxStr, nameIdx] of Object.entries(playerIds ?? {})) {
+    for (const [idIdxStr, nameIdx] of Object.entries(playerIds)) {
       const idIdx = parseInt(idIdxStr);
       if (!this.isLogDefinitionFieldIdx(idIdx, typeDef.name)) {
         notifier.warn(`internal error: invalid field index: ${idIdx}`, splitLine);

--- a/util/logtools/anonymizer.ts
+++ b/util/logtools/anonymizer.ts
@@ -134,13 +134,19 @@ export default class Anonymizer {
     if (!canAnonymizeSubField && !typeDef.canAnonymize)
       return;
 
+    const playerIds = typeDef.playerIds ?? {};
+    const possibleIds = typeDef.possiblePlayerIds ?? [];
+    possibleIds.forEach((id) => {
+      if (!(id in playerIds))
+        playerIds[id] = null;
+    });
+
     // If nothing to anonymize, we're done.
-    const playerIds = typeDef.playerIds;
-    if (playerIds === undefined)
+    if (Object.keys(playerIds).length === 0)
       return splitLine.join('|');
 
     // Anonymize fields.
-    for (const [idIdxStr, nameIdx] of Object.entries(playerIds)) {
+    for (const [idIdxStr, nameIdx] of Object.entries(playerIds ?? {})) {
       const idIdx = parseInt(idIdxStr);
       if (!this.isLogDefinitionFieldIdx(idIdx, typeDef.name)) {
         notifier.warn(`internal error: invalid field index: ${idIdx}`, splitLine);
@@ -149,6 +155,8 @@ export default class Anonymizer {
 
       const isOptional = typeDef.firstOptionalField !== undefined &&
         idIdx >= typeDef.firstOptionalField;
+
+      const isPossible = possibleIds.includes(idIdx);
 
       // Check for ids that are out of range, possibly optional.
       // The last field is always the hash, so don't include that either.
@@ -172,8 +180,8 @@ export default class Anonymizer {
       // Cutscenes get added combatant messages with ids such as 'FF000006' and no name.
       const isCutsceneId = playerId.startsWith('FF');
 
-      // Handle weirdly shaped ids.
-      if (playerId.length !== 8 || isCutsceneId) {
+      // Handle weirdly shaped ids (if not a 'possible' id field).
+      if (!isPossible && (playerId.length !== 8 || isCutsceneId)) {
         // Also, sometimes ids are '0000' or '0'.  Treat these the same as implicitly optional.
         const isZero = parseInt(playerId) === 0;
         if (isOptional || isZero || isCutsceneId) {
@@ -192,6 +200,17 @@ export default class Anonymizer {
       // Ignore monsters.
       if (playerId.startsWith('4'))
         continue;
+
+      // If it's a 'possible' field but not a playerId-like value, no need to anonymize.
+      // If a playerId-like value:
+      //   - If it's a known playerId, do nothing here (it will be silently anonymized later)
+      //   - If it's a new id, it could be a false positive, so give an awareness info msg.
+      if (isPossible) {
+        if (playerId.match(/^1.{7}$/) === null)
+          continue;
+        else if (!(playerId in this.anonMap))
+          notifier.info(`found & anonymized possible playerid ${playerId}`, splitLine);
+      }
 
       // Replace the id at this index with a fake player id.
       const fakePlayerId = this.anonMap[playerId] ??= this.addNewPlayer();

--- a/util/logtools/notifier.ts
+++ b/util/logtools/notifier.ts
@@ -1,10 +1,18 @@
 export interface Notifier {
+  info: (reason: string, splitLine?: string[]) => void;
   warn: (reason: string, splitLine?: string[]) => void;
   error: (reason: string, splitLine?: string[]) => void;
 }
 
 export class ConsoleNotifier implements Notifier {
   constructor(private fileName: string, private errorFunc: (str: string) => void) {}
+
+  public info(reason: string, splitLine?: string[]): void {
+    if (splitLine === undefined)
+      this.errorFunc(`${this.fileName}: ${reason}`);
+    else
+      this.errorFunc(`${this.fileName}: ${reason}: ${splitLine.join('|')}`);
+  }
 
   public warn(reason: string, splitLine?: string[]): void {
     if (splitLine === undefined)

--- a/util/logtools/splitter.css
+++ b/util/logtools/splitter.css
@@ -59,3 +59,8 @@ button {
   font-weight: bold;
   color: yellow;
 }
+
+.info {
+  font-weight: bold;
+  color: darkgreen;
+}

--- a/util/logtools/web_splitter.ts
+++ b/util/logtools/web_splitter.ts
@@ -211,7 +211,7 @@ class PageState {
 class WebNotifier implements Notifier {
   constructor(private errorDiv: HTMLElement) {}
 
-  private errorFunc(severity: 'warn' | 'error', reason: string, splitLine?: string[]) {
+  private errorFunc(severity: 'info' | 'warn' | 'error', reason: string, splitLine?: string[]) {
     const splitStr = splitLine === undefined ? '' : `:${splitLine.join('|')}`;
     const outputStr = `${severity}: ${reason}${splitStr}`;
 
@@ -219,6 +219,10 @@ class WebNotifier implements Notifier {
     div.innerHTML = outputStr;
     div.classList.add(severity);
     this.errorDiv.appendChild(div);
+  }
+
+  public info(reason: string, splitLine?: string[]): void {
+    this.errorFunc('info', reason, splitLine);
   }
 
   public warn(reason: string, splitLine?: string[]): void {


### PR DESCRIPTION
Closes #122. I will probably do a separate PR at some point to add support for repeating fields (per the note on `CombatantMemory` in `netlog_defs`).