### PR TITLE
raidboss: r1s left/right, tb, and aoe triggers

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r1s.ts
+++ b/ui/raidboss/data/07-dt/raid/r1s.ts
@@ -34,7 +34,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'R1S Bloody Scratch',
       type: 'StartsUsing',
       netRegex: { id: '9494', source: 'Black Cat', capture: false },
-      response: Responses.aoe(),
+      response: Responses.bigAoe(),
     },
   ],
 };

--- a/ui/raidboss/data/07-dt/raid/r1s.ts
+++ b/ui/raidboss/data/07-dt/raid/r1s.ts
@@ -1,3 +1,4 @@
+import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
@@ -8,7 +9,34 @@ const triggerSet: TriggerSet<Data> = {
   id: 'AacLightHeavyweightM1Savage',
   zoneId: ZoneId.AacLightHeavyweightM1Savage,
   timelineFile: 'r1s.txt',
-  triggers: [],
+  triggers: [
+    {
+      id: 'R1S One-two Paw Right Left',
+      type: 'StartsUsing',
+      netRegex: { id: '9436', source: 'Black Cat', capture: false },
+      durationSeconds: 9.5,
+      response: Responses.goLeftThenRight(),
+    },
+    {
+      id: 'R1S One-two Paw Left Right',
+      type: 'StartsUsing',
+      netRegex: { id: '9439', source: 'Black Cat', capture: false },
+      durationSeconds: 9.5,
+      response: Responses.goRightThenLeft(),
+    },
+    {
+      id: 'R1S Biscuit Maker',
+      type: 'StartsUsing',
+      netRegex: { id: '9495', source: 'Black Cat', capture: true },
+      response: Responses.tankBuster(),
+    },
+    {
+      id: 'R1S Bloody Scratch',
+      type: 'StartsUsing',
+      netRegex: { id: '9494', source: 'Black Cat', capture: false },
+      response: Responses.aoe(),
+    },
+  ],
 };
 
 export default triggerSet;


### PR DESCRIPTION
Adds a left/right call for boss. There are multiple spell-ids, could use a double-check to make sure the ones here are both from the boss and not the other entities.

TB callout just calls the initial target.

AoE callout for bloody scratch