### PR TITLE
util: suppress i18n errors for example log lines

### DIFF
--- a/util/example_log_lines.ts
+++ b/util/example_log_lines.ts
@@ -2,6 +2,8 @@
 // Use `npm run generate-log-guide` after updating this file.
 // Also make sure to add unit tests in /test/helper/example_log_lines_test_data.ts.
 
+// cactbot-ignore-all-missing-translations
+
 import { Lang } from '../resources/languages';
 import { LogDefinitionName } from '../resources/netlog_defs';
 import NetRegexes from '../resources/netregexes';

--- a/util/find_missing_translations.ts
+++ b/util/find_missing_translations.ts
@@ -83,11 +83,12 @@ const parseJavascriptFile = async (
   const keyRe = /^\s*(\w{2}):/;
   const fixmeRe = /\/\/ FIX-?ME/;
   const ignoreRe = /cactbot-ignore-missing-translations/;
+  const ignoreAllRe = /cactbot-ignore-all-missing-translations/; // file-wide ignore
 
   for await (const line of lineReader) {
     lineNumber++;
-    // Immediately exit if the file is auto-generated
-    if (line.match('// Auto-generated')) {
+    // Immediately exit if the file is auto-generated or we're ignoring all missing translations.
+    if (line.match('// Auto-generated') || line.match(ignoreAllRe)) {
       lineReader.close();
       lineReader.removeAllListeners();
       return;

--- a/util/gen_log_guide.ts
+++ b/util/gen_log_guide.ts
@@ -41,6 +41,7 @@ type LocaleText = LocaleObject<string>;
 
 type LangStrings =
   & {
+    // cactbot-ignore-missing-translations
     en: readonly string[];
   }
   & {


### PR DESCRIPTION
Closes #157.  I agree with @valarnin 's point there that certain example log lines could benefit from translations.

But since we do not have any translated versions of `LogGuide` at the moment, and the unit tests are all based on the `en` lines, I think it makes sense to at least suppress the warnings for now to prevent clutter on the `missing_translations` pages until it becomes relevant.