### PR TITLE
jobs: fix Manafont cooldown changed with level

### DIFF
--- a/ui/jobs/components/blm.ts
+++ b/ui/jobs/components/blm.ts
@@ -121,7 +121,7 @@ export class BLMComponent extends BaseComponent {
         this.thunderDot.duration = 30;
         break;
       case kAbility.Manafont:
-        this.manafont.duration = 100;
+        this.manafont.duration = this.player.level >= 84 ? 100 : 120;
     }
   }
 


### PR DESCRIPTION
At level 84 a trait reduce Manafont cooldown to 100s, before is 120s.