### PR TITLE
i18n: TEA Wormhole start configuration message for Japanese

### DIFF
--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.ts
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.ts
@@ -360,7 +360,8 @@ const triggerSet: TriggerSet<Data> = {
           'Aktiviere Cactbot Wormhole Strategie: https://ff14.toolboxgaming.space/?id=17050133675751&preview=1',
         fr:
           'Activer cactbot pour la strat Wormhole : https://ff14.toolboxgaming.space/?id=17050133675751&preview=1',
-        ja: '絶アレキサンダー討滅戦：cactbot「次元断絶のマーチ」ギミック', // FIXME
+        ja:
+          '次元断絶のマーチ 開始時トリガー有効化 初期設定の想定: https://ff14.toolboxgaming.space/?id=17050133675751&preview=1',
         cn: '启用 cactbot 灵泉策略: https://ff14.toolboxgaming.space/?id=17050133675751&preview=1',
         ko: 'cactbot 웜홀 공략방식 사용: https://ff14.toolboxgaming.space/?id=17050133675751&preview=1',
       },


### PR DESCRIPTION
## Overview

This is a small Japanese translation update for The Epic of Alexander trigger settings. 
This change is necessary to inform users that the actual mechanic handling (e.g., positioning, movement) and initial setup differ from the popular method used in Japan.