### PR TITLE
build: Bump version to 0.32.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cactbot",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cactbot",
-      "version": "0.32.0",
+      "version": "0.32.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@fast-csv/parse": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "cactbot",
-  "version": "0.32.0",
-  "releaseSummary": "initial 7.0 (DT) support",
-  "releaseInDraft": "false",
+  "version": "0.32.1",
+  "releaseSummary": "ex1 timeline + triggers",
+  "releaseInDraft": "true",
   "license": "Apache-2.0",
   "type": "module",
   "types": "./types",

--- a/plugin/CactbotEventSource/Properties/AssemblyInfo.cs
+++ b/plugin/CactbotEventSource/Properties/AssemblyInfo.cs
@@ -21,5 +21,5 @@ using System.Runtime.InteropServices;
 // - Revision
 // GitHub has only 3 version components, so Revision should always be 0.
 // CactbotOverlay and CactbotEventSource version should match.
-[assembly: AssemblyVersion("0.32.0.0")]
-[assembly: AssemblyFileVersion("0.32.0.0")]
+[assembly: AssemblyVersion("0.32.1.0")]
+[assembly: AssemblyFileVersion("0.32.1.0")]

--- a/plugin/CactbotOverlay/Properties/AssemblyInfo.cs
+++ b/plugin/CactbotOverlay/Properties/AssemblyInfo.cs
@@ -20,5 +20,5 @@ using System.Runtime.InteropServices;
 // - Build Number
 // - Revision
 // GitHub has only 3 version components, so Revision should always be 0.
-[assembly: AssemblyVersion("0.32.0.0")]
-[assembly: AssemblyFileVersion("0.32.0.0")]
+[assembly: AssemblyVersion("0.32.1.0")]
+[assembly: AssemblyFileVersion("0.32.1.0")]


### PR DESCRIPTION
Pushing ex1 support out.  Releasing in draft so the release notes can be edited to (a) note that ex2 is next, followed by other content, and (b) include a link to the content coverage page.  Hopefully this should quell some of the questions in the ACT discord about DT content support...