### PR TITLE
raidboss: ex2 timeline+triggers

### DIFF
--- a/resources/outputs.ts
+++ b/resources/outputs.ts
@@ -86,6 +86,17 @@ export default {
     cn: '坦克死刑',
     ko: '탱버',
   },
+  tetherBusters: {
+    en: 'Tank Tethers',
+    de: 'Tank-Verbindungen',
+    fr: 'Liens Tank',
+    ja: 'タンク線取り',
+    cn: '坦克截线',
+    ko: '탱커가 선 가로채기',
+  },
+  avoidTetherBusters: {
+    en: 'Avoid Tank Tethers',
+  },
   tankCleave: {
     en: 'Tank cleave',
     de: 'Tank Cleave',

--- a/ui/oopsyraidsy/data/07-dt/trial/zoraal-ja-ex.ts
+++ b/ui/oopsyraidsy/data/07-dt/trial/zoraal-ja-ex.ts
@@ -7,33 +7,33 @@ export type Data = OopsyData;
 const triggerSet: OopsyTriggerSet<Data> = {
   zoneId: ZoneId.EverkeepExtreme,
   damageWarn: {
-    'ZoraalJaEx MultiDirectional Divide Initial Lines': '93A2', // initial cross (+) AoE
-    'ZoraalJaEx MultiDirectional Divide Safe Squares 1': '93A4', // room-wide AoE with tiny safe squares
+    'ZoraalJaEx Multidirectional Divide Initial Lines': '93A2', // initial cross (+) AoE
+    'ZoraalJaEx Multidirectional Divide Safe Squares 1': '93A4', // room-wide AoE with tiny safe squares
     'ZoraalJaEx MultiDirectional Divide Safe Squares 2': '93A3', // ^ same - possibly the original lines?
     'ZoraalJaEx Backward Edge': '9972', // forward-facing room cleave
     'ZoraalJaEx Forward Edge': '937F', // backward-facing room cleave
-    'ZoraalJaEx Half Full Right': '9380', // Half-room cleave (left safe)
-    'ZoraalJaEx Half Full Left': '939E', // Half-room cleave (right safe)
-    'ZoraalJaEx Chasm of Vollok (Swords)': '939A', // Teleporting sword tile
-    'ZoraalJaEx Forged Track': '939D', // Teleporting sword line cleave
-    'ZoraalJaEx Stormy Edge': '9386', // Wind/knockback cleave
+    'ZoraalJaEx Half Full Right': '9380', // half-room cleave (left safe)
+    'ZoraalJaEx Half Full Left': '939E', // half-room cleave (right safe)
+    'ZoraalJaEx Chasm of Vollok (Swords)': '939A', // teleporting sword tile
+    'ZoraalJaEx Forged Track': '939D', // teleporting sword line cleave
+    'ZoraalJaEx Stormy Edge': '9386', // wind/knockback cleave
     // TODO: Figure out if the difference between 9383 vs. 9384 is
     // standing in the telegraphed line vs. one of the splashed lines?
-    'ZoraalJaEx Fiery Edge 1': '9383', // Fire cleave
-    'ZoraalJaEx Fiery Edge 2': '9384', // Fire cleave
+    'ZoraalJaEx Fiery Edge 1': '9383', // fire cleave
+    'ZoraalJaEx Fiery Edge 2': '9384', // fire cleave
     'ZoraalJaEx Siege of Vollok': '938B', // moving line with donut AoEs
     'ZoraalJaEx Walls of Vollok': '938C', // moving line with puddle AoEs
     'ZoraalJaEx Half Circuit Side': '939F', // left/right cleave
     'ZoraalJaEx Half Circuit Donut': '93A0', // swords out - inside safe
-    'ZoraalJaEx Half Circuit Point-blank': '93A1', // swords in - outside safe'
+    'ZoraalJaEx Half Circuit Point-blank': '93A1', // swords in - outside safe
     'ZoraalJaEx Chasm of Vollok (Knockaround)': '9394', // big quadrant swords
     'ZoraalJaEx Aero III': '9391', // standing in/near tornado with wind debuff
   },
   shareWarn: {
     'ZoraalJaEx Regicidal Rage': '993C', // tank tether busters (2x, solo)
-    'ZoraalJaEx Chasm of Vollok (Spread)': '9389', // Yellow Titan spreads
-    'ZoraalJaEx Bitter Whirlwind': '993E', // telegraphed - solo tankbuster
-    'ZoraalJaEx Bitter Whirlwind Followup': '9940', // untelegraphed - followup hits
+    'ZoraalJaEx Chasm of Vollok (Spread)': '9389', // yellow Titan spreads
+    'ZoraalJaEx Bitter Whirlwind': '993E', // telegraphed solo tankbuster
+    'ZoraalJaEx Bitter Whirlwind Followup': '9940', // untelegraphed follow-up hits
   },
   soloWarn: {
     'ZoraalJaEx Drum of Vollok': '938F', // enumerations

--- a/ui/oopsyraidsy/data/07-dt/trial/zoraal-ja-ex.ts
+++ b/ui/oopsyraidsy/data/07-dt/trial/zoraal-ja-ex.ts
@@ -1,0 +1,43 @@
+import ZoneId from '../../../../../resources/zone_id';
+import { OopsyData } from '../../../../../types/data';
+import { OopsyTriggerSet } from '../../../../../types/oopsy';
+
+export type Data = OopsyData;
+
+const triggerSet: OopsyTriggerSet<Data> = {
+  zoneId: ZoneId.EverkeepExtreme,
+  damageWarn: {
+    'ZoraalJaEx MultiDirectional Divide Initial Lines': '93A2', // initial cross (+) AoE
+    'ZoraalJaEx MultiDirectional Divide Safe Squares 1': '93A4', // room-wide AoE with tiny safe squares
+    'ZoraalJaEx MultiDirectional Divide Safe Squares 2': '93A3', // ^ same - possibly the original lines?
+    'ZoraalJaEx Backward Edge': '9972', // forward-facing room cleave
+    'ZoraalJaEx Forward Edge': '937F', // backward-facing room cleave
+    'ZoraalJaEx Half Full Right': '9380', // Half-room cleave (left safe)
+    'ZoraalJaEx Half Full Left': '939E', // Half-room cleave (right safe)
+    'ZoraalJaEx Chasm of Vollok (Swords)': '939A', // Teleporting sword tile
+    'ZoraalJaEx Forged Track': '939D', // Teleporting sword line cleave
+    'ZoraalJaEx Stormy Edge': '9386', // Wind/knockback cleave
+    // TODO: Figure out if the difference between 9383 vs. 9384 is
+    // standing in the telegraphed line vs. one of the splashed lines?
+    'ZoraalJaEx Fiery Edge 1': '9383', // Fire cleave
+    'ZoraalJaEx Fiery Edge 2': '9384', // Fire cleave
+    'ZoraalJaEx Siege of Vollok': '938B', // moving line with donut AoEs
+    'ZoraalJaEx Walls of Vollok': '938C', // moving line with puddle AoEs
+    'ZoraalJaEx Half Circuit Side': '939F', // left/right cleave
+    'ZoraalJaEx Half Circuit Donut': '93A0', // swords out - inside safe
+    'ZoraalJaEx Half Circuit Point-blank': '93A1', // swords in - outside safe'
+    'ZoraalJaEx Chasm of Vollok (Knockaround)': '9394', // big quadrant swords
+    'ZoraalJaEx Aero III': '9391', // standing in/near tornado with wind debuff
+  },
+  shareWarn: {
+    'ZoraalJaEx Regicidal Rage': '993C', // tank tether busters (2x, solo)
+    'ZoraalJaEx Chasm of Vollok (Spread)': '9389', // Yellow Titan spreads
+    'ZoraalJaEx Bitter Whirlwind': '993E', // telegraphed - solo tankbuster
+    'ZoraalJaEx Bitter Whirlwind Followup': '9940', // untelegraphed - followup hits
+  },
+  soloWarn: {
+    'ZoraalJaEx Drum of Vollok': '938F', // enumerations
+  },
+};
+
+export default triggerSet;

--- a/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.ts
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.ts
@@ -350,7 +350,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Zoraal Ja Ex Bitter Whirlwind',
       type: 'StartsUsing',
       netRegex: { id: '993E', source: 'Zoraal Ja' },
-      response: Responses.tankBuster(),
+      response: Responses.tankBusterSwap(),
     },
     {
       id: 'Zoraal Ja Ex Drum of Vollok Collect',
@@ -362,7 +362,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Zoraal Ja Ex Drum of Vollok',
       type: 'StartsUsing',
       netRegex: { id: '938F', source: 'Zoraal Ja', capture: false },
-      delaySeconds: 1,
+      delaySeconds: 0.3, // let Collect run first
       suppressSeconds: 1,
       alertText: (data, _matches, output) => {
         if (data.drumTargets.includes(data.me))
@@ -380,7 +380,6 @@ const triggerSet: TriggerSet<Data> = {
         },
       },
     },
-
     {
       id: 'Zoraal Ja Ex Knockaround Swords Collect',
       type: 'StartsUsing',
@@ -416,7 +415,7 @@ const triggerSet: TriggerSet<Data> = {
           swordQuad = 'west';
         else if (swordX > 102)
           swordQuad = 'east';
-        else if (swordY < 99)
+        else if (swordY < 98)
           swordQuad = 'north';
         else
           swordQuad = 'south';
@@ -435,10 +434,9 @@ const triggerSet: TriggerSet<Data> = {
         if (data.safeQuadrants.length !== 2 || data.mirrorPlatformLoc === undefined)
           return output.unknown!();
 
-        // Call these as left/right based on whether the player is on the knock plat or not
+        // Call these as left/right based on whether the player is on the mirror plat or not
         // Assume they are facing the boss at this point.
         // There will always be one safe quadrant closest to the boss on each platform.
-
         if (data.drumFar) { // player is on the mirror platform
           if (data.mirrorPlatformLoc === 'northwest')
             return data.safeQuadrants.includes('east')
@@ -530,6 +528,12 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { id: '9374', source: 'Zoraal Ja', capture: false },
       response: Responses.stackMarker(),
     },
+    // Calling 'Stay'/'Go Across' is based on whether the player receives the chains debuff
+    // and whether they still have the Wind Resistance debuff from jumping for Forward/Backward Half
+    // This can lead to some potentially erroneous results - e.g., a player dies (debuff removed
+    // early), is rezzed on the wrong platform, jumps early, etc.  We could instead call stay/go by
+    // role, but that would break in non-standard comps, and could still lead to the same erroneous
+    // results.  There doesn't seem to be a perfect solution here.
     {
       id: 'Zoraal Ja Ex Burning Chains',
       type: 'GainsEffect',
@@ -583,8 +587,10 @@ const triggerSet: TriggerSet<Data> = {
         },
       },
     },
-    // Use explicit output rather than Outputs.left/Outputs.right for these triggers
-    // Boss likes to jump & rotate, so pure 'left'/'right' can be misleading
+    // Continue to use 'Boss\'s X' output rather than Outputs.left/.right for these triggers
+    // Zoraal Ja jumps and rotates as the line moves through the arena, and players may
+    // change directions, so use boss-relative rather than trying to guess which way the player
+    // is facing.
     {
       id: 'Zoraal Ja Ex Might of Vollok Right Sword',
       type: 'StartsUsing',

--- a/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.ts
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.ts
@@ -1,20 +1,66 @@
+﻿import Conditions from '../../../../../resources/conditions';
+import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
 
 // TO DO:
-// - Regicidal Rage - add appropriate tank call
-// - Vollok/Sync - add safe tile(s) callout?
-// - Sync/Half Full - call safe boss half
-// - Half Circuit - call safe side
+// * Sync (swords & knockaround phases) - call safe tile(s)
+// * Forged Track + Fiery/Stormy Edge - call knockback dir/safe lanes
+// * Yellow (Titan) spread markers - maybe better call than 'spread', possibly based on phase?
+// * Knockaround phase - call out whether to jump or stay for Forward Edge/Backward Edge?
+// * Knockaround phase - call whether to jump or stay to break chains?
 
-const triggerSet: TriggerSet<RaidbossData> = {
+type Phase = 'arena' | 'swords' | 'lines' | 'knockaround';
+export interface Data extends RaidbossData {
+  phase: Phase;
+  drumTargets: string[];
+  halfCircuitSafeSide?: 'left' | 'right';
+  seenHalfCircuit: boolean;
+}
+
+const triggerSet: TriggerSet<Data> = {
   id: 'EverkeepExtreme',
   zoneId: ZoneId.EverkeepExtreme,
   timelineFile: 'zoraal-ja-ex.txt',
+  initData: () => {
+    return {
+      phase: 'arena',
+      drumTargets: [],
+      seenHalfCircuit: false,
+    };
+  },
   triggers: [
     {
+      id: 'Zoraal Ja Ex Phase Tracker',
+      type: 'StartsUsing',
+      // 9397 - Dawn of an Age
+      // 938F - Drum of Vollok
+      // 938A - Projection of Triumph
+      // 93A2 - Multidirectional Divide (needed to reset to arena phase before enrage)
+      netRegex: { id: ['9397', '938F', '938A', '93A2'], source: 'Zoraal Ja' },
+      run: (data, matches) => {
+        // Knockaround is preceded by a 'Dawn of an Age' cast, but catching 'Drum of Vollok'
+        // allows us to detect phase correctly.
+        if (matches.id === '9397')
+          data.phase = 'swords';
+        else if (matches.id === '938F')
+          data.phase = 'knockaround';
+        else if (matches.id === '938A')
+          data.phase = 'lines';
+        else
+          data.phase = 'arena';
+      },
+    },
+    {
+      id: 'Zoraal Ja Ex Actualize',
+      type: 'StartsUsing',
+      netRegex: { id: '9398', source: 'Zoraal Ja', capture: false },
+      response: Responses.aoe(),
+    },
+    {
+      // Right sword glowing (right safe)
       id: 'Zoraal Ja Ex Forward Half Right Sword',
       type: 'StartsUsing',
       netRegex: { id: '937B', source: 'Zoraal Ja', capture: false },
@@ -26,6 +72,7 @@ const triggerSet: TriggerSet<RaidbossData> = {
       },
     },
     {
+      // Left sword glowing (left safe)
       id: 'Zoraal Ja Ex Forward Half Left Sword',
       type: 'StartsUsing',
       netRegex: { id: '937C', source: 'Zoraal Ja', capture: false },
@@ -37,6 +84,7 @@ const triggerSet: TriggerSet<RaidbossData> = {
       },
     },
     {
+      // Right sword glowing (left safe)
       id: 'Zoraal Ja Ex Backward Half Right Sword',
       type: 'StartsUsing',
       netRegex: { id: '937D', source: 'Zoraal Ja', capture: false },
@@ -48,6 +96,7 @@ const triggerSet: TriggerSet<RaidbossData> = {
       },
     },
     {
+      // Left sword glowing (right safe)
       id: 'Zoraal Ja Ex Backward Half Left Sword',
       type: 'StartsUsing',
       netRegex: { id: '937E', source: 'Zoraal Ja', capture: false },
@@ -59,21 +108,28 @@ const triggerSet: TriggerSet<RaidbossData> = {
       },
     },
     {
-      id: 'Zoraal Ja Ex Actualize',
-      type: 'StartsUsing',
-      netRegex: { id: '9398', source: 'Zoraal Ja', capture: false },
-      response: Responses.aoe(),
-    },
-    {
-      // FIX ME
       id: 'Zoraal Ja Ex Regicidal Rage',
       type: 'StartsUsing',
-      netRegex: { id: '993C', source: 'Zoraal Ja', capture: false },
-      infoText: (_data, _matches, output) => output.text!(),
-      outputStrings: {
-        text: {
-          en: 'Buster tethers (fix me)',
-        },
+      netRegex: { id: '993B', source: 'Zoraal Ja', capture: false },
+      response: (data, _matches, output) => {
+        // cactbot-builtin-response
+        output.responseOutputStrings = {
+          tetherBuster: {
+            en: 'Tank Tethers',
+            de: 'Tank-Verbindungen',
+            fr: 'Liens Tank',
+            ja: 'タンク線取り',
+            cn: '坦克截线',
+            ko: '탱커가 선 가로채기',
+          },
+          busterAvoid: {
+            en: 'Avoid Tank Tethers',
+          },
+        };
+
+        if (data.role === 'tank')
+          return { alertText: output.tetherBuster!() };
+        return { infoText: output.busterAvoid!() };
       },
     },
     {
@@ -84,24 +140,131 @@ const triggerSet: TriggerSet<RaidbossData> = {
     },
     {
       id: 'Zoraal Ja Ex Sync',
-      type: 'StartsUsing',
+      type: 'Ability',
       netRegex: { id: '9359', source: 'Zoraal Ja', capture: false },
-      alertText: (_data, _matches, output) => output.text!(),
+      infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
-          en: 'Avoid Swords (+Halfroom cleave?)',
+          en: 'Avoid Swords',
         },
       },
     },
-    // FIX ME
+    // Use explicit output rather than Outputs.left/Outputs.right for these triggers
+    // Boss likes to jump & rotate, so pure 'left'/'right' can be misleading
+    // Only use these two triggers during swords1 and Might of Vollok in lines2
+    // All other phases/uses use other triggers.
+    {
+      id: 'Zoraal Ja Ex Half Full Right Sword',
+      type: 'StartsUsing',
+      netRegex: { id: '9368', source: 'Zoraal Ja', capture: false },
+      condition: (data) => data.phase === 'swords' || data.seenHalfCircuit,
+      alertText: (_data, _matches, output) => output.rightSword!(),
+      outputStrings: {
+        rightSword: {
+          en: 'Boss\'s Left',
+        },
+      },
+    },
+    {
+      id: 'Zoraal Ja Ex Half Full Left Sword',
+      type: 'StartsUsing',
+      netRegex: { id: '9369', source: 'Zoraal Ja', capture: false },
+      condition: (data) => data.phase === 'swords' || data.seenHalfCircuit,
+      alertText: (_data, _matches, output) => output.leftSword!(),
+      outputStrings: {
+        leftSword: {
+          en: 'Boss\'s Right',
+        },
+      },
+    },
+    {
+      id: 'Zoraal Ja Ex Bitter Whirlwind',
+      type: 'StartsUsing',
+      netRegex: { id: '993E', source: 'Zoraal Ja' },
+      response: Responses.tankBuster(),
+    },
+    {
+      id: 'Zoraal Ja Ex Drum of Vollok Collect',
+      type: 'StartsUsing',
+      netRegex: { id: '938F', source: 'Zoraal Ja' },
+      run: (data, matches) => data.drumTargets.push(matches.target),
+    },
+    {
+      id: 'Zoraal Ja Ex Drum of Vollok',
+      type: 'StartsUsing',
+      netRegex: { id: '938F', source: 'Zoraal Ja', capture: false },
+      delaySeconds: 1,
+      suppressSeconds: 1,
+      alertText: (data, _matches, output) => {
+        if (data.drumTargets.includes(data.me))
+          return output.enumOnYou!();
+        return output.enumKnockback!();
+      },
+      run: (data) => data.drumTargets = [],
+      outputStrings: {
+        enumOnYou: {
+          en: 'Partner stack (on you)',
+        },
+        enumKnockback: {
+          en: 'Partner stack (knockback)',
+        },
+      },
+    },
+    {
+      id: 'Zoraal Ja Ex Spread Markers',
+      type: 'HeadMarker',
+      netRegex: { id: '00B9' },
+      condition: Conditions.targetIsYou(),
+      alertText: (_data, _matches, output) => output.safeSpread!(),
+      outputStrings: {
+        safeSpread: Outputs.spread,
+      },
+    },
+    {
+      id: 'Zoraal Ja Ex Duty\'s Edge',
+      type: 'StartsUsing',
+      netRegex: { id: '9374', source: 'Zoraal Ja', capture: false },
+      response: Responses.stackMarker(),
+    },
+    {
+      id: 'Zoraal Ja Ex Burning Chains',
+      type: 'Ability',
+      netRegex: { id: '9395', source: 'Zoraal Ja', capture: false },
+      response: Responses.breakChains(),
+    },
+    {
+      id: 'Zoraal Ja Ex Half Circuit Left/Right Collect',
+      type: 'StartsUsing',
+      // 936B - Right Sword (left safe)
+      // 936C - Left Sword (right safe)
+      netRegex: { id: ['936B', '936C'], source: 'Zoraal Ja' },
+      run: (data, matches) => data.halfCircuitSafeSide = matches.id === '936B' ? 'left' : 'right',
+    },
     {
       id: 'Zoraal Ja Ex Half Circuit',
       type: 'StartsUsing',
-      netRegex: { id: ['936B', '936C'], source: 'Zoraal Ja', capture: false },
-      alertText: (_data, _matches, output) => output.text!(),
+      // 93A0 - Swords Out (in safe)
+      // 93A1 - Swords In (out safe)
+      netRegex: { id: ['93A0', '93A1'], source: 'Zoraal Ja' },
+      delaySeconds: 0.3, // let Left/Right Collect run first
+      alertText: (data, matches, output) => {
+        const inOut = matches.id === '93A0' ? output.in!() : output.out!();
+        if (data.halfCircuitSafeSide === undefined)
+          return inOut;
+        return output.combo!({ inOut: inOut, side: output[data.halfCircuitSafeSide]!() });
+      },
+      run: (data) => data.seenHalfCircuit = true,
       outputStrings: {
-        text: {
-          en: 'Dodge half-room cleave + in/out',
+        left: {
+          en: 'Boss\'s Left',
+        },
+        right: {
+          en: 'Boss\'s Right',
+        },
+        in: Outputs.in,
+        out: Outputs.out,
+        combo: {
+          en: '${inOut} + ${side}',
         },
       },
     },
@@ -111,6 +274,8 @@ const triggerSet: TriggerSet<RaidbossData> = {
       'locale': 'en',
       'replaceText': {
         'Forward Edge/Backward Edge': 'Forward/Backward Edge',
+        'Fiery Edge/Stormy Edge': 'Fiery/Stormy Edge',
+        'Siege of Vollok/Walls of Vollok': 'Siege/Walls of Vollok',
       },
     },
   ],

--- a/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.ts
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.ts
@@ -189,17 +189,8 @@ const triggerSet: TriggerSet<Data> = {
       response: (data, _matches, output) => {
         // cactbot-builtin-response
         output.responseOutputStrings = {
-          tetherBuster: {
-            en: 'Tank Tethers',
-            de: 'Tank-Verbindungen',
-            fr: 'Liens Tank',
-            ja: 'タンク線取り',
-            cn: '坦克截线',
-            ko: '탱커가 선 가로채기',
-          },
-          busterAvoid: {
-            en: 'Avoid Tank Tethers',
-          },
+          tetherBuster: Outputs.tetherBusters,
+          busterAvoid: Outputs.avoidTetherBusters,
         };
 
         if (data.role === 'tank')
@@ -366,11 +357,11 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Zoraal Ja Ex Knockaround Swords + Spread',
       type: 'StartsUsing',
-      netRegex: { id: '9393', source: 'Fang' },
+      netRegex: { id: '9393', source: 'Fang', capture: false },
       condition: (data) => data.phase === 'knockaround',
       delaySeconds: 0.2,
       suppressSeconds: 1,
-      alertText: (data, matches, output) => {
+      alertText: (data, _matches, output) => {
         if (data.safeQuadrants.length !== 2)
           return output.unknown!();
 

--- a/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.ts
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.ts
@@ -1,0 +1,57 @@
+import ZoneId from '../../../../../resources/zone_id';
+import { RaidbossData } from '../../../../../types/data';
+import { TriggerSet } from '../../../../../types/trigger';
+
+const triggerSet: TriggerSet<RaidbossData> = {
+  id: 'EverkeepExtreme',
+  zoneId: ZoneId.EverkeepExtreme,
+  timelineFile: 'zoraal-ja-ex.txt',
+  triggers: [
+    {
+      id: 'Zoraal Ja Ex Forward Half Right Sword',
+      type: 'StartsUsing',
+      netRegex: { id: '937B', capture: false },
+      alertText: (_data, _matches, output) => output.frontRight!(),
+      outputStrings: {
+        frontRight: {
+          en: 'In front of boss + right side of boss',
+        },
+      },
+    },
+    {
+      id: 'Zoraal Ja Ex Forward Half Left Sword',
+      type: 'StartsUsing',
+      netRegex: { id: '937C', capture: false },
+      alertText: (_data, _matches, output) => output.frontRight!(),
+      outputStrings: {
+        frontRight: {
+          en: 'In front of boss + left side of boss',
+        },
+      },
+    },
+    {
+      id: 'Zoraal Ja Ex Backward Half Right Sword',
+      type: 'StartsUsing',
+      netRegex: { id: '937D', capture: false },
+      alertText: (_data, _matches, output) => output.frontRight!(),
+      outputStrings: {
+        frontRight: {
+          en: 'Behind boss + left side of boss',
+        },
+      },
+    },
+    {
+      id: 'Zoraal Ja Ex Backward Half Left Sword',
+      type: 'StartsUsing',
+      netRegex: { id: '937E', capture: false },
+      alertText: (_data, _matches, output) => output.frontRight!(),
+      outputStrings: {
+        frontRight: {
+          en: 'Behind boss + right side of boss',
+        },
+      },
+    },
+  ],
+};
+
+export default triggerSet;

--- a/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.ts
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.ts
@@ -1,4 +1,4 @@
-﻿import Conditions from '../../../../../resources/conditions';
+import Conditions from '../../../../../resources/conditions';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';

--- a/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.ts
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.ts
@@ -507,7 +507,7 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'Zooraal Ja Ex Knockaround Tornado Debuff Gain',
+      id: 'Zoraal Ja Ex Knockaround Tornado Debuff Gain',
       type: 'GainsEffect',
       netRegex: { effectId: '830' }, // Wind Resistance Down II - 45.96s duration
       condition: (data, matches) => {
@@ -518,7 +518,7 @@ const triggerSet: TriggerSet<Data> = {
       run: (data) => data.cantTakeTornadoJump = true,
     },
     {
-      id: 'Zooraal Ja Ex Knockaround Tornado Debuff Lose',
+      id: 'Zoraal Ja Ex Knockaround Tornado Debuff Lose',
       type: 'LosesEffect',
       netRegex: { effectId: '830' }, // Wind Resistance Down II - 45.96s duration
       condition: (data, matches) => data.phase === 'knockaround' && data.me === matches.target,

--- a/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.ts
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.ts
@@ -1,6 +1,13 @@
+import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
+
+// TO DO:
+// - Regicidal Rage - add appropriate tank call
+// - Vollok/Sync - add safe tile(s) callout?
+// - Sync/Half Full - call safe boss half
+// - Half Circuit - call safe side
 
 const triggerSet: TriggerSet<RaidbossData> = {
   id: 'EverkeepExtreme',
@@ -10,45 +17,100 @@ const triggerSet: TriggerSet<RaidbossData> = {
     {
       id: 'Zoraal Ja Ex Forward Half Right Sword',
       type: 'StartsUsing',
-      netRegex: { id: '937B', capture: false },
+      netRegex: { id: '937B', source: 'Zoraal Ja', capture: false },
       alertText: (_data, _matches, output) => output.frontRight!(),
       outputStrings: {
         frontRight: {
-          en: 'In front of boss + right side of boss',
+          en: 'Front + Boss\'s Right',
         },
       },
     },
     {
       id: 'Zoraal Ja Ex Forward Half Left Sword',
       type: 'StartsUsing',
-      netRegex: { id: '937C', capture: false },
-      alertText: (_data, _matches, output) => output.frontRight!(),
+      netRegex: { id: '937C', source: 'Zoraal Ja', capture: false },
+      alertText: (_data, _matches, output) => output.frontLeft!(),
       outputStrings: {
-        frontRight: {
-          en: 'In front of boss + left side of boss',
+        frontLeft: {
+          en: 'Front + Boss\'s Left',
         },
       },
     },
     {
       id: 'Zoraal Ja Ex Backward Half Right Sword',
       type: 'StartsUsing',
-      netRegex: { id: '937D', capture: false },
-      alertText: (_data, _matches, output) => output.frontRight!(),
+      netRegex: { id: '937D', source: 'Zoraal Ja', capture: false },
+      alertText: (_data, _matches, output) => output.backRight!(),
       outputStrings: {
-        frontRight: {
-          en: 'Behind boss + left side of boss',
+        backRight: {
+          en: 'Behind + Boss\'s Left',
         },
       },
     },
     {
       id: 'Zoraal Ja Ex Backward Half Left Sword',
       type: 'StartsUsing',
-      netRegex: { id: '937E', capture: false },
-      alertText: (_data, _matches, output) => output.frontRight!(),
+      netRegex: { id: '937E', source: 'Zoraal Ja', capture: false },
+      alertText: (_data, _matches, output) => output.backLeft!(),
       outputStrings: {
-        frontRight: {
-          en: 'Behind boss + right side of boss',
+        backLeft: {
+          en: 'Behind + Boss\'s Right',
         },
+      },
+    },
+    {
+      id: 'Zoraal Ja Ex Actualize',
+      type: 'StartsUsing',
+      netRegex: { id: '9398', source: 'Zoraal Ja', capture: false },
+      response: Responses.aoe(),
+    },
+    {
+      // FIX ME
+      id: 'Zoraal Ja Ex Regicidal Rage',
+      type: 'StartsUsing',
+      netRegex: { id: '993C', source: 'Zoraal Ja', capture: false },
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Buster tethers (fix me)',
+        },
+      },
+    },
+    {
+      id: 'Zoraal Ja Ex Dawn of an Age',
+      type: 'StartsUsing',
+      netRegex: { id: '9397', source: 'Zoraal Ja', capture: false },
+      response: Responses.aoe(),
+    },
+    {
+      id: 'Zoraal Ja Ex Sync',
+      type: 'StartsUsing',
+      netRegex: { id: '9359', source: 'Zoraal Ja', capture: false },
+      alertText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Avoid Swords (+Halfroom cleave?)',
+        },
+      },
+    },
+    // FIX ME
+    {
+      id: 'Zoraal Ja Ex Half Circuit',
+      type: 'StartsUsing',
+      netRegex: { id: ['936B', '936C'], source: 'Zoraal Ja', capture: false },
+      alertText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Dodge half-room cleave + in/out',
+        },
+      },
+    },
+  ],
+  timelineReplace: [
+    {
+      'locale': 'en',
+      'replaceText': {
+        'Forward Edge/Backward Edge': 'Forward/Backward Edge',
       },
     },
   ],

--- a/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.txt
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.txt
@@ -1,0 +1,122 @@
+# -r 4zpQDykmMGJnX2FW -rf=8
+# Sorry, no `-ii` parameters, I cleaned this up by hand because it was such a mess
+
+hideall "--Reset--"
+hideall "--sync--"
+
+# Forward Half:
+# 937B - Right sword glowing, safe spot is front+right
+# 999B - Left sword glowing, safe spot is front+left
+
+# Forward Half:
+# 937D - Right sword glowing, safe spot is back+left
+# 937E - Left sword glowing, safe spot is back+right
+
+# Arena phase
+0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
+3.2 "--sync--" Ability { id: "93A7", source: "Zoraal Ja" } window 3.2,1
+8.0 "--sync--" StartsUsing { id: "9398", source: "Zoraal Ja" } window 8,8
+12.7 "Actualize" Ability { id: "9398", source: "Zoraal Ja" }
+23.0 "Multidirectional Divide (cast)" Ability { id: "93A2", source: "Zoraal Ja" }
+34.0 "Multidirectional Divide (damage)" Ability { id: "93A3", source: "Zoraal Ja" }
+35.0 "Half Full" #Ability { id: "939E|9380", source: "Zoraal Ja" }
+35.0 "Forward Edge/Backward Edge" #Ability { id: "9972|937F", source: "Zoraal Ja" }
+44.2 "Multidirectional Divide (cast)" Ability { id: "93A2", source: "Zoraal Ja" }
+55.2 "Multidirectional Divide (damage)" Ability { id: "93A3", source: "Zoraal Ja" }
+55.3 "Regicidal Rage" #Ability { id: "993C", source: "Zoraal Ja" }
+
+# Tiles phase
+70.5 "Dawn of an Age" Ability { id: "9397", source: "Zoraal Ja" } window 5,5
+84.5 "Vollok" Ability { id: "9357", source: "Zoraal Ja" }
+94.7 "Sync" Ability { id: "9359", source: "Zoraal Ja" }
+103.6 "Chasm of Vollok" Ability { id: "939A", source: "Zoraal Ja" }
+104.1 "Half Full" Ability { id: "939E|9380", source: "Zoraal Ja" }
+112.9 "Greater Gateway" Ability { id: "9381", source: "Zoraal Ja" }
+121.1 "Blade Warp" Ability { id: "935E", source: "Zoraal Ja" }
+129.3 "Forged Track (cast)" Ability { id: "935F", source: "Zoraal Ja" }
+137.5 "Forged Track (damage)" Ability { id: "939D", source: "Fang" }
+137.6 "Fiery Edge/Stormy Edge" #Ability { id: "938[36]", source: "Fang" }
+142.3 "Chasm of Vollok" Ability { id: "9389", source: "Zoraal Ja" }
+147.3 "Actualize" Ability { id: "9398", source: "Zoraal Ja" } window 5,5
+
+# Arena phase
+159.5 "Projection of Triumph" Ability { id: "938A", source: "Zoraal Ja" }
+# TODO: `Fang` actor might actually have a random or potentially empty name because of actor reuse
+169.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+169.8 "Projection of Triumph" Ability { id: "938A", source: "Zoraal Ja" }
+174.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+179.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+184.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+188.1 "Half Full" Ability { id: "939E|9380", source: "Zoraal Ja" }
+188.1 "Forward Edge/Backward Edge" #Ability { id: "9972|937F", source: "Zoraal Ja" }
+189.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+194.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+198.4 "Actualize" Ability { id: "9398", source: "Zoraal Ja" }
+210.5 "Projection of Turmoil" Ability { id: "9A88", source: "Zoraal Ja" }
+260.4 "Bitter Whirlwind" Ability { id: "993E", source: "Zoraal Ja" }
+263.7 "Bitter Whirlwind" Ability { id: "9940", source: "Zoraal Ja" }
+266.8 "Bitter Whirlwind" Ability { id: "9940", source: "Zoraal Ja" }
+
+# Tiles phase
+282.1 "Dawn of an Age" Ability { id: "9397", source: "Zoraal Ja" } window 5,5
+299.4 "Drum of Vollok" Ability { id: "938E", source: "Zoraal Ja" }
+300.1 "Drum of Vollok" Ability { id: "938F", source: "Zoraal Ja" }
+311.1 "Vollok" Ability { id: "9392", source: "Zoraal Ja" }
+320.2 "Sync" Ability { id: "9359", source: "Zoraal Ja" }
+329.2 "Chasm of Vollok" Ability { id: "9389", source: "Zoraal Ja" }
+329.3 "Aero III" #Ability { id: "9390", source: "Zoraal Ja" }
+343.6 "Half Full" Ability { id: "939E|9380", source: "Zoraal Ja" } window 5,5
+343.6 "Forward Edge/Backward Edge" #Ability { id: "9972|937F", source: "Zoraal Ja" }
+349.3 "Duty's Edge (cast)" Ability { id: "9374", source: "Zoraal Ja" } window 5,5
+349.7 "Duty's Edge (damage 1)" #Ability { id: "94A7", source: "Zoraal Ja" }
+351.4 "Duty's Edge (damage 2)" #Ability { id: "94A7", source: "Zoraal Ja" }
+353.1 "Duty's Edge (damage 3)" #Ability { id: "94A7", source: "Zoraal Ja" }
+354.9 "Duty's Edge (damage 4)" #Ability { id: "94A7", source: "Zoraal Ja" }
+360.8 "Burning Chains (cast)" Ability { id: "9395", source: "Zoraal Ja" } window 5,5
+367.6 "Burning Chains (damage 1)" #Ability { id: "9396", source: "Zoraal Ja" }
+379.4 "Actualize" Ability { id: "9398", source: "Zoraal Ja" } window 5,5
+
+# Arena phase
+392.8 "Projection of Triumph" Ability { id: "938A", source: "Zoraal Ja" }
+402.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+402.8 "Projection of Triumph" Ability { id: "938A", source: "Zoraal Ja" }
+407.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+412.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+414.7 "Half Circuit" Ability { id: "936[BC]", source: "Zoraal Ja" }
+417.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+422.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+427.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+430.8 "Regicidal Rage" Ability { id: "993C", source: "Zoraal Ja" }
+442.9 "Projection of Turmoil" Ability { id: "9A88", source: "Zoraal Ja" }
+465.4 "Half Full" Ability { id: "939E|9380", source: "Zoraal Ja" }
+474.6 "Half Full" Ability { id: "939E|9380", source: "Zoraal Ja" }
+484.9 "Half Full" Ability { id: "939E|9380", source: "Zoraal Ja" }
+493.8 "Bitter Whirlwind" Ability { id: "993E", source: "Zoraal Ja" }
+497.1 "Bitter Whirlwind" Ability { id: "9940", source: "Zoraal Ja" }
+500.2 "Bitter Whirlwind" Ability { id: "9940", source: "Zoraal Ja" }
+
+# Tiles phase
+515.4 "Dawn of an Age" Ability { id: "9397", source: "Zoraal Ja" } window 5,5
+529.4 "Vollok" Ability { id: "9357", source: "Zoraal Ja" }
+538.5 "Sync" Ability { id: "9359", source: "Zoraal Ja" }
+547.4 "Chasm of Vollok (cast)" Ability { id: "939A", source: "Zoraal Ja" }
+550.6 "Chasm of Vollok (damage)" #Ability { id: "9389", source: "Zoraal Ja" }
+555.5 "Duty's Edge (cast)" Ability { id: "9374", source: "Zoraal Ja" }
+555.9 "Duty's Edge (damage 1)" #Ability { id: "94A7", source: "Zoraal Ja" }
+558.0 "Duty's Edge (damage 2)" #Ability { id: "94A7", source: "Zoraal Ja" }
+560.0 "Duty's Edge (damage 3)" #Ability { id: "94A7", source: "Zoraal Ja" }
+562.1 "Duty's Edge (damage 4)" #Ability { id: "94A7", source: "Zoraal Ja" }
+571.1 "Greater Gateway" Ability { id: "9381", source: "Zoraal Ja" }
+579.2 "Blade Warp" Ability { id: "935E", source: "Zoraal Ja" }
+587.4 "Forged Track (cast)" Ability { id: "935F", source: "Zoraal Ja" }
+595.5 "Forged Track (damage)" Ability { id: "939D", source: "Fang" }
+596.0 "Fiery Edge/Stormy Edge" Ability { id: "938[36]", source: "Fang" }
+600.3 "Chasm of Vollok" Ability { id: "9389", source: "Zoraal Ja" }
+605.3 "Actualize" Ability { id: "9398", source: "Zoraal Ja" } window 5,5
+
+# Arena phase
+618.6 "Multidirectional Divide (cast)" Ability { id: "93A2", source: "Zoraal Ja" }
+629.6 "Multidirectional Divide (damage)" Ability { id: "93A3", source: "Zoraal Ja" }
+630.7 "Half Full" Ability { id: "9380", source: "Zoraal Ja" }
+630.7 "Forward Edge/Backward Edge" #Ability { id: "9972|937F", source: "Zoraal Ja" }
+645.8 "Actualize (enrage)" Ability { id: "996A", source: "Zoraal Ja" }

--- a/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.txt
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.txt
@@ -8,7 +8,7 @@ hideall "--sync--"
 # 937B - Right sword glowing, safe spot is front+right
 # 999B - Left sword glowing, safe spot is front+left
 
-# Forward Half:
+# Backward Half:
 # 937D - Right sword glowing, safe spot is back+left
 # 937E - Left sword glowing, safe spot is back+right
 
@@ -17,12 +17,12 @@ hideall "--sync--"
 3.2 "--sync--" Ability { id: "93A7", source: "Zoraal Ja" } window 3.2,1
 8.0 "--sync--" StartsUsing { id: "9398", source: "Zoraal Ja" } window 8,8
 12.7 "Actualize" Ability { id: "9398", source: "Zoraal Ja" }
-23.0 "Multidirectional Divide (cast)" Ability { id: "93A2", source: "Zoraal Ja" }
-34.0 "Multidirectional Divide (damage)" Ability { id: "93A3", source: "Zoraal Ja" }
+23.0 "--sync--" Ability { id: "93A2", source: "Zoraal Ja" } # Multidirectional Divice, drops lines (no damage)
+34.0 "Multidirectional Divide" Ability { id: "93A3", source: "Zoraal Ja" } # damage from line drops
 35.0 "Half Full" #Ability { id: "939E|9380", source: "Zoraal Ja" }
 35.0 "Forward Edge/Backward Edge" #Ability { id: "9972|937F", source: "Zoraal Ja" }
-44.2 "Multidirectional Divide (cast)" Ability { id: "93A2", source: "Zoraal Ja" }
-55.2 "Multidirectional Divide (damage)" Ability { id: "93A3", source: "Zoraal Ja" }
+44.2 "--sync--" Ability { id: "93A2", source: "Zoraal Ja" }
+55.2 "Multidirectional Divide" Ability { id: "93A3", source: "Zoraal Ja" }
 55.3 "Regicidal Rage" #Ability { id: "993C", source: "Zoraal Ja" }
 
 # Tiles phase
@@ -35,7 +35,7 @@ hideall "--sync--"
 121.1 "Blade Warp" Ability { id: "935E", source: "Zoraal Ja" }
 129.3 "Forged Track (cast)" Ability { id: "935F", source: "Zoraal Ja" }
 137.5 "Forged Track (damage)" Ability { id: "939D", source: "Fang" }
-137.6 "Fiery Edge/Stormy Edge" #Ability { id: "938[36]", source: "Fang" }
+137.6 "Fiery Edge/Stormy Edge" #Ability { id: "9383|9386", source: "Fang" }
 142.3 "Chasm of Vollok" Ability { id: "9389", source: "Zoraal Ja" }
 147.3 "Actualize" Ability { id: "9398", source: "Zoraal Ja" } window 5,5
 
@@ -82,7 +82,7 @@ hideall "--sync--"
 402.8 "Projection of Triumph" Ability { id: "938A", source: "Zoraal Ja" }
 407.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
 412.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
-414.7 "Half Circuit" Ability { id: "936[BC]", source: "Zoraal Ja" }
+414.7 "Half Circuit" Ability { id: "936B|936C", source: "Zoraal Ja" }
 417.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
 422.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
 427.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }

--- a/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.txt
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.txt
@@ -90,9 +90,9 @@ hideall "--sync--"
 441.9 "Regicidal Rage" Ability { id: "993C", source: "Zoraal Ja" }
 454.0 "Projection of Turmoil" Ability { id: "9A88", source: "Zoraal Ja" }
 460.5 "Might of Vollok" duration 40
-476.9 "Half Full 1" Ability { id: "9380|939E", source: "Zoraal Ja" }
-486.0 "Half Full 2" Ability { id: "9380|939E", source: "Zoraal Ja" }
-496.3 "Half Full 3" Ability { id: "9380|939E", source: "Zoraal Ja" }
+476.9 "Half Full" Ability { id: "9380|939E", source: "Zoraal Ja" }
+486.0 "Half Full" Ability { id: "9380|939E", source: "Zoraal Ja" }
+496.3 "Half Full" Ability { id: "9380|939E", source: "Zoraal Ja" }
 505.3 "Bitter Whirlwind (initial)" Ability { id: "993E", source: "Zoraal Ja" }
 508.5 "Bitter Whirlwind (damage)" Ability { id: "9940", source: "Zoraal Ja" }
 511.5 "Bitter Whirlwind (damage)" Ability { id: "9940", source: "Zoraal Ja" }

--- a/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.txt
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.txt
@@ -1,122 +1,160 @@
-# -r 4zpQDykmMGJnX2FW -rf=8
-# Sorry, no `-ii` parameters, I cleaned this up by hand because it was such a mess
+### Everkeep (Extreme)
+# ZoneId: 1201
+
+# -ii 93A7 9355 93A4 937B 937D 993B 9399 9368 9369 9360 939C 9383 9384 9386 9387 937C 937E 938D
+#     993D 993F 938E 9394 9393 9391 8AEF 9375 999B 999D 936B 936C 93A0 93A1 9365
 
 hideall "--Reset--"
 hideall "--sync--"
 
-# Forward Half:
-# 937B - Right sword glowing, safe spot is front+right
-# 999B - Left sword glowing, safe spot is front+left
-
-# Backward Half:
-# 937D - Right sword glowing, safe spot is back+left
-# 937E - Left sword glowing, safe spot is back+right
-
-# Arena phase
+# Initial Phase
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
-3.2 "--sync--" Ability { id: "93A7", source: "Zoraal Ja" } window 3.2,1
-8.0 "--sync--" StartsUsing { id: "9398", source: "Zoraal Ja" } window 8,8
-12.7 "Actualize" Ability { id: "9398", source: "Zoraal Ja" }
-23.0 "--sync--" Ability { id: "93A2", source: "Zoraal Ja" } # Multidirectional Divice, drops lines (no damage)
-34.0 "Multidirectional Divide" Ability { id: "93A3", source: "Zoraal Ja" } # damage from line drops
-35.0 "Half Full" #Ability { id: "939E|9380", source: "Zoraal Ja" }
-35.0 "Forward Edge/Backward Edge" #Ability { id: "9972|937F", source: "Zoraal Ja" }
-44.2 "--sync--" Ability { id: "93A2", source: "Zoraal Ja" }
-55.2 "Multidirectional Divide" Ability { id: "93A3", source: "Zoraal Ja" }
-55.3 "Regicidal Rage" #Ability { id: "993C", source: "Zoraal Ja" }
+3.4 "--sync--" Ability { id: "93A7", source: "Zoraal Ja" } window 3.4,1
+11.2 "--sync--" StartsUsing { id: "9398", source: "Zoraal Ja" } window 11.2,4
+16.0 "Actualize" Ability { id: "9398", source: "Zoraal Ja" }
+26.3 "Multidirectional Divide (lines drop)" Ability { id: "93A2", source: "Zoraal Ja" }
+37.3 "Multidirectional Divide (damage)" Ability { id: "93A3", source: "Zoraal Ja" }
+38.4 "Half Full" Ability { id: "9380|939E", source: "Zoraal Ja" }
+38.4 "Forward Edge/Backward Edge" #Ability { id: "9972|937F", source: "Zoraal Ja" }
+47.7 "Multidirectional Divide (lines drop)" Ability { id: "93A2", source: "Zoraal Ja" }
+58.7 "Multidirectional Divide (damage)" Ability { id: "93A3", source: "Zoraal Ja" }
+58.9 "Regicidal Rage" Ability { id: "993C", source: "Zoraal Ja" }
 
-# Tiles phase
-70.5 "Dawn of an Age" Ability { id: "9397", source: "Zoraal Ja" } window 5,5
-84.5 "Vollok" Ability { id: "9357", source: "Zoraal Ja" }
-94.7 "Sync" Ability { id: "9359", source: "Zoraal Ja" }
-103.6 "Chasm of Vollok" Ability { id: "939A", source: "Zoraal Ja" }
-104.1 "Half Full" Ability { id: "939E|9380", source: "Zoraal Ja" }
-112.9 "Greater Gateway" Ability { id: "9381", source: "Zoraal Ja" }
-121.1 "Blade Warp" Ability { id: "935E", source: "Zoraal Ja" }
-129.3 "Forged Track (cast)" Ability { id: "935F", source: "Zoraal Ja" }
-137.5 "Forged Track (damage)" Ability { id: "939D", source: "Fang" }
-137.6 "Fiery Edge/Stormy Edge" #Ability { id: "9383|9386", source: "Fang" }
-142.3 "Chasm of Vollok" Ability { id: "9389", source: "Zoraal Ja" }
-147.3 "Actualize" Ability { id: "9398", source: "Zoraal Ja" } window 5,5
+# Swords & Tiles Phase 1
+74.2 "Dawn of an Age" Ability { id: "9397", source: "Zoraal Ja" }
+88.3 "Vollok" Ability { id: "9357", source: "Zoraal Ja" }
+98.6 "Sync" Ability { id: "9359", source: "Zoraal Ja" }
+107.6 "Chasm of Vollok" Ability { id: "939A", source: "Zoraal Ja" }
+108.2 "Half Full" Ability { id: "9380|939E", source: "Zoraal Ja" }
+117.1 "Greater Gateway" Ability { id: "9381", source: "Zoraal Ja" }
+125.2 "Blade Warp" Ability { id: "935E", source: "Zoraal Ja" }
+133.3 "Forged Track (cast)" Ability { id: "935F", source: "Zoraal Ja" }
+141.6 "Fiery Edge/Stormy Edge" Ability { id: "9382|9385", source: "Fang" }
+141.6 "Forged Track (damage)" #Ability { id: "939D", source: "Fang" }
+146.4 "Chasm of Vollok" Ability { id: "9389", source: "Zoraal Ja" }
+151.4 "Actualize" Ability { id: "9398", source: "Zoraal Ja" } window 5,5
 
-# Arena phase
-159.5 "Projection of Triumph" Ability { id: "938A", source: "Zoraal Ja" }
-# TODO: `Fang` actor might actually have a random or potentially empty name because of actor reuse
-169.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
-169.8 "Projection of Triumph" Ability { id: "938A", source: "Zoraal Ja" }
-174.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
-179.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
-184.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
-188.1 "Half Full" Ability { id: "939E|9380", source: "Zoraal Ja" }
-188.1 "Forward Edge/Backward Edge" #Ability { id: "9972|937F", source: "Zoraal Ja" }
-189.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
-194.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
-198.4 "Actualize" Ability { id: "9398", source: "Zoraal Ja" }
-210.5 "Projection of Turmoil" Ability { id: "9A88", source: "Zoraal Ja" }
-260.4 "Bitter Whirlwind" Ability { id: "993E", source: "Zoraal Ja" }
-263.7 "Bitter Whirlwind" Ability { id: "9940", source: "Zoraal Ja" }
-266.8 "Bitter Whirlwind" Ability { id: "9940", source: "Zoraal Ja" }
+# Lines, Lines, Lines Phase 1
+163.7 "Projection of Triumph" Ability { id: "938A", source: "Zoraal Ja" }
+# Don't sync 'Siege/Walls of Vollok' due to spamminess
+173.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B|938C", source: "Fang" }
+# Second cast, with identical ID, but happens with the first Siege/Walls so don't display
+#173.8 "Projection of Triumph" Ability { id: "938A", source: "Zoraal Ja" }
+178.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B|938C", source: "Fang" }
+183.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B|938C", source: "Fang" }
+188.9 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B|938C", source: "Fang" }
+192.4 "Half Full" Ability { id: "9380|939E", source: "Zoraal Ja" }
+192.4 "Forward Edge/Backward Edge" #Ability { id: "9972|937F", source: "Zoraal Ja" }
+193.9 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+198.9 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+202.4 "Actualize" Ability { id: "9398", source: "Zoraal Ja" }
+214.5 "Projection of Turmoil" Ability { id: "9A88", source: "Zoraal Ja" }
+# Might of Vollok (938D) occurs when a player crosses the line
+# Instead of syncing (which will be random based on player resolution),
+# display a long duration while the line is moving
+221.0 "Might of Vollok" duration 40
+264.8 "Bitter Whirlwind (initial)" Ability { id: "993E", source: "Zoraal Ja" }
+268.0 "Bitter Whirlwind (damage)" Ability { id: "9940", source: "Zoraal Ja" }
+271.0 "Bitter Whirlwind (damage)" Ability { id: "9940", source: "Zoraal Ja" }
 
-# Tiles phase
-282.1 "Dawn of an Age" Ability { id: "9397", source: "Zoraal Ja" } window 5,5
-299.4 "Drum of Vollok" Ability { id: "938E", source: "Zoraal Ja" }
-300.1 "Drum of Vollok" Ability { id: "938F", source: "Zoraal Ja" }
-311.1 "Vollok" Ability { id: "9392", source: "Zoraal Ja" }
-320.2 "Sync" Ability { id: "9359", source: "Zoraal Ja" }
-329.2 "Chasm of Vollok" Ability { id: "9389", source: "Zoraal Ja" }
-329.3 "Aero III" #Ability { id: "9390", source: "Zoraal Ja" }
-343.6 "Half Full" Ability { id: "939E|9380", source: "Zoraal Ja" } window 5,5
-343.6 "Forward Edge/Backward Edge" #Ability { id: "9972|937F", source: "Zoraal Ja" }
-349.3 "Duty's Edge (cast)" Ability { id: "9374", source: "Zoraal Ja" } window 5,5
-349.7 "Duty's Edge (damage 1)" #Ability { id: "94A7", source: "Zoraal Ja" }
-351.4 "Duty's Edge (damage 2)" #Ability { id: "94A7", source: "Zoraal Ja" }
-353.1 "Duty's Edge (damage 3)" #Ability { id: "94A7", source: "Zoraal Ja" }
-354.9 "Duty's Edge (damage 4)" #Ability { id: "94A7", source: "Zoraal Ja" }
-360.8 "Burning Chains (cast)" Ability { id: "9395", source: "Zoraal Ja" } window 5,5
-367.6 "Burning Chains (damage 1)" #Ability { id: "9396", source: "Zoraal Ja" }
-379.4 "Actualize" Ability { id: "9398", source: "Zoraal Ja" } window 5,5
+# Body-Chucking Phase
+286.3 "Dawn of an Age" Ability { id: "9397", source: "Zoraal Ja" } window 5,5
+304.4 "Drum of Vollok" Ability { id: "938F", source: "Zoraal Ja" }
+315.5 "Vollok" Ability { id: "9392", source: "Zoraal Ja" }
+324.6 "Sync" Ability { id: "9359", source: "Zoraal Ja" }
+333.6 "Chasm of Vollok" Ability { id: "9389", source: "Zoraal Ja" }
+333.7 "Aero III" Ability { id: "9390", source: "Zoraal Ja" }
+350.1 "Half Full" Ability { id: "9380|939E", source: "Zoraal Ja" } window 5,5
+350.1 "Forward Edge/Backward Edge" #Ability { id: "9972|937F", source: "Zoraal Ja" }
+357.0 "Duty's Edge (cast)" Ability { id: "9374", source: "Zoraal Ja" }
+357.2 "Duty's Edge (damage 1)" #Ability { id: "94A7", source: "Zoraal Ja" }
+359.2 "Duty's Edge (damage 2)" #Ability { id: "94A7", source: "Zoraal Ja" }
+361.2 "Duty's Edge (damage 3)" #Ability { id: "94A7", source: "Zoraal Ja" }
+363.2 "Duty's Edge (damage 4)" #Ability { id: "94A7", source: "Zoraal Ja" }
+370.5 "Burning Chains (cast)" Ability { id: "9395", source: "Zoraal Ja" }
+378.3 "Burning Chains (damage 1)" #Ability { id: "9396", source: "Zoraal Ja" }
+390.5 "Actualize" Ability { id: "9398", source: "Zoraal Ja" } window 5,5
 
-# Arena phase
-392.8 "Projection of Triumph" Ability { id: "938A", source: "Zoraal Ja" }
-402.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
-402.8 "Projection of Triumph" Ability { id: "938A", source: "Zoraal Ja" }
-407.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
-412.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
-414.7 "Half Circuit" Ability { id: "936B|936C", source: "Zoraal Ja" }
-417.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
-422.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
-427.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
-430.8 "Regicidal Rage" Ability { id: "993C", source: "Zoraal Ja" }
-442.9 "Projection of Turmoil" Ability { id: "9A88", source: "Zoraal Ja" }
-465.4 "Half Full" Ability { id: "939E|9380", source: "Zoraal Ja" }
-474.6 "Half Full" Ability { id: "939E|9380", source: "Zoraal Ja" }
-484.9 "Half Full" Ability { id: "939E|9380", source: "Zoraal Ja" }
-493.8 "Bitter Whirlwind" Ability { id: "993E", source: "Zoraal Ja" }
-497.1 "Bitter Whirlwind" Ability { id: "9940", source: "Zoraal Ja" }
-500.2 "Bitter Whirlwind" Ability { id: "9940", source: "Zoraal Ja" }
+# Lines, Lines, Lines Phase 2
+403.7 "Projection of Triumph" Ability { id: "938A", source: "Zoraal Ja" }
+# Don't sync 'Siege/Walls of Vollok' due to spamminess
+413.7 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+# Second cast, with identical ID, but happens with the first Siege/Walls so don't display
+#413.7 "Projection of Triumph" Ability { id: "938A", source: "Zoraal Ja" }
+418.6 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+423.6 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+425.9 "Half Circuit" Ability { id: "939F", source: "Zoraal Ja" }
+428.7 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+433.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+438.8 "Siege of Vollok/Walls of Vollok" #Ability { id: "938B", source: "Fang" }
+441.9 "Regicidal Rage" Ability { id: "993C", source: "Zoraal Ja" }
+454.0 "Projection of Turmoil" Ability { id: "9A88", source: "Zoraal Ja" }
+460.5 "Might of Vollok" duration 40
+476.9 "Half Full 1" Ability { id: "9380|939E", source: "Zoraal Ja" }
+486.0 "Half Full 2" Ability { id: "9380|939E", source: "Zoraal Ja" }
+496.3 "Half Full 3" Ability { id: "9380|939E", source: "Zoraal Ja" }
+505.3 "Bitter Whirlwind (initial)" Ability { id: "993E", source: "Zoraal Ja" }
+508.5 "Bitter Whirlwind (damage)" Ability { id: "9940", source: "Zoraal Ja" }
+511.5 "Bitter Whirlwind (damage)" Ability { id: "9940", source: "Zoraal Ja" }
 
-# Tiles phase
-515.4 "Dawn of an Age" Ability { id: "9397", source: "Zoraal Ja" } window 5,5
-529.4 "Vollok" Ability { id: "9357", source: "Zoraal Ja" }
-538.5 "Sync" Ability { id: "9359", source: "Zoraal Ja" }
-547.4 "Chasm of Vollok (cast)" Ability { id: "939A", source: "Zoraal Ja" }
-550.6 "Chasm of Vollok (damage)" #Ability { id: "9389", source: "Zoraal Ja" }
-555.5 "Duty's Edge (cast)" Ability { id: "9374", source: "Zoraal Ja" }
-555.9 "Duty's Edge (damage 1)" #Ability { id: "94A7", source: "Zoraal Ja" }
-558.0 "Duty's Edge (damage 2)" #Ability { id: "94A7", source: "Zoraal Ja" }
-560.0 "Duty's Edge (damage 3)" #Ability { id: "94A7", source: "Zoraal Ja" }
-562.1 "Duty's Edge (damage 4)" #Ability { id: "94A7", source: "Zoraal Ja" }
-571.1 "Greater Gateway" Ability { id: "9381", source: "Zoraal Ja" }
-579.2 "Blade Warp" Ability { id: "935E", source: "Zoraal Ja" }
-587.4 "Forged Track (cast)" Ability { id: "935F", source: "Zoraal Ja" }
-595.5 "Forged Track (damage)" Ability { id: "939D", source: "Fang" }
-596.0 "Fiery Edge/Stormy Edge" Ability { id: "938[36]", source: "Fang" }
-600.3 "Chasm of Vollok" Ability { id: "9389", source: "Zoraal Ja" }
-605.3 "Actualize" Ability { id: "9398", source: "Zoraal Ja" } window 5,5
+# Swords & Tiles Phase 2
+526.8 "Dawn of an Age" Ability { id: "9397", source: "Zoraal Ja" } window 5,5
+540.9 "Vollok" Ability { id: "9357", source: "Zoraal Ja" }
+550.0 "Sync" Ability { id: "9359", source: "Zoraal Ja" }
+559.0 "Chasm of Vollok (cast)" Ability { id: "939A", source: "Zoraal Ja" }
+562.2 "Chasm of Vollok (damage)" Ability { id: "9389", source: "Zoraal Ja" }
+567.1 "Duty's Edge (cast)" Ability { id: "9374", source: "Zoraal Ja" }
+567.5 "Duty's Edge (damage 1)" #Ability { id: "94A7", source: "Zoraal Ja" }
+569.5 "Duty's Edge (damage 2)" #Ability { id: "94A7", source: "Zoraal Ja" }
+571.5 "Duty's Edge (damage 3)" #Ability { id: "94A7", source: "Zoraal Ja" }
+573.5 "Duty's Edge (damage 4)" #Ability { id: "94A7", source: "Zoraal Ja" }
+582.8 "Greater Gateway" Ability { id: "9381", source: "Zoraal Ja" }
+590.8 "Blade Warp" Ability { id: "935E", source: "Zoraal Ja" }
+598.8 "Forged Track (cast)" Ability { id: "935F", source: "Zoraal Ja" }
+607.0 "Fiery Edge/Stormy Edge" Ability { id: "9382|9385", source: "Fang" }
+607.0 "Forged Track (damage)" #Ability { id: "939D", source: "Fang" }
+611.9 "Chasm of Vollok" Ability { id: "9389", source: "Zoraal Ja" }
+616.9 "Actualize" Ability { id: "9398", source: "Zoraal Ja" } window 5,5
 
-# Arena phase
-618.6 "Multidirectional Divide (cast)" Ability { id: "93A2", source: "Zoraal Ja" }
-629.6 "Multidirectional Divide (damage)" Ability { id: "93A3", source: "Zoraal Ja" }
-630.7 "Half Full" Ability { id: "9380", source: "Zoraal Ja" }
-630.7 "Forward Edge/Backward Edge" #Ability { id: "9972|937F", source: "Zoraal Ja" }
-645.8 "Actualize (enrage)" Ability { id: "996A", source: "Zoraal Ja" }
+# Final Phase/Enrage
+630.3 "Multidirectional Divide (lines drop)" Ability { id: "93A2", source: "Zoraal Ja" }
+641.3 "Multidirectional Divide (damage)" Ability { id: "93A3", source: "Zoraal Ja" }
+642.5 "Half Full" Ability { id: "9380|939E", source: "Zoraal Ja" }
+642.5 "Forward Edge/Backward Edge" Ability { id: "9972|937F", source: "Zoraal Ja" }
+657.6 "Actualize (enrage)" Ability { id: "996A", source: "Zoraal Ja" }
+
+# IGNORED ABILITIES
+#
+# 93A7 (unicode) (tank auto)
+# 9355 --sync-- (possibly re-center?)
+# 93A4 Multidirectional Divide (used duplicatively with 93A3)
+# 937B Forward Half (effect/damage is 937F Forward Edge)
+# 937D Backward Half (effect/damage is 9972 Backward Edge)
+# 993B Regicidal Rage (used duplicatively with 993C)
+# 9399 Chasm of Vollok (used duplicatively with 939A)
+# 9368 Half Full (used duplicatively with 939E)
+# 9369 Half Full (used duplicatively with 939E)
+# 9360 --sync-- (damage related to Forged Track or Fiery/Stormy Edge?)
+# 939C Forged Track (animation)
+# 9383 Fiery Edge (used duplicatively with 9382 Fiery Edge)
+# 9384 Fiery Edge (used duplicatively with 9382 Fiery Edge)
+# 9386 Stormy Edge (used duplicatively with 9385 Stormy Edge)
+# 9387 Stormy Edge (used duplicatively with 9385 Stormy Edge)
+# 937C Forward Half (effect/damage is 937F Forward Edge)
+# 937E Backward Half (effect/damage is 9972 Backward Edge)
+# 938D Might of Vollok (player-caused damage from crossing the line)
+# 993D Bitter Whirlwind (uused duplicatively with 993E)
+# 993F Bitter Whirlwind (used duplicatively with 9940)
+# 938E Drum of Vollok (used duplicatively with 938F)
+# 9394 Chasm of Vollok (used duplicatively with 9389)
+# 9393 Vollok (used duplicatively with 9389)
+# 9391 Aero III (used duplicatively with 9390)
+# 8AEF --sync-- (line stack animation?)
+# 9375 Duty's Edge (used duplicatively with 94A7)
+# 999B Forward Half (used duplicatively with 937F Forward Edge)
+# 999D Backward Half (effect/damage is 9972 Backward Edge)
+# 936B Half Circuit (used duplicatively with 939F - variation)
+# 936C Half Circuit (used duplicatively with 939F - variation)
+# 93A0 Half Circuit (used duplicatively with 939F - variation)
+# 93A1 Half Circuit (used duplicatively with 939F - variation)
+# 9365 Smiting Circuit (used duplicatively with 939F)

--- a/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.txt
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.txt
@@ -53,9 +53,9 @@ hideall "--sync--"
 # Instead of syncing (which will be random based on player resolution),
 # display a long duration while the line is moving
 221.0 "Might of Vollok" duration 40
-264.8 "Bitter Whirlwind (initial)" Ability { id: "993E", source: "Zoraal Ja" }
-268.0 "Bitter Whirlwind (damage)" Ability { id: "9940", source: "Zoraal Ja" }
-271.0 "Bitter Whirlwind (damage)" Ability { id: "9940", source: "Zoraal Ja" }
+264.8 "Bitter Whirlwind (1)" Ability { id: "993E", source: "Zoraal Ja" }
+268.0 "Bitter Whirlwind (2)" Ability { id: "9940", source: "Zoraal Ja" }
+271.0 "Bitter Whirlwind (3)" Ability { id: "9940", source: "Zoraal Ja" }
 
 # Body-Chucking Phase
 286.3 "Dawn of an Age" Ability { id: "9397", source: "Zoraal Ja" } window 5,5
@@ -93,9 +93,9 @@ hideall "--sync--"
 476.9 "Half Full" Ability { id: "9380|939E", source: "Zoraal Ja" }
 486.0 "Half Full" Ability { id: "9380|939E", source: "Zoraal Ja" }
 496.3 "Half Full" Ability { id: "9380|939E", source: "Zoraal Ja" }
-505.3 "Bitter Whirlwind (initial)" Ability { id: "993E", source: "Zoraal Ja" }
-508.5 "Bitter Whirlwind (damage)" Ability { id: "9940", source: "Zoraal Ja" }
-511.5 "Bitter Whirlwind (damage)" Ability { id: "9940", source: "Zoraal Ja" }
+505.3 "Bitter Whirlwind (1)" Ability { id: "993E", source: "Zoraal Ja" }
+508.5 "Bitter Whirlwind (2)" Ability { id: "9940", source: "Zoraal Ja" }
+511.5 "Bitter Whirlwind (3)" Ability { id: "9940", source: "Zoraal Ja" }
 
 # Swords & Tiles Phase 2
 526.8 "Dawn of an Age" Ability { id: "9397", source: "Zoraal Ja" } window 5,5


### PR DESCRIPTION
This is an initial pass at ex2.  Original timeline thanks to @valarnin (this PR replaces #192), with some adjustments/cleanup from me, but I think the timeline is largely good.

Triggers have been tested against raidemulator but still need some testing in game and may need a little cleanup in some spots (marked as draft/wip for now, but I should be able to get back in tonight).  There's a to-do list at the top for some mechs that do not yet have triggers.  I'm going to keep poking at them tonight, but it may make sense to merge as-is and do with follow-up PRs.