### PR TITLE
util: Fix bug in fflogs tool

### DIFF
--- a/util/logtools/fflogs.ts
+++ b/util/logtools/fflogs.ts
@@ -116,8 +116,7 @@ class FFLogs {
     // For Event retrieval, check whether the data is paginated.
     // If it is, recursively retrieve it until it is all obtained.
     if (data.nextPageTimestamp !== undefined) {
-      const nextOptions = new URLSearchParams();
-      Object.assign(nextOptions, options);
+      const nextOptions = new URLSearchParams(options);
       nextOptions.set('start', data.nextPageTimestamp.toString());
       data = data as FFLogsEventResponse;
       const nextData = await this.callFFLogs(


### PR DESCRIPTION
I mentioned this bug in Discord a few days ago, but `Object.assign` isn't actually duplicating the options properly. This causes issues if the amount of events in a fight exceeds the fflogs page limit.