### PR TITLE
jobs: NIN right-side-icon fix and TA/dokumori duration fix

### DIFF
--- a/ui/jobs/buff_tracker.ts
+++ b/ui/jobs/buff_tracker.ts
@@ -361,7 +361,7 @@ export class BuffTracker {
         cooldownAbility: [kAbility.Dokumori],
         mobGainsEffect: EffectId.Dokumori,
         mobLosesEffect: EffectId.Dokumori,
-        useEffectDuration: true,
+        durationSeconds: 20 + 0.5, // This debuff has an animation lock
         icon: dokumoriImage,
         // Magenta.
         borderColor: '#FC4AE6',

--- a/ui/jobs/components/nin.ts
+++ b/ui/jobs/components/nin.ts
@@ -5,7 +5,7 @@ import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
 import { ComboTracker } from '../combo_tracker';
 import { kAbility } from '../constants';
-import { computeBackgroundColorFrom } from '../utils';
+import { computeBackgroundColorFrom, showDuration } from '../utils';
 
 import { BaseComponent, ComponentInterface } from './base';
 
@@ -89,23 +89,27 @@ export class NINComponent extends BaseComponent {
         this.ninjutsu.duration = 0;
         break;
       case kAbility.TrickAttack:
-      case kAbility.KunaisBane: {
-        this.trickAttack.duration = 15;
-        this.trickAttack.threshold = 1000;
-        this.trickAttack.fg = computeBackgroundColorFrom(
-          this.trickAttack,
-          'nin-color-trickattack.active',
-        );
-        this.tid1 = window.setTimeout(() => {
-          this.trickAttack.duration = 45;
-          this.trickAttack.threshold = this.player.gcdSkill * 4;
-          this.trickAttack.fg = computeBackgroundColorFrom(
-            this.trickAttack,
-            'nin-color-trickattack',
-          );
-        }, 15000);
+        this.tid1 = showDuration({
+          tid: this.tid1,
+          timerbox: this.trickAttack,
+          duration: 15 + 0.5, // Trick Attack has an animation lock
+          cooldown: 60,
+          threshold: this.player.gcdSkill * 4 + 1,
+          activecolor: 'nin-color-trickattack.active',
+          deactivecolor: 'nin-color-trickattack',
+        });
         break;
-      }
+      case kAbility.KunaisBane:
+        this.tid1 = showDuration({
+          tid: this.tid1,
+          timerbox: this.trickAttack,
+          duration: 15 + 1, // Kunai's Bane has a longer animation lock
+          cooldown: 60,
+          threshold: this.player.gcdSkill * 4 + 1,
+          activecolor: 'nin-color-trickattack.active',
+          deactivecolor: 'nin-color-trickattack',
+        });
+        break;
     }
   }
 

--- a/ui/jobs/components/nin.ts
+++ b/ui/jobs/components/nin.ts
@@ -142,7 +142,7 @@ export class NINComponent extends BaseComponent {
     this.mudraTriggerCd = true;
     this.ninjutsu.duration = 0;
     this.trickAttack.duration = 0;
-    this.trickAttack.threshold = this.player.gcdSkill * 4;
+    this.trickAttack.threshold = this.player.gcdSkill * 4 + 1;
     this.trickAttack.fg = computeBackgroundColorFrom(
       this.trickAttack,
       'nin-color-trickattack',

--- a/ui/jobs/components/nin.ts
+++ b/ui/jobs/components/nin.ts
@@ -89,21 +89,12 @@ export class NINComponent extends BaseComponent {
         this.ninjutsu.duration = 0;
         break;
       case kAbility.TrickAttack:
-        this.tid1 = showDuration({
-          tid: this.tid1,
-          timerbox: this.trickAttack,
-          duration: 15 + 0.5, // Trick Attack has an animation lock
-          cooldown: 60,
-          threshold: this.player.gcdSkill * 4 + 1,
-          activecolor: 'nin-color-trickattack.active',
-          deactivecolor: 'nin-color-trickattack',
-        });
-        break;
       case kAbility.KunaisBane:
         this.tid1 = showDuration({
           tid: this.tid1,
           timerbox: this.trickAttack,
-          duration: 15 + 1, // Kunai's Bane has a longer animation lock
+          // TA & KB has an animation lock, KB's is longer.
+          duration: 15 + (id === kAbility.KunaisBane ? 1 : 0.5),
           cooldown: 60,
           threshold: this.player.gcdSkill * 4 + 1,
           activecolor: 'nin-color-trickattack.active',

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -270,8 +270,7 @@ div.justbuffs div#procs-container {
 /* Space for 1 big resource box */
 .drk #right-side-icons,
 .whm #right-side-icons,
-.sge #right-side-icons,
-.nin #right-side-icons {
+.sge #right-side-icons {
   left: 250px;
 }
 


### PR DESCRIPTION
A duplicated `.nin #right-side-icons` here makes right icon position error.
Also find that new Kunai's Bane (TA upgrade) and new Dokumori (mug upgrade) has a longer animation lock for debuff.