### PR TITLE
plugin: fix crash during act shutdown

### DIFF
--- a/plugin/CactbotEventSource/CactbotEventSource.cs
+++ b/plugin/CactbotEventSource/CactbotEventSource.cs
@@ -161,7 +161,7 @@ namespace Cactbot {
         url = Path.GetFullPath(Path.Combine(dir, configFile));
 
       control.VisibleChanged += (o, e) => {
-        if (initDone)
+        if (initDone || !control.Visible)
           return;
         initDone = true;
         control.Init(url);


### PR DESCRIPTION
During shutdown, the `VisibleChanged` event is raised when the tab with the control is destroyed even if it was never visible. To avoid initialising the control panel during shutdown, I added a check that only initialises the control if it's actually visible. This should fix the crash causing this message:

![](https://camo.githubusercontent.com/855d1d4b82ab6f8022f29fb1b658745cc6c5da94bb639a33073d0ac8daba5c90/68747470733a2f2f692e696d6775722e636f6d2f64745a337652692e706e67)