### PR TITLE
raidboss: fix R1N Black Cat Crossing

### DIFF
--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -1359,7 +1359,7 @@ const latestLogDefinitions = {
       2: null,
     },
     canAnonymize: true,
-    firstOptionalField: 7,
+    firstOptionalField: undefined,
     analysisOptions: {
       include: 'filter',
       filters: { sourceId: '4.{7}' }, // NPC casts only

--- a/ui/raidboss/data/07-dt/raid/r1n.ts
+++ b/ui/raidboss/data/07-dt/raid/r1n.ts
@@ -202,11 +202,10 @@ const triggerSet: TriggerSet<Data> = {
       infoText: (_data, matches, output) => {
         const heading = parseFloat(matches.heading);
         const dir = Directions.hdgTo8DirNum(heading);
-        if (dir % 2 === 0) {
+        if (dir % 2 === 0)
           // `dir % 2 === 0` = this is aimed at a cardinal, so intercards safe first
-          return output.cardsIntercards!();
-        }
-        return output.intercardsCards!();
+          return output.intercardsCards!();
+        return output.cardsIntercards!();
       },
       outputStrings: {
         cardsIntercards: {


### PR DESCRIPTION
Right now `R1N Black Cat Crossing` always outputs `Intercards => Cards` regardless of the proper order.  This seems to be happening for two reasons.  The `heading` field for `StartsUsingExtra` line is listed as the `firstUnknownField`, which means it is never being captured by regex.  Second, and unrelated, the output calls in the trigger are inverted.

@valarnin - not sure if there was a reason why the `heading` field was originally treated as optional (e.g. if there is ever a circumstance that field won't be populated from OP), or whether that was just a copy-paste thing?