### PR TITLE
build: Bump version to 0.32.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cactbot",
-  "version": "0.32.4",
+  "version": "0.32.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cactbot",
-      "version": "0.32.4",
+      "version": "0.32.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@fast-csv/parse": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cactbot",
-  "version": "0.32.4",
-  "releaseSummary": "full DT jobs support, more arcadion, i18n",
+  "version": "0.32.5",
+  "releaseSummary": "initial savage floors 1-3, jobs fixes",
   "releaseInDraft": "false",
   "license": "Apache-2.0",
   "type": "module",

--- a/plugin/CactbotEventSource/Properties/AssemblyInfo.cs
+++ b/plugin/CactbotEventSource/Properties/AssemblyInfo.cs
@@ -21,5 +21,5 @@ using System.Runtime.InteropServices;
 // - Revision
 // GitHub has only 3 version components, so Revision should always be 0.
 // CactbotOverlay and CactbotEventSource version should match.
-[assembly: AssemblyVersion("0.32.4.0")]
-[assembly: AssemblyFileVersion("0.32.4.0")]
+[assembly: AssemblyVersion("0.32.5.0")]
+[assembly: AssemblyFileVersion("0.32.5.0")]

--- a/plugin/CactbotOverlay/Properties/AssemblyInfo.cs
+++ b/plugin/CactbotOverlay/Properties/AssemblyInfo.cs
@@ -20,5 +20,5 @@ using System.Runtime.InteropServices;
 // - Build Number
 // - Revision
 // GitHub has only 3 version components, so Revision should always be 0.
-[assembly: AssemblyVersion("0.32.4.0")]
-[assembly: AssemblyFileVersion("0.32.4.0")]
+[assembly: AssemblyVersion("0.32.5.0")]
+[assembly: AssemblyFileVersion("0.32.5.0")]


### PR DESCRIPTION
Prepping this version bump for whoever decides that it's a good time to push what we have for savage out.

Summary includes floor 3 under the assumption #296 will be merged before this.