### PR TITLE
config: add remote subscription

### DIFF
--- a/resources/user_config.ts
+++ b/resources/user_config.ts
@@ -463,7 +463,12 @@ class UserConfig {
             fetch(link).then((response) => {
               if (!response.ok) {
                 console.log(`*** ERROR: Failed to fetch remote subscription link: ${link}`);
-                reject(new Error('Fetch failed'));
+                if (String(savedRemoteFiles[link])) {
+                  remoteFiles[link] = savedRemoteFiles[link] as string;
+                  resolve(savedRemoteFiles[link]);
+                } else {
+                  reject(new Error('Fetch failed'));
+                }
               }
               return response.text();
             }).then((text) => {

--- a/ui/config/config.css
+++ b/ui/config/config.css
@@ -429,3 +429,9 @@ input[type="checkbox"] {
   width: 15px;
   height: 15px;
 }
+
+textarea {
+  padding: 3px;
+  white-space: nowrap;
+  overflow: hidden;
+}

--- a/ui/config/config.ts
+++ b/ui/config/config.ts
@@ -542,6 +542,9 @@ export class CactbotConfigurator {
       case 'directory':
         this.buildDirectory(derivedOptions, groupDiv, opt, group, path);
         break;
+      case 'multiline':
+        this.buildMultiline(derivedOptions, groupDiv, opt, group, path);
+        break;
       default:
         console.error(`unknown type: ${JSON.stringify(opt)}`);
         break;
@@ -843,6 +846,45 @@ export class CactbotConfigurator {
     const setFunc = () => this.setOption(group, optIdPath, input.value);
     input.onchange = setFunc;
     input.oninput = setFunc;
+
+    parent.appendChild(this.buildLeftDiv(opt));
+    parent.appendChild(div);
+  }
+
+  buildMultiline(
+    options: BaseOptions,
+    parent: HTMLElement,
+    opt: ConfigEntry,
+    group: string,
+    path?: string[],
+  ): void {
+    const div = document.createElement('div');
+    div.classList.add('option-input-container');
+
+    const textarea = document.createElement('textarea');
+    textarea.classList.add('input-string-field');
+    div.appendChild(textarea);
+
+    const optIdPath = [...path ?? [], opt.id];
+    const optDefault = getOptDefault(opt, options);
+    textarea.placeholder = optDefault.toString();
+    textarea.value = this.getStringOption(
+      group,
+      optIdPath,
+      optDefault.toString(),
+    ).toString();
+    const calcSize = () => {
+      textarea.rows = textarea.value.split('\n').length;
+      const maxWidth = Math.max(...textarea.value.split('\n').map((line) => line.length));
+      textarea.style.width = `${Math.max(maxWidth + 10, 50)}ch`;
+    };
+    calcSize();
+    const setFunc = () => this.setOption(group, optIdPath, textarea.value);
+    textarea.onchange = setFunc;
+    textarea.oninput = () => {
+      calcSize();
+      setFunc();
+    };
 
     parent.appendChild(this.buildLeftDiv(opt));
     parent.appendChild(div);

--- a/ui/eureka/eureka_config.ts
+++ b/ui/eureka/eureka_config.ts
@@ -208,7 +208,7 @@ UserConfig.registerOptions('eureka', {
       default: '',
       comment: {
         en:
-          '<strong style="color:red;>WARNING!</strong>Importing remote JavaScript files can expose your device to risks. These files might steal your information or damage your device. Make sure to import files only from trusted developers.',
+          '<strong style="color:red;">WARNING!</strong>Importing remote JavaScript files can expose your device to risks. These files might steal your information or damage your device. Make sure to import files only from trusted developers.',
         cn:
           '<strong style="color:red;">警告！</strong>导入远程 JavaScript 文件可能会让你的设备暴露在风险中。这些文件可能会窃取你的信息或造成设备损坏。请确保只从信任的开发者处导入文件。',
       },

--- a/ui/eureka/eureka_config.ts
+++ b/ui/eureka/eureka_config.ts
@@ -194,5 +194,18 @@ UserConfig.registerOptions('eureka', {
         options['RefreshRateMs'] = seconds * 1000;
       },
     },
+    {
+      id: 'EurekaRemoteSubscriptionLink',
+      name: {
+        en: 'Eureka remote subscription link',
+        de: 'Eureka Remote Abonnement Link',
+        fr: 'Lien de souscription Eureka à distance',
+        ja: 'Eureka リモートサブスクリプションリンク',
+        cn: 'Eureka 远程订阅链接',
+        ko: 'Eureka 원격 구독 링크',
+      },
+      type: 'multiline',
+      default: '',
+    },
   ],
 });

--- a/ui/eureka/eureka_config.ts
+++ b/ui/eureka/eureka_config.ts
@@ -206,6 +206,12 @@ UserConfig.registerOptions('eureka', {
       },
       type: 'multiline',
       default: '',
+      comment: {
+        en:
+          '<strong style="color:red;>WARNING!</strong>Importing remote JavaScript files can expose your device to risks. These files might steal your information or damage your device. Make sure to import files only from trusted developers.',
+        cn:
+          '<strong style="color:red;">警告！</strong>导入远程 JavaScript 文件可能会让你的设备暴露在风险中。这些文件可能会窃取你的信息或造成设备损坏。请确保只从信任的开发者处导入文件。',
+      },
     },
   ],
 });

--- a/ui/jobs/jobs_config.ts
+++ b/ui/jobs/jobs_config.ts
@@ -310,7 +310,7 @@ UserConfig.registerOptions('jobs', {
       default: '',
       comment: {
         en:
-          '<strong style="color:red;>WARNING!</strong>Importing remote JavaScript files can expose your device to risks. These files might steal your information or damage your device. Make sure to import files only from trusted developers.',
+          '<strong style="color:red;">WARNING!</strong>Importing remote JavaScript files can expose your device to risks. These files might steal your information or damage your device. Make sure to import files only from trusted developers.',
         cn:
           '<strong style="color:red;">警告！</strong>导入远程 JavaScript 文件可能会让你的设备暴露在风险中。这些文件可能会窃取你的信息或造成设备损坏。请确保只从信任的开发者处导入文件。',
       },

--- a/ui/jobs/jobs_config.ts
+++ b/ui/jobs/jobs_config.ts
@@ -308,6 +308,12 @@ UserConfig.registerOptions('jobs', {
       },
       type: 'multiline',
       default: '',
+      comment: {
+        en:
+          '<strong style="color:red;>WARNING!</strong>Importing remote JavaScript files can expose your device to risks. These files might steal your information or damage your device. Make sure to import files only from trusted developers.',
+        cn:
+          '<strong style="color:red;">警告！</strong>导入远程 JavaScript 文件可能会让你的设备暴露在风险中。这些文件可能会窃取你的信息或造成设备损坏。请确保只从信任的开发者处导入文件。',
+      },
     },
   ],
 });

--- a/ui/jobs/jobs_config.ts
+++ b/ui/jobs/jobs_config.ts
@@ -296,5 +296,18 @@ UserConfig.registerOptions('jobs', {
       },
       default: 'threshold',
     },
+    {
+      id: 'JobsRemoteSubscriptionLink',
+      name: {
+        en: 'Jobs remote subscription link',
+        de: 'Jobs Remote Abonnement Link',
+        fr: 'Lien de souscription Jobs à distance',
+        ja: 'Jobs リモートサブスクリプションリンク',
+        cn: 'Jobs 远程订阅链接',
+        ko: 'Jobs 원격 구독 링크',
+      },
+      type: 'multiline',
+      default: '',
+    },
   ],
 });

--- a/ui/oopsyraidsy/oopsyraidsy_config.ts
+++ b/ui/oopsyraidsy/oopsyraidsy_config.ts
@@ -448,7 +448,7 @@ const templateOptions: OptionsTemplate = {
       default: '',
       comment: {
         en:
-          '<strong style="color:red;>WARNING!</strong>Importing remote JavaScript files can expose your device to risks. These files might steal your information or damage your device. Make sure to import files only from trusted developers.',
+          '<strong style="color:red;">WARNING!</strong>Importing remote JavaScript files can expose your device to risks. These files might steal your information or damage your device. Make sure to import files only from trusted developers.',
         cn:
           '<strong style="color:red;">警告！</strong>导入远程 JavaScript 文件可能会让你的设备暴露在风险中。这些文件可能会窃取你的信息或造成设备损坏。请确保只从信任的开发者处导入文件。',
       },

--- a/ui/oopsyraidsy/oopsyraidsy_config.ts
+++ b/ui/oopsyraidsy/oopsyraidsy_config.ts
@@ -434,6 +434,19 @@ const templateOptions: OptionsTemplate = {
       type: 'float',
       default: 2,
     },
+    {
+      id: 'OopsyraidsyRemoteSubscriptionLink',
+      name: {
+        en: 'Oopsyraidsy remote subscription link',
+        de: 'Oopsyraidsy Remote Abonnement Link',
+        fr: 'Lien de souscription Oopsyraidsy à distance',
+        ja: 'Oopsyraidsy リモートサブスクリプションリンク',
+        cn: 'Oopsyraidsy 远程订阅链接',
+        ko: 'Oopsyraidsy 원격 구독 링크',
+      },
+      type: 'multiline',
+      default: '',
+    },
   ],
 };
 
@@ -458,7 +471,8 @@ const userFileHandler: UserFileCallback = (
 
     // `filename` here is just cosmetic for better debug printing to make it more clear
     // where a trigger or an override is coming from.
-    set.filename = `${basePath}${name}`;
+    const isRemote = name.startsWith('http://') || name.startsWith('https://');
+    set.filename = isRemote ? name : `${basePath}${name}`;
     set.isUserTriggerSet = true;
   }
 };

--- a/ui/oopsyraidsy/oopsyraidsy_config.ts
+++ b/ui/oopsyraidsy/oopsyraidsy_config.ts
@@ -446,6 +446,12 @@ const templateOptions: OptionsTemplate = {
       },
       type: 'multiline',
       default: '',
+      comment: {
+        en:
+          '<strong style="color:red;>WARNING!</strong>Importing remote JavaScript files can expose your device to risks. These files might steal your information or damage your device. Make sure to import files only from trusted developers.',
+        cn:
+          '<strong style="color:red;">警告！</strong>导入远程 JavaScript 文件可能会让你的设备暴露在风险中。这些文件可能会窃取你的信息或造成设备损坏。请确保只从信任的开发者处导入文件。',
+      },
     },
   ],
 };

--- a/ui/radar/radar_config.ts
+++ b/ui/radar/radar_config.ts
@@ -131,6 +131,12 @@ UserConfig.registerOptions('radar', {
       },
       type: 'multiline',
       default: '',
+      comment: {
+        en:
+          '<strong style="color:red;>WARNING!</strong>Importing remote JavaScript files can expose your device to risks. These files might steal your information or damage your device. Make sure to import files only from trusted developers.',
+        cn:
+          '<strong style="color:red;">警告！</strong>导入远程 JavaScript 文件可能会让你的设备暴露在风险中。这些文件可能会窃取你的信息或造成设备损坏。请确保只从信任的开发者处导入文件。',
+      },
     },
   ],
 });

--- a/ui/radar/radar_config.ts
+++ b/ui/radar/radar_config.ts
@@ -119,5 +119,18 @@ UserConfig.registerOptions('radar', {
       type: 'checkbox',
       default: true,
     },
+    {
+      id: 'RadarRemoteSubscriptionLink',
+      name: {
+        en: 'Radar remote subscription link',
+        de: 'Radar Remote Abonnement Link',
+        fr: 'Lien de souscription Radar à distance',
+        ja: 'Radar リモートサブスクリプションリンク',
+        cn: 'Radar 远程订阅链接',
+        ko: 'Radar 원격 구독 링크',
+      },
+      type: 'multiline',
+      default: '',
+    },
   ],
 });

--- a/ui/radar/radar_config.ts
+++ b/ui/radar/radar_config.ts
@@ -133,7 +133,7 @@ UserConfig.registerOptions('radar', {
       default: '',
       comment: {
         en:
-          '<strong style="color:red;>WARNING!</strong>Importing remote JavaScript files can expose your device to risks. These files might steal your information or damage your device. Make sure to import files only from trusted developers.',
+          '<strong style="color:red;">WARNING!</strong>Importing remote JavaScript files can expose your device to risks. These files might steal your information or damage your device. Make sure to import files only from trusted developers.',
         cn:
           '<strong style="color:red;">警告！</strong>导入远程 JavaScript 文件可能会让你的设备暴露在风险中。这些文件可能会窃取你的信息或造成设备损坏。请确保只从信任的开发者处导入文件。',
       },

--- a/ui/raidboss/raidboss_config.ts
+++ b/ui/raidboss/raidboss_config.ts
@@ -2541,6 +2541,12 @@ const templateOptions: OptionsTemplate = {
       },
       type: 'multiline',
       default: '',
+      comment: {
+        en:
+          '<strong style="color:red;>WARNING!</strong>Importing remote JavaScript files can expose your device to risks. These files might steal your information or damage your device. Make sure to import files only from trusted developers.',
+        cn:
+          '<strong style="color:red;">警告！</strong>导入远程 JavaScript 文件可能会让你的设备暴露在风险中。这些文件可能会窃取你的信息或造成设备损坏。请确保只从信任的开发者处导入文件。',
+      },
     },
   ],
 };

--- a/ui/raidboss/raidboss_config.ts
+++ b/ui/raidboss/raidboss_config.ts
@@ -1607,7 +1607,8 @@ const userFileHandler: UserFileCallback = (
 
     // `filename` here is just cosmetic for better debug printing to make it more clear
     // where a trigger or an override is coming from.
-    set.filename = `${basePath}${name}`;
+    const isRemote = name.startsWith('http://') || name.startsWith('https://');
+    set.filename = isRemote ? name : `${basePath}${name}`;
     set.isUserTriggerSet = true;
 
     flattenTimeline(set, name, files);
@@ -2527,6 +2528,19 @@ const templateOptions: OptionsTemplate = {
       },
       type: 'float',
       default: 0.75,
+    },
+    {
+      id: 'RaidbossRemoteSubscriptionLink',
+      name: {
+        en: 'Raidboss remote subscription link',
+        de: 'Raidboss Remote Abonnement Link',
+        fr: 'Lien de souscription Raidboss à distance',
+        ja: 'Raidboss リモートサブスクリプションリンク',
+        cn: 'Raidboss 远程订阅链接',
+        ko: 'Raidboss 원격 구독 링크',
+      },
+      type: 'multiline',
+      default: '',
     },
   ],
 };

--- a/ui/raidboss/raidboss_config.ts
+++ b/ui/raidboss/raidboss_config.ts
@@ -2543,7 +2543,7 @@ const templateOptions: OptionsTemplate = {
       default: '',
       comment: {
         en:
-          '<strong style="color:red;>WARNING!</strong>Importing remote JavaScript files can expose your device to risks. These files might steal your information or damage your device. Make sure to import files only from trusted developers.',
+          '<strong style="color:red;">WARNING!</strong>Importing remote JavaScript files can expose your device to risks. These files might steal your information or damage your device. Make sure to import files only from trusted developers.',
         cn:
           '<strong style="color:red;">警告！</strong>导入远程 JavaScript 文件可能会让你的设备暴露在风险中。这些文件可能会窃取你的信息或造成设备损坏。请确保只从信任的开发者处导入文件。',
       },


### PR DESCRIPTION
This is a feature that allows users to fill in one or more remote file links in the config. 

I hope this will be useful when users need to follow a frequently updated user file, eliminating the need to repeatedly: "check for updates, download the file, open the local user folder, place the file, and reload the cactbot overlay."

Intended Use Case: Sharing your latest files with your teammates during the first week of savage content release.

Of course, this is not a recommended long-term solution. When file updates are less frequent, users should continue using the original local file folder solution.

This is just a sudden idea I had. If this proposal does not align with the design philosophy of cactbot, I fully understand if this feature is rejected.

![image](https://github.com/OverlayPlugin/cactbot/assets/33572696/f93d0e43-c11e-4600-8408-327013cc0c2a)

test link: `https://raw.githubusercontent.com/Souma-Sumire/20240620-test/main/raidboss.js`