### PR TITLE
build: enable user dir access for local webpack instance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,9 +119,9 @@ will immediately update the overlay,
 prompting a refresh within the overlay itself.
 This is the recommended approach of validating local code changes.
 
-For convenience, webpack has access to the `/user/webpack/` directory 
-inside your local git root.  You can use this directory to store assets
-for your persoonal user confiiguration (if any).
+For convenience, webpack has access to the `/user/webpack/` directory
+inside your local git root.
+You can use this directory to store assets for your persoonal user confiiguration (if any).
 The `/user/` directory is also suppressed for change tracking by `/.gitignore`.
 
 Alternatively, `npm run build` will locally create a production distribution

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,11 @@ will immediately update the overlay,
 prompting a refresh within the overlay itself.
 This is the recommended approach of validating local code changes.
 
+For convenience, webpack has access to the `/user/webpack/` directory 
+inside your local git root.  You can use this directory to store assets
+for your persoonal user confiiguration (if any).
+The `/user/` directory is also suppressed for change tracking by `/.gitignore`.
+
 Alternatively, `npm run build` will locally create a production distribution
 of cactbot. This shouldn't be necessary for developing
 and will be slower than running `npm start` for validating changes,

--- a/webpack/webpack.config.ts
+++ b/webpack/webpack.config.ts
@@ -77,6 +77,10 @@ export default (
           noErrorOnMissing: true,
         },
         {
+          from: 'user/webpack/**/*',
+          noErrorOnMissing: true,
+        },
+        {
           from: 'util/coverage/missing_translations*.html',
         },
       ],


### PR DESCRIPTION
Small QOL update to allow local webpack instances to access files within the `/user/webpack` directory inside the git root.  This is so user files (resources/sound files, etc.) can be accessed regardless of whether an overlay is pointed to a local plugin install or webpack.

(NB: Although webpack_dev does have access to the /resources dir, that dir is tracked for git updates whereas /user is not.)