### PR TITLE
util: add new duty support allies to ignore list

### DIFF
--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -32,6 +32,9 @@ type FightEncInfo = ZoneEncInfo & {
 
 // Some NPCs can be picked up by our entry processor.
 // We list them out explicitly here so we can ignore them at will.
+
+// TODO: Zoraal Ja is an ally combatant in Worqor Lar Dor (duty support),
+// but an enemy combatant in Everkeep. Need to figure out how to handle this.
 export const ignoredCombatants = PetData['en'].concat([
   '',
   'Alisaie',
@@ -53,6 +56,7 @@ export const ignoredCombatants = PetData['en'].concat([
   'G\'raha Tia\'s Avatar',
   'Gosetsu',
   'Hien',
+  'Krile',
   'Liturgic Bell',
   'Lyse',
   'Mikoto',
@@ -73,6 +77,7 @@ export const ignoredCombatants = PetData['en'].concat([
   'Urianger',
   'Urianger\'s Avatar',
   'Varshahn',
+  'Wuk Lamat',
   'Y\'shtola',
   'Y\'shtola\'s Avatar',
   'Yugiri',

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -56,6 +56,7 @@ export const ignoredCombatants = PetData['en'].concat([
   'G\'raha Tia\'s Avatar',
   'Gosetsu',
   'Hien',
+  'Koana',
   'Krile',
   'Liturgic Bell',
   'Lyse',


### PR DESCRIPTION
Adds Krile, Wuk Lamat, and Koana (Worqor Lar Dor) to the combatant-ignore list in `util/logtools/encounter_tools` as they are now trust dummies or duty support allies (or both).  

NB. Zoraal Ja is also a duty support ally for Worqor Lar Dor, but given that he's decidedly *not* in Everkeep, I've left a to-do to figure out how to handle that.