### PR TITLE
jobs: remove valuescale setting

### DIFF
--- a/ui/jobs/bars.ts
+++ b/ui/jobs/bars.ts
@@ -260,11 +260,10 @@ export class Bars {
     return textDiv as ResourceBox;
   }
 
-  addProcBox({ id, fgColor, threshold, scale, notifyWhenExpired }: {
+  addProcBox({ id, fgColor, threshold, notifyWhenExpired }: {
     id?: string;
     fgColor?: string;
     threshold?: number;
-    scale?: number;
     notifyWhenExpired?: boolean;
   }): TimerBox {
     let container = id !== undefined ? document.getElementById(id) : undefined;
@@ -281,7 +280,6 @@ export class Bars {
       threshold: threshold ? threshold : 0,
       hideafter: null,
       roundupthreshold: false,
-      valuescale: scale ? scale : 1,
     });
     container.innerHTML = ''; // remove any existing timer boxes, if there are.
     container.appendChild(timerBox);

--- a/ui/jobs/components/ast.ts
+++ b/ui/jobs/components/ast.ts
@@ -101,10 +101,7 @@ export class ASTComponent extends BaseComponent {
     }
   }
   override onStatChange({ gcdSpell }: { gcdSpell: number }): void {
-    this.combustBox.valuescale = gcdSpell;
     this.combustBox.threshold = gcdSpell + 1;
-    this.drawBox.valuescale = gcdSpell;
-    this.lucidBox.valuescale = gcdSpell;
     this.lucidBox.threshold = gcdSpell + 1;
   }
 
@@ -243,13 +240,9 @@ export class AST6xComponent extends BaseComponent {
     }
   }
   override onStatChange({ gcdSpell }: { gcdSpell: number }): void {
-    this.combustBox.valuescale = gcdSpell;
     this.combustBox.threshold = gcdSpell + 1;
-    this.drawBox.valuescale = gcdSpell;
     this.drawBox.threshold = gcdSpell + 1;
-    this.minorDrawBox.valuescale = gcdSpell;
     this.minorDrawBox.threshold = gcdSpell + 1;
-    this.lucidBox.valuescale = gcdSpell;
     this.lucidBox.threshold = gcdSpell + 1;
   }
 

--- a/ui/jobs/components/brd.ts
+++ b/ui/jobs/components/brd.ts
@@ -180,10 +180,7 @@ export class BRDComponent extends BaseComponent {
   }
 
   override onStatChange({ gcdSkill }: { gcdSkill: number }): void {
-    this.biteBox.valuescale = gcdSkill;
     this.biteBox.threshold = gcdSkill * 2;
-    this.songBox.valuescale = gcdSkill;
-    this.empyrealBox.valuescale = gcdSkill;
     this.empyrealBox.threshold = gcdSkill;
   }
 

--- a/ui/jobs/components/dnc.ts
+++ b/ui/jobs/components/dnc.ts
@@ -150,11 +150,8 @@ export class DNCComponent extends BaseComponent {
   }
 
   override onStatChange({ gcdSkill }: { gcdSkill: number }): void {
-    this.standardStep.valuescale = gcdSkill;
     this.standardStep.threshold = gcdSkill + 1;
-    this.technicalStep.valuescale = gcdSkill;
     this.technicalStep.threshold = gcdSkill + 1;
-    this.flourish.valuescale = gcdSkill;
     this.flourish.threshold = gcdSkill + 1;
   }
 

--- a/ui/jobs/components/drg.ts
+++ b/ui/jobs/components/drg.ts
@@ -105,9 +105,7 @@ export class DRGComponent extends BaseComponent {
   }
 
   override onStatChange({ gcdSkill }: { gcdSkill: number }): void {
-    this.powerSergeBox.valuescale = gcdSkill;
     this.powerSergeBox.threshold = gcdSkill * 4;
-    this.highJumpBox.valuescale = gcdSkill;
     this.highJumpBox.threshold = gcdSkill + 1;
   }
 
@@ -230,9 +228,7 @@ export class DRG6xComponent extends BaseComponent {
   }
 
   override onStatChange({ gcdSkill }: { gcdSkill: number }): void {
-    this.disembowelBox.valuescale = gcdSkill;
     this.disembowelBox.threshold = gcdSkill * 5;
-    this.highJumpBox.valuescale = gcdSkill;
     this.highJumpBox.threshold = gcdSkill + 1;
   }
 

--- a/ui/jobs/components/drk.ts
+++ b/ui/jobs/components/drk.ts
@@ -51,11 +51,8 @@ export class DRKComponent extends BaseComponent {
   }
 
   override onStatChange({ gcdSkill }: { gcdSkill: number }): void {
-    this.bloodWeapon.valuescale = gcdSkill;
     this.bloodWeapon.threshold = gcdSkill + 1;
-    this.saltedEarth.valuescale = gcdSkill;
     this.saltedEarth.threshold = gcdSkill + 1;
-    this.livingShadow.valuescale = gcdSkill;
     this.livingShadow.threshold = gcdSkill + 1;
   }
 
@@ -157,11 +154,8 @@ export class DRK6xComponent extends BaseComponent {
   }
 
   override onStatChange({ gcdSkill }: { gcdSkill: number }): void {
-    this.bloodWeapon.valuescale = gcdSkill;
     this.bloodWeapon.threshold = gcdSkill + 1;
-    this.delirium.valuescale = gcdSkill;
     this.delirium.threshold = gcdSkill + 1;
-    this.livingShadow.valuescale = gcdSkill;
     this.livingShadow.threshold = gcdSkill * 4 + 1;
   }
 

--- a/ui/jobs/components/gnb.ts
+++ b/ui/jobs/components/gnb.ts
@@ -49,10 +49,7 @@ export class GNBComponent extends BaseComponent {
     this.reset();
   }
   override onStatChange({ gcdSkill }: { gcdSkill: number }): void {
-    this.gnashingFangBox.valuescale = gcdSkill;
     this.gnashingFangBox.threshold = gcdSkill * 3 + 1;
-    this.noMercyBox.valuescale = gcdSkill;
-    this.bloodfestBox.valuescale = gcdSkill;
     this.bloodfestBox.threshold = gcdSkill * 3 + 1;
   }
 

--- a/ui/jobs/components/mch.ts
+++ b/ui/jobs/components/mch.ts
@@ -180,13 +180,9 @@ export class MCHComponent extends BaseComponent {
   }
 
   override onStatChange({ gcdSkill }: { gcdSkill: number }): void {
-    this.drillBox.valuescale = gcdSkill;
     this.drillBox.threshold = gcdSkill * 3 + 1;
-    this.airAnchorBox.valuescale = gcdSkill;
     this.airAnchorBox.threshold = gcdSkill * 3 + 1;
-    this.chainSawBox.valuescale = gcdSkill;
     this.chainSawBox.threshold = gcdSkill * 3 + 1;
-    this.wildFireBox.valuescale = gcdSkill;
     this.wildFireBox.threshold = gcdSkill + 1;
   }
 

--- a/ui/jobs/components/mnk.ts
+++ b/ui/jobs/components/mnk.ts
@@ -207,13 +207,9 @@ export class MNKComponent extends BaseComponent {
   }
 
   override onStatChange({ gcdSkill }: { gcdSkill: number }): void {
-    this.perfectbalanceBox.valuescale = gcdSkill;
     this.perfectbalanceBox.threshold = gcdSkill + 1;
-    this.riddleOfFireBox.valuescale = gcdSkill;
     this.riddleOfFireBox.threshold = gcdSkill + 1;
-    this.riddleOfWindBox.valuescale = gcdSkill;
     this.riddleOfWindBox.threshold = gcdSkill + 1;
-    this.brotherhoodBox.valuescale = gcdSkill;
     this.brotherhoodBox.threshold = gcdSkill + 1;
   }
 

--- a/ui/jobs/components/nin.ts
+++ b/ui/jobs/components/nin.ts
@@ -105,10 +105,7 @@ export class NINComponent extends BaseComponent {
   }
 
   override onStatChange({ gcdSkill }: { gcdSkill: number }): void {
-    this.trickAttack.valuescale = gcdSkill;
-    this.bunshin.valuescale = gcdSkill;
     this.bunshin.threshold = gcdSkill * 8;
-    this.ninjutsu.valuescale = gcdSkill;
     this.ninjutsu.threshold = gcdSkill * 2;
   }
 
@@ -254,10 +251,7 @@ export class NIN6xComponent extends BaseComponent {
   }
 
   override onStatChange({ gcdSkill }: { gcdSkill: number }): void {
-    this.trickAttack.valuescale = gcdSkill;
-    this.bunshin.valuescale = gcdSkill;
     this.bunshin.threshold = gcdSkill * 8;
-    this.ninjutsu.valuescale = gcdSkill;
     this.ninjutsu.threshold = gcdSkill * 2;
   }
 

--- a/ui/jobs/components/pld.ts
+++ b/ui/jobs/components/pld.ts
@@ -135,13 +135,9 @@ export class PLDComponent extends BaseComponent {
   }
 
   override onStatChange({ gcdSkill }: { gcdSkill: number }): void {
-    this.scornBox.valuescale = gcdSkill;
     this.scornBox.threshold = gcdSkill + 1;
-    this.expiacionBox.valuescale = gcdSkill;
     this.expiacionBox.threshold = gcdSkill + 1;
-    this.requiescatBox.valuescale = gcdSkill;
     this.requiescatBox.threshold = gcdSkill + 1;
-    this.fightOrFlightBox.valuescale = gcdSkill;
     this.fightOrFlightBox.threshold = gcdSkill * 2 + 1;
   }
 
@@ -318,11 +314,8 @@ export class PLD6xComponent extends BaseComponent {
   }
 
   override onStatChange({ gcdSkill }: { gcdSkill: number }): void {
-    this.goreBox.valuescale = gcdSkill;
     this.goreBox.threshold = gcdSkill * 3 + 0.3;
-    this.expiacionBox.valuescale = gcdSkill;
     this.expiacionBox.threshold = gcdSkill;
-    this.fightOrFlightBox.valuescale = gcdSkill;
     this.fightOrFlightBox.threshold = gcdSkill * 2 + 1;
   }
 

--- a/ui/jobs/components/rdm.ts
+++ b/ui/jobs/components/rdm.ts
@@ -102,9 +102,7 @@ export class RDMComponent extends BaseComponent {
       this.contreSixteBox.duration = this.player.level < 74 ? 45 : 35;
   }
   override onStatChange({ gcdSpell }: { gcdSpell: number }): void {
-    this.flecheBox.valuescale = gcdSpell;
     this.flecheBox.threshold = gcdSpell + 1;
-    this.contreSixteBox.valuescale = gcdSpell;
     this.contreSixteBox.threshold = gcdSpell + 1;
   }
 

--- a/ui/jobs/components/rpr.ts
+++ b/ui/jobs/components/rpr.ts
@@ -166,13 +166,9 @@ export class RPRComponent extends BaseComponent {
   }
 
   override onStatChange({ gcdSkill }: { gcdSkill: number }): void {
-    this.deathsDesignBox.valuescale = gcdSkill;
     this.deathsDesignBox.threshold = gcdSkill * 3 + 1;
-    this.gluttonyBox.valuescale = gcdSkill;
     this.gluttonyBox.threshold = gcdSkill * 2 + 1;
-    this.soulSliceBox.valuescale = gcdSkill;
     this.soulSliceBox.threshold = gcdSkill * 2 + 1;
-    this.arcaneCircleBox.valuescale = gcdSkill;
     this.arcaneCircleBox.threshold = gcdSkill + 1;
   }
 

--- a/ui/jobs/components/sam.ts
+++ b/ui/jobs/components/sam.ts
@@ -144,13 +144,9 @@ export class SAMComponent extends BaseComponent {
   }
 
   override onStatChange({ gcdSkill }: { gcdSkill: number }): void {
-    this.fuka.valuescale = gcdSkill;
     this.fuka.threshold = gcdSkill * 6;
-    this.fugetsu.valuescale = gcdSkill;
     this.fugetsu.threshold = gcdSkill * 6;
-    this.tsubameGaeshi.valuescale = gcdSkill;
     this.tsubameGaeshi.threshold = this.ffxivVersion < 700 ? gcdSkill * 4 : gcdSkill + 1;
-    this.higanbana.valuescale = gcdSkill;
     this.higanbana.threshold = gcdSkill * 4;
   }
 

--- a/ui/jobs/components/sch.ts
+++ b/ui/jobs/components/sch.ts
@@ -103,10 +103,7 @@ export class SCHComponent extends BaseComponent {
   }
 
   override onStatChange({ gcdSpell }: { gcdSpell: number }): void {
-    this.bioBox.valuescale = gcdSpell;
     this.bioBox.threshold = gcdSpell + 1;
-    this.aetherflowBox.valuescale = gcdSpell;
-    this.lucidBox.valuescale = gcdSpell;
     this.lucidBox.threshold = gcdSpell + 1;
   }
 

--- a/ui/jobs/components/sge.ts
+++ b/ui/jobs/components/sge.ts
@@ -120,13 +120,9 @@ export class SGEComponent extends BaseComponent {
   }
 
   override onStatChange({ gcdSpell }: { gcdSpell: number }): void {
-    this.eukrasianDosis.valuescale = gcdSpell;
     this.eukrasianDosis.threshold = gcdSpell + 1;
-    this.phlegma.valuescale = gcdSpell;
     this.phlegma.threshold = gcdSpell + 1;
-    this.rhizomata.valuescale = gcdSpell;
     this.rhizomata.threshold = gcdSpell + 1;
-    this.lucidDream.valuescale = gcdSpell;
     this.lucidDream.threshold = gcdSpell + 1;
     // Due to unknown reason, if you sync to below lv45,
     // addersgall is not availble but memory still says you have 3 addersgall.

--- a/ui/jobs/components/smn.ts
+++ b/ui/jobs/components/smn.ts
@@ -180,10 +180,7 @@ export class SMNComponent extends BaseComponent {
   }
 
   override onStatChange({ gcdSpell }: { gcdSpell: number }): void {
-    this.energyDrainBox.valuescale = gcdSpell;
     this.energyDrainBox.threshold = gcdSpell + 1;
-    this.tranceBox.valuescale = gcdSpell;
-    this.lucidBox.valuescale = gcdSpell;
     this.lucidBox.threshold = gcdSpell + 1;
   }
 

--- a/ui/jobs/components/war.ts
+++ b/ui/jobs/components/war.ts
@@ -98,11 +98,8 @@ export class WARComponent extends BaseComponent {
   }
 
   override onStatChange({ gcdSkill }: { gcdSkill: number }): void {
-    this.tempestBox.valuescale = gcdSkill;
     this.tempestBox.threshold = gcdSkill * 3 + 1;
-    this.upheavalBox.valuescale = gcdSkill;
     this.upheavalBox.threshold = gcdSkill;
-    this.innerReleaseBox.valuescale = gcdSkill;
     this.innerReleaseBox.threshold = gcdSkill * 3;
   }
 

--- a/ui/jobs/components/whm.ts
+++ b/ui/jobs/components/whm.ts
@@ -116,13 +116,9 @@ export class WHMComponent extends BaseComponent {
   }
 
   override onStatChange({ gcdSpell }: { gcdSpell: number }): void {
-    this.diaBox.valuescale = gcdSpell;
     this.diaBox.threshold = gcdSpell + 1;
-    this.assizeBox.valuescale = gcdSpell;
     this.assizeBox.threshold = gcdSpell + 1;
-    this.pomBox.valuescale = gcdSpell;
     this.pomBox.threshold = gcdSpell + 1;
-    this.lucidBox.valuescale = gcdSpell;
     this.lucidBox.threshold = gcdSpell + 1;
   }
 


### PR DESCRIPTION
https://github.com/OverlayPlugin/cactbot/blob/1be5017fe1233268ab6dd10cf8d206f2921508c7/resources/timerbox.ts#L488

The valuescale setting seems to be used as a divider before showing the timerbox text (i.e the remaining time), so translate the plain time to be how many GCDs remaining if we set it to the current GCD length.
But it looks like most of the time, instead of seeing the text, we are just watching the box showing larger -> prepare to press the corresponding button. @Echoring would explain it more!