### PR TITLE
jobs: use const EffectId instead of resource effect_id

### DIFF
--- a/ui/jobs/buff_tracker.ts
+++ b/ui/jobs/buff_tracker.ts
@@ -1,4 +1,3 @@
-import EffectId from '../../resources/effect_id';
 import arcaneCircleImage from '../../resources/ffxiv/status/arcane-circle.png';
 import arrowImage from '../../resources/ffxiv/status/arrow.png';
 import astralImage from '../../resources/ffxiv/status/astral.png';
@@ -33,7 +32,7 @@ import PartyTracker from '../../resources/party';
 import WidgetList from '../../resources/widget_list';
 import { NetMatches } from '../../types/net_matches';
 
-import { kAbility } from './constants';
+import { EffectId, kAbility } from './constants';
 import { FfxivVersion } from './jobs';
 import { JobsOptions } from './jobs_options';
 import { makeAuraTimerIcon } from './utils';

--- a/ui/jobs/components/blm.ts
+++ b/ui/jobs/components/blm.ts
@@ -1,7 +1,7 @@
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
-import { kAbility, EffectId } from '../constants';
+import { EffectId, kAbility } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 
 import { BaseComponent, ComponentInterface } from './base';

--- a/ui/jobs/components/blm.ts
+++ b/ui/jobs/components/blm.ts
@@ -1,8 +1,7 @@
-import EffectId from '../../../resources/effect_id';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
-import { kAbility } from '../constants';
+import { kAbility, EffectId } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 
 import { BaseComponent, ComponentInterface } from './base';

--- a/ui/jobs/components/brd.ts
+++ b/ui/jobs/components/brd.ts
@@ -1,9 +1,8 @@
-import EffectId from '../../../resources/effect_id';
 import TimerBar from '../../../resources/timerbar';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
-import { kAbility } from '../constants';
+import { kAbility, EffectId } from '../constants';
 import { computeBackgroundColorFrom } from '../utils';
 
 import { BaseComponent, ComponentInterface } from './base';

--- a/ui/jobs/components/brd.ts
+++ b/ui/jobs/components/brd.ts
@@ -2,7 +2,7 @@ import TimerBar from '../../../resources/timerbar';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
-import { kAbility, EffectId } from '../constants';
+import { EffectId, kAbility } from '../constants';
 import { computeBackgroundColorFrom } from '../utils';
 
 import { BaseComponent, ComponentInterface } from './base';

--- a/ui/jobs/components/dnc.ts
+++ b/ui/jobs/components/dnc.ts
@@ -1,10 +1,9 @@
-import EffectId from '../../../resources/effect_id';
 import TimerBar from '../../../resources/timerbar';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
 import { ComboTracker } from '../combo_tracker';
-import { kAbility } from '../constants';
+import { kAbility, EffectId } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 import { computeBackgroundColorFrom } from '../utils';
 

--- a/ui/jobs/components/dnc.ts
+++ b/ui/jobs/components/dnc.ts
@@ -3,7 +3,7 @@ import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
 import { ComboTracker } from '../combo_tracker';
-import { kAbility, EffectId } from '../constants';
+import { EffectId, kAbility } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 import { computeBackgroundColorFrom } from '../utils';
 

--- a/ui/jobs/components/index.ts
+++ b/ui/jobs/components/index.ts
@@ -3,7 +3,7 @@ import Util from '../../../resources/util';
 import { Job } from '../../../types/job';
 import { Bars } from '../bars';
 import { BuffTracker } from '../buff_tracker';
-import { kWellFedContentTypes, EffectId } from '../constants';
+import { EffectId, kWellFedContentTypes } from '../constants';
 import { JobsEventEmitter } from '../event_emitter';
 import { FfxivVersion } from '../jobs';
 import { JobsOptions } from '../jobs_options';

--- a/ui/jobs/components/index.ts
+++ b/ui/jobs/components/index.ts
@@ -1,10 +1,9 @@
-import EffectId from '../../../resources/effect_id';
 import PartyTracker from '../../../resources/party';
 import Util from '../../../resources/util';
 import { Job } from '../../../types/job';
 import { Bars } from '../bars';
 import { BuffTracker } from '../buff_tracker';
-import { kWellFedContentTypes } from '../constants';
+import { kWellFedContentTypes, EffectId } from '../constants';
 import { JobsEventEmitter } from '../event_emitter';
 import { FfxivVersion } from '../jobs';
 import { JobsOptions } from '../jobs_options';

--- a/ui/jobs/components/mch.ts
+++ b/ui/jobs/components/mch.ts
@@ -1,10 +1,9 @@
-import EffectId from '../../../resources/effect_id';
 import TimerBar from '../../../resources/timerbar';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
 import { ComboTracker } from '../combo_tracker';
-import { kAbility } from '../constants';
+import { kAbility, EffectId } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 import { computeBackgroundColorFrom } from '../utils';
 

--- a/ui/jobs/components/mch.ts
+++ b/ui/jobs/components/mch.ts
@@ -3,7 +3,7 @@ import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
 import { ComboTracker } from '../combo_tracker';
-import { kAbility, EffectId } from '../constants';
+import { EffectId, kAbility } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 import { computeBackgroundColorFrom } from '../utils';
 

--- a/ui/jobs/components/mnk.ts
+++ b/ui/jobs/components/mnk.ts
@@ -2,7 +2,7 @@ import TimerBar from '../../../resources/timerbar';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
-import { kAbility, EffectId } from '../constants';
+import { EffectId, kAbility } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 import { computeBackgroundColorFrom } from '../utils';
 

--- a/ui/jobs/components/mnk.ts
+++ b/ui/jobs/components/mnk.ts
@@ -1,9 +1,8 @@
-import EffectId from '../../../resources/effect_id';
 import TimerBar from '../../../resources/timerbar';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
-import { kAbility } from '../constants';
+import { kAbility, EffectId } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 import { computeBackgroundColorFrom } from '../utils';
 

--- a/ui/jobs/components/nin.ts
+++ b/ui/jobs/components/nin.ts
@@ -1,10 +1,9 @@
-import EffectId from '../../../resources/effect_id';
 import TimerBar from '../../../resources/timerbar';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
 import { ComboTracker } from '../combo_tracker';
-import { kAbility } from '../constants';
+import { kAbility, EffectId } from '../constants';
 import { computeBackgroundColorFrom, showDuration } from '../utils';
 
 import { BaseComponent, ComponentInterface } from './base';

--- a/ui/jobs/components/nin.ts
+++ b/ui/jobs/components/nin.ts
@@ -3,7 +3,7 @@ import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
 import { ComboTracker } from '../combo_tracker';
-import { kAbility, EffectId } from '../constants';
+import { EffectId, kAbility } from '../constants';
 import { computeBackgroundColorFrom, showDuration } from '../utils';
 
 import { BaseComponent, ComponentInterface } from './base';

--- a/ui/jobs/components/pct.ts
+++ b/ui/jobs/components/pct.ts
@@ -2,7 +2,7 @@ import TimerBar from '../../../resources/timerbar';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
-import { kAbility, EffectId } from '../constants';
+import { EffectId, kAbility } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 
 import { BaseComponent, ComponentInterface } from './base';

--- a/ui/jobs/components/pct.ts
+++ b/ui/jobs/components/pct.ts
@@ -1,9 +1,8 @@
-import EffectId from '../../../resources/effect_id';
 import TimerBar from '../../../resources/timerbar';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
-import { kAbility } from '../constants';
+import { kAbility, EffectId } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 
 import { BaseComponent, ComponentInterface } from './base';

--- a/ui/jobs/components/pld.ts
+++ b/ui/jobs/components/pld.ts
@@ -3,7 +3,7 @@ import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
 import { ComboTracker } from '../combo_tracker';
-import { kAbility, EffectId } from '../constants';
+import { EffectId, kAbility } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 import { computeBackgroundColorFrom, showDuration } from '../utils';
 

--- a/ui/jobs/components/pld.ts
+++ b/ui/jobs/components/pld.ts
@@ -1,10 +1,9 @@
-import EffectId from '../../../resources/effect_id';
 import TimerBar from '../../../resources/timerbar';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
 import { ComboTracker } from '../combo_tracker';
-import { kAbility } from '../constants';
+import { kAbility, EffectId } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 import { computeBackgroundColorFrom, showDuration } from '../utils';
 

--- a/ui/jobs/components/rdm.ts
+++ b/ui/jobs/components/rdm.ts
@@ -1,9 +1,8 @@
-import EffectId from '../../../resources/effect_id';
 import ResourceBar from '../../../resources/resourcebar';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
-import { kAbility } from '../constants';
+import { kAbility, EffectId } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 import { computeBackgroundColorFrom } from '../utils';
 

--- a/ui/jobs/components/rdm.ts
+++ b/ui/jobs/components/rdm.ts
@@ -2,7 +2,7 @@ import ResourceBar from '../../../resources/resourcebar';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
-import { kAbility, EffectId } from '../constants';
+import { EffectId, kAbility } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 import { computeBackgroundColorFrom } from '../utils';
 

--- a/ui/jobs/components/rpr.ts
+++ b/ui/jobs/components/rpr.ts
@@ -1,10 +1,9 @@
-import EffectId from '../../../resources/effect_id';
 import TimerBar from '../../../resources/timerbar';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
 import { ComboTracker } from '../combo_tracker';
-import { kAbility } from '../constants';
+import { kAbility, EffectId } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 import { computeBackgroundColorFrom } from '../utils';
 

--- a/ui/jobs/components/rpr.ts
+++ b/ui/jobs/components/rpr.ts
@@ -3,7 +3,7 @@ import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
 import { ComboTracker } from '../combo_tracker';
-import { kAbility, EffectId } from '../constants';
+import { EffectId, kAbility } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 import { computeBackgroundColorFrom } from '../utils';
 

--- a/ui/jobs/components/sam.ts
+++ b/ui/jobs/components/sam.ts
@@ -3,7 +3,7 @@ import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
 import { ComboTracker } from '../combo_tracker';
-import { kAbility, EffectId } from '../constants';
+import { EffectId, kAbility } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 
 import { BaseComponent, ComponentInterface } from './base';

--- a/ui/jobs/components/sam.ts
+++ b/ui/jobs/components/sam.ts
@@ -1,10 +1,9 @@
-import EffectId from '../../../resources/effect_id';
 import TimerBar from '../../../resources/timerbar';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
 import { ComboTracker } from '../combo_tracker';
-import { kAbility } from '../constants';
+import { kAbility, EffectId } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 
 import { BaseComponent, ComponentInterface } from './base';

--- a/ui/jobs/components/sge.ts
+++ b/ui/jobs/components/sge.ts
@@ -1,7 +1,7 @@
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
-import { kAbility, EffectId } from '../constants';
+import { EffectId, kAbility } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 
 import { BaseComponent, ComponentInterface } from './base';

--- a/ui/jobs/components/sge.ts
+++ b/ui/jobs/components/sge.ts
@@ -1,8 +1,7 @@
-import EffectId from '../../../resources/effect_id';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
-import { kAbility } from '../constants';
+import { kAbility, EffectId } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 
 import { BaseComponent, ComponentInterface } from './base';

--- a/ui/jobs/components/vpr.ts
+++ b/ui/jobs/components/vpr.ts
@@ -1,9 +1,8 @@
-import EffectId from '../../../resources/effect_id';
 import TimerBar from '../../../resources/timerbar';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
-import { kAbility, kComboDelay } from '../constants';
+import { kAbility, kComboDelay, EffectId } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 
 import { BaseComponent, ComponentInterface } from './base';

--- a/ui/jobs/components/vpr.ts
+++ b/ui/jobs/components/vpr.ts
@@ -2,7 +2,7 @@ import TimerBar from '../../../resources/timerbar';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
-import { kAbility, kComboDelay, EffectId } from '../constants';
+import { EffectId, kAbility, kComboDelay } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 
 import { BaseComponent, ComponentInterface } from './base';

--- a/ui/jobs/components/war.ts
+++ b/ui/jobs/components/war.ts
@@ -3,7 +3,7 @@ import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
 import { ComboTracker } from '../combo_tracker';
-import { kAbility, EffectId } from '../constants';
+import { EffectId, kAbility } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 
 import { BaseComponent, ComponentInterface } from './base';

--- a/ui/jobs/components/war.ts
+++ b/ui/jobs/components/war.ts
@@ -1,10 +1,9 @@
-import EffectId from '../../../resources/effect_id';
 import TimerBar from '../../../resources/timerbar';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
 import { ComboTracker } from '../combo_tracker';
-import { kAbility } from '../constants';
+import { kAbility, EffectId } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
 
 import { BaseComponent, ComponentInterface } from './base';

--- a/ui/jobs/components/whm.ts
+++ b/ui/jobs/components/whm.ts
@@ -1,8 +1,7 @@
-import EffectId from '../../../resources/effect_id';
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
-import { kAbility } from '../constants';
+import { kAbility, EffectId } from '../constants';
 
 import { BaseComponent, ComponentInterface } from './base';
 

--- a/ui/jobs/components/whm.ts
+++ b/ui/jobs/components/whm.ts
@@ -1,7 +1,7 @@
 import TimerBox from '../../../resources/timerbox';
 import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
-import { kAbility, EffectId } from '../constants';
+import { EffectId, kAbility } from '../constants';
 
 import { BaseComponent, ComponentInterface } from './base';
 

--- a/ui/jobs/constants.ts
+++ b/ui/jobs/constants.ts
@@ -19,6 +19,123 @@ export const kWellFedContentTypes: number[] = [
   ContentType.UltimateRaids,
 ];
 
+export const EffectId = {
+  // General
+  WellFed: '30',
+  Medicated: '31',
+  // PLD
+  Requiescat: '558',
+  AtonementReady: '76E', // to-remove
+  // WAR
+  SurgingTempest: 'A75',
+  // DRK
+
+  // GNB
+
+  // WHM
+  PresenceOfMind: '9D',
+  // SCH
+  ChainStratagem: '4C5',
+  // AST
+  Divination: '756',
+  TheBalance: 'F2F',
+  TheSpear: 'F31',
+  TheBalance6x: '75A', // to-remove
+  TheSpear6x: '75D', // to-remove
+  TheArrow: '75C', // to-remove
+  TheBole: '75B', // to-remove
+  TheEwer: '75E', // to-remove
+  TheSpire: '75F', // to-remove
+  LordOfCrowns: '754', // to-remove
+  LadyOfCrowns: '755', // to-remove
+  // SGE
+  EukrasianDosis: 'A36',
+  EukrasianDosisIi: 'A37',
+  EukrasianDosisIii: 'A38',
+  EukrasianDyskrasia: 'F39',
+  // MNK
+  OpoOpoForm: '6B',
+  RaptorForm: '6C',
+  CoeurlForm: '6D',
+  PerfectBalance: '6E',
+  FormlessFist: '9D1',
+  Brotherhood: '4A1',
+  DisciplinedFist: 'BB9', // to-remove
+  LeadenFist: '745', // to-remove
+  // DRG
+  BattleLitany: '312',
+  LeftEye: '5AE', // to-remove
+  RightEye: '776', // to-remove
+  // NIN
+  VulnerabilityUp: '27E',
+  Dokumori: 'F09',
+  Mudra: '1F0',
+  Kassatsu: '1F1',
+  // SAM
+  Fugetsu: '512',
+  Fuka: '513',
+  Higanbana: '4CC',
+  // RPR
+  ArcaneCircle: 'A27',
+  DeathsDesign: 'A1A',
+  // VPR
+  FlankstungVenom: 'E3D',
+  FlanksbaneVenom: 'E3E',
+  HindstungVenom: 'E3F',
+  HindsbaneVenom: 'E40',
+  GrimhuntersVenom: 'E41',
+  GrimskinsVenom: 'E42',
+  NoxiousGnash: 'E53',
+  HuntersInstinct: 'E54',
+  Swiftscaled: 'E55',
+  // BRD
+  VenomousBite: '7C',
+  Windbite: '81',
+  CausticBite: '4B0',
+  Stormbite: '4B1',
+  BattleVoice: '8D',
+  RadiantFinale: 'B94',
+  HawksEye: 'F15',
+  Barrage: '80',
+  ArmysMuse: '78C',
+  ArmysEthos: '78D',
+  StraightShotReady: '7A', // to-remove
+  // MCH
+  Overheated: 'A80',
+  Wildfire: '35D',
+  // DNC
+  Devilment: '721',
+  StandardFinish: '839',
+  TechnicalFinish: '71E',
+  FlourishingSymmetry: 'BC9',
+  FlourishingFlow: 'BCA',
+  ThreefoldFanDance: '71C',
+  FourfoldFanDance: 'A8B',
+  FinishingMoveReady: 'F1C',
+  // BLM
+  Firestarter: 'A5',
+  Thunderhead: 'F1E',
+  CircleOfPower: '2E2',
+  Thundercloud: 'A4', // to-remove
+  // SMN
+  SearingLight: 'A8F',
+  // RDM
+  Embolden: '511',
+  EmboldenSelf: '4D7',
+  VerstoneReady: '4D3',
+  VerfireReady: '4D2',
+  // PCT
+  HammerTime: 'E60',
+  StarryMuse: 'E65',
+  MonochromeTones: 'E6B',
+  // BLU
+  AstralAttenuation: '849',
+  UmbralAttenuation: '84A',
+  PhysicalAttenuation: '84B',
+  OffGuard: '6B5',
+  PeculiarLight: '6B9',
+} as const;
+
 export const kAbility = {
   // LB
   ShieldWall: 'C5', // T LB1


### PR DESCRIPTION
Reasons:
1. The auto generated `resource/effect_id.ts`  is somehow unstable and risks the stability of `jobs` modules. Duplicated effect name may be added in later patches, and someone may run `gen_effect_id.ts` in workflow then remove the duplicated effect and break modules in unawareness.
2. Of all 89 referenced effect IDs imported from `resource/effect_id.ts`, near a half of them is manually handled in `gen_effect_id.ts`. `jobs` module tracking those important and famous effects, which are more likely to appear on NPC and PVP effect. Instead of `check resource and find it not availble -> edit known map -> run gen_effect_id -> use`, `edit constant -> use` is more direct and easy to handle.
3. `jobs` module is the only module that using `resource/effect_id.ts`. Other modules all maintain there own effect ID map or using hard-coding ID. I believe it somewhat represent the inconvenience of `effect_id`. With this change, `effect_id` can be easily deprecated or refactored without concern of breaking current modules.