### PR TITLE
raidboss: Initial r2n triggers/timeline

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r2n.ts
+++ b/ui/raidboss/data/07-dt/raid/r2n.ts
@@ -1,14 +1,104 @@
+import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
 
 export type Data = RaidbossData;
 
+// MapEffect lines only control arena appearance
+
+// Head Marker data for future reference
+const headMarkerData = {
+  // Vfx Path: tank_laser_lockon01p
+  tankLines: 'E6',
+  // Vfx Path: com_share3_7s0p
+  stack: '13D',
+  // Vfx Path: target_ae_s7k1
+  spread: '177',
+  // Vfx Path: m0906_tgae_s701k2
+  spreadHearts: '203',
+  // Vfx Path: m0906_share4_7s0k2
+  lightPartyStacks: '205',
+} as const;
+
+console.assert(headMarkerData);
+
 const triggerSet: TriggerSet<Data> = {
   id: 'AacLightHeavyweightM2',
   zoneId: ZoneId.AacLightHeavyweightM2,
   timelineFile: 'r2n.txt',
-  triggers: [],
+  triggers: [
+    {
+      id: 'R2N Call Me Honey',
+      type: 'StartsUsing',
+      netRegex: { id: '9164', source: 'Honey B. Lovely', capture: false },
+      response: Responses.aoe(),
+    },
+    {
+      id: 'R2N Honey Beeline',
+      type: 'StartsUsing',
+      netRegex: { id: ['9B39', '9B3B'], source: 'Honey B. Lovely', capture: false },
+      response: Responses.goSides(),
+    },
+    {
+      id: 'R2N Tempting Twist',
+      type: 'StartsUsing',
+      netRegex: { id: ['9B3A', '9B3C'], source: 'Honey B. Lovely', capture: false },
+      response: Responses.getUnder(),
+    },
+    {
+      id: 'R2N Honeyed Breeze',
+      type: 'StartsUsing',
+      netRegex: { id: '9167', source: 'Honey B. Lovely', capture: true },
+      response: Responses.tankBuster(),
+    },
+    {
+      id: 'R2N Drop of Venom',
+      type: 'StartsUsing',
+      netRegex: { id: '9170', source: 'Honey B. Lovely', capture: true },
+      response: Responses.stackMarkerOn(),
+    },
+    {
+      id: 'R2N Blow Kiss',
+      type: 'StartsUsing',
+      netRegex: { id: '9173', source: 'Honey B. Lovely', capture: false },
+      response: Responses.awayFromFront(),
+    },
+    {
+      id: 'R2N Heartsore',
+      type: 'StartsUsing',
+      netRegex: { id: '917A', source: 'Honey B. Lovely', capture: false },
+      suppressSeconds: 5,
+      response: Responses.spread(),
+    },
+    {
+      id: 'R2N Loveseeker',
+      type: 'StartsUsing',
+      netRegex: { id: '9AC1', source: 'Honey B. Lovely', capture: false },
+      response: Responses.getOut(),
+    },
+    {
+      id: 'R2N Honey B. Finale',
+      type: 'StartsUsing',
+      netRegex: { id: '917B', source: 'Honey B. Lovely', capture: false },
+      response: Responses.aoe(),
+    },
+    {
+      id: 'R2N Heartsick',
+      type: 'StartsUsing',
+      netRegex: { id: '9B8D', source: 'Honey B. Lovely', capture: false },
+      infoText: (_data, _matches, output) => output.stacks!(),
+      outputStrings: {
+        stacks: {
+          en: 'Stacks',
+          de: 'Sammeln',
+          fr: 'Package',
+          cn: '分摊',
+          ko: '쉐어',
+        },
+      },
+    },
+  ],
 };
 
 export default triggerSet;

--- a/ui/raidboss/data/07-dt/raid/r2n.txt
+++ b/ui/raidboss/data/07-dt/raid/r2n.txt
@@ -1,8 +1,77 @@
 ### Arcadion (R2N): AAC Light-heavyweight M2
+# -ii 917E 91C7 9A65 9166 9168 9172 9A6A 9165 916B 916C 916E 917C 916D 917F 9A66 9169
+# -it "Honey B. Lovely"
+
+# 9163 = teleport to middle
 
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
-
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
+5.6 "--sync--" StartsUsing { id: "9164", source: "Honey B. Lovely" }
+10.6 "Call Me Honey" Ability { id: "9164", source: "Honey B. Lovely" }
+24.1 "Tempting Twist" Ability { id: "9B3A", source: "Honey B. Lovely" }
+33.9 "Honey Beeline" Ability { id: "9B39", source: "Honey B. Lovely" }
+41.2 "Honeyed Breeze" Ability { id: "9167", source: "Honey B. Lovely" }
+52.8 "Tempting Twist/Honey Beeline" Ability { id: ["9B39", "9B3A", "9B3B", "9B3C"], source: "Honey B. Lovely" }
+59.4 "--middle--" Ability { id: "9163", source: "Honey B. Lovely" }
+70.1 "Honey B. Live" Ability { id: "9A7E", source: "Honey B. Lovely" }
+
+# First hearts phase
+80.0 "Love Me Tender" Ability { id: "9174", source: "Honey B. Lovely" }
+88.1 "Heartsore" Ability { id: "917A", source: "Honey B. Lovely" }
+97.1 "Fracture" Ability { id: "9178", source: "Honey B. Lovely" }
+99.1 "--middle--" Ability { id: "9163", source: "Honey B. Lovely" }
+105.4 "Loveseeker" Ability { id: "9AC1", source: "Honey B. Lovely" }
+105.4 "Heart-struck" duration 33
+110.5 "Love Me Tender" Ability { id: "9174", source: "Honey B. Lovely" }
+138.4 "Blow Kiss" Ability { id: "9173", source: "Honey B. Lovely" }
+146.1 "Love Me Tender" Ability { id: "9174", source: "Honey B. Lovely" }
+152.2 "Heart-struck" duration 3.2
+160.7 "Blow Kiss" Ability { id: "9173", source: "Honey B. Lovely" }
+171.5 "Honey B. Finale" Ability { id: "917B", source: "Honey B. Lovely" }
+# End first hearts phase
+
+180.6 "Honeyed Breeze" Ability { id: "9167", source: "Honey B. Lovely" }
+186.8 "--middle--" Ability { id: "9163", source: "Honey B. Lovely" }
+192.1 "Splash of Venom" Ability { id: "9169", source: "Honey B. Lovely" }
+202.6 "Tempting Twist/Honey Beeline" Ability { id: ["9B39", "9B3A", "9B3B", "9B3C"], source: "Honey B. Lovely" }
+212.9 "Splash of Venom/Drop of Venom" Ability { id: ["916F", "9170"], source: "Honey B. Lovely" }
+219.9 "Drop of Venom" Ability { id: "916A", source: "Honey B. Lovely" }
+229.4 "Tempting Twist/Honey Beeline" Ability { id: ["9B39", "9B3A", "9B3B", "9B3C"], source: "Honey B. Lovely" }
+239.7 "Splash of Venom/Drop of Venom" Ability { id: ["916F", "9170"], source: "Honey B. Lovely" }
+251.8 "Alarm Pheromones" Ability { id: "917D", source: "Honey B. Lovely" }
+251.8 "Blinding Love" duration 34.3
+293.1 "Tempting Twist/Honey Beeline" Ability { id: ["9B39", "9B3A", "9B3B", "9B3C"], source: "Honey B. Lovely" }
+
+299.7 label "loop"
+299.7 "--middle--" Ability { id: "9163", source: "Honey B. Lovely" }
+310.4 "Honey B. Live" Ability { id: "9A7E", source: "Honey B. Lovely" }
+
+# Second hearts phase
+315.2 "Love Me Tender" Ability { id: "9174", source: "Honey B. Lovely" }
+323.3 "Heartsick" Ability { id: "9B8D", source: "Honey B. Lovely" }
+323.3 "Fracture x6" duration 17
+339.3 "--middle--" Ability { id: "9163", source: "Honey B. Lovely" }
+345.5 "Loveseeker" Ability { id: "9AC1", source: "Honey B. Lovely" }
+345.5 "Heart-struck" duration 42.1
+350.6 "Love Me Tender" Ability { id: "9174", source: "Honey B. Lovely" }
+376.9 "Blow Kiss" Ability { id: "9173", source: "Honey B. Lovely" }
+387.6 "Honey B. Finale" Ability { id: "917B", source: "Honey B. Lovely" }
+# End second hearts phase
+
+396.7 "Honeyed Breeze" Ability { id: "9167", source: "Honey B. Lovely" }
+402.9 "--middle--" Ability { id: "9163", source: "Honey B. Lovely" }
+408.1 "Alarm Pheromones" Ability { id: "917D", source: "Honey B. Lovely" }
+408.1 "Blinding Love" duration 28.3
+413.1 "Drop of Venom" Ability { id: "916A", source: "Honey B. Lovely" }
+436.2 "--middle--" Ability { id: "9163", source: "Honey B. Lovely" }
+445.4 "Tempting Twist/Honey Beeline" Ability { id: ["9B39", "9B3A", "9B3B", "9B3C"], source: "Honey B. Lovely" }
+455.7 "Splash of Venom/Drop of Venom" Ability { id: ["916F", "9170"], source: "Honey B. Lovely" }
+456.7 "Splash of Venom" Ability { id: "9169", source: "Honey B. Lovely" }
+463.8 "--middle--" Ability { id: "9163", source: "Honey B. Lovely" }
+473.6 "Tempting Twist/Honey Beeline" Ability { id: ["9B39", "9B3A", "9B3B", "9B3C"], source: "Honey B. Lovely" }
+483.9 "Splash of Venom/Drop of Venom" Ability { id: ["916F", "9170"], source: "Honey B. Lovely" }
+490.9 "Call Me Honey" Ability { id: "9164", source: "Honey B. Lovely" }
+500.0 "Honeyed Breeze" Ability { id: "9167", source: "Honey B. Lovely" }
+510.2 "--middle--" Ability { id: "9163", source: "Honey B. Lovely" } forcejump "loop"

--- a/ui/raidboss/data/07-dt/raid/r2n.txt
+++ b/ui/raidboss/data/07-dt/raid/r2n.txt
@@ -7,6 +7,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 5.6 "--sync--" StartsUsing { id: "9164", source: "Honey B. Lovely" }
 10.6 "Call Me Honey" Ability { id: "9164", source: "Honey B. Lovely" }
@@ -38,7 +39,7 @@ hideall "--sync--"
 202.6 "Tempting Twist/Honey Beeline" Ability { id: ["9B39", "9B3A", "9B3B", "9B3C"], source: "Honey B. Lovely" }
 212.9 "Splash of Venom/Drop of Venom" Ability { id: ["916F", "9170"], source: "Honey B. Lovely" }
 219.9 "Drop of Venom" Ability { id: "916A", source: "Honey B. Lovely" }
-229.4 "Tempting Twist/Honey Beeline" Ability { id: ["9B39", "9B3A", "9B3B", "9B3C"], source: "Honey B. Lovely" }
+229.4 "Honey Beeline/Tempting Twist" Ability { id: ["9B39", "9B3A", "9B3B", "9B3C"], source: "Honey B. Lovely" }
 239.7 "Splash of Venom/Drop of Venom" Ability { id: ["916F", "9170"], source: "Honey B. Lovely" }
 251.8 "Alarm Pheromones" Ability { id: "917D", source: "Honey B. Lovely" }
 251.8 "Blinding Love" duration 34.3
@@ -70,7 +71,7 @@ hideall "--sync--"
 455.7 "Splash of Venom/Drop of Venom" Ability { id: ["916F", "9170"], source: "Honey B. Lovely" }
 456.7 "Splash of Venom" Ability { id: "9169", source: "Honey B. Lovely" }
 463.8 "--middle--" Ability { id: "9163", source: "Honey B. Lovely" }
-473.6 "Tempting Twist/Honey Beeline" Ability { id: ["9B39", "9B3A", "9B3B", "9B3C"], source: "Honey B. Lovely" }
+473.6 "Honey Beeline/Tempting Twist" Ability { id: ["9B39", "9B3A", "9B3B", "9B3C"], source: "Honey B. Lovely" }
 483.9 "Splash of Venom/Drop of Venom" Ability { id: ["916F", "9170"], source: "Honey B. Lovely" }
 490.9 "Call Me Honey" Ability { id: "9164", source: "Honey B. Lovely" }
 500.0 "Honeyed Breeze" Ability { id: "9167", source: "Honey B. Lovely" }


### PR DESCRIPTION
I included headmarker info for future savage comparison. 

Loop needs verified still.

Stack/Spread/tank lines/light party stacks  might be better triggered off of headmarkers, felt like the cast ability was slightly slower than headmarker.

`stacks` outputStrings value was copy/pasted from another trigger set, might be better to only include the `en` value and let translators handle the others.