### PR TITLE
raidboss: r1n timeline tweaks

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r1n.txt
+++ b/ui/raidboss/data/07-dt/raid/r1n.txt
@@ -6,7 +6,9 @@
 hideall "--Reset--"
 hideall "--sync--"
 
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
+8.9 "Bloody Scratch" StartsUsing { id: "9340", source: "Black Cat" }
 13.6 "Bloody Scratch" Ability { id: "9340", source: "Black Cat" }
 18.7 "--middle--" Ability { id: "9308", source: "Black Cat" }
 26.9 "One-two Paw (cast)" Ability { id: ["9309", "930C"], source: "Black Cat" }

--- a/ui/raidboss/data/07-dt/raid/r1n.txt
+++ b/ui/raidboss/data/07-dt/raid/r1n.txt
@@ -8,7 +8,7 @@ hideall "--sync--"
 
 0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
-8.9 "Bloody Scratch" StartsUsing { id: "9340", source: "Black Cat" }
+8.9 "--sync--" StartsUsing { id: "9340", source: "Black Cat" }
 13.6 "Bloody Scratch" Ability { id: "9340", source: "Black Cat" }
 18.7 "--middle--" Ability { id: "9308", source: "Black Cat" }
 26.9 "One-two Paw (cast)" Ability { id: ["9309", "930C"], source: "Black Cat" }


### PR DESCRIPTION
Add reset based on comments on r2n PR, and add missing initial sync to first raidwide which I missed.