### PR TITLE
i18n: Add Japanese translations for r1s triggers

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r1s.ts
+++ b/ui/raidboss/data/07-dt/raid/r1s.ts
@@ -334,6 +334,7 @@ const triggerSet: TriggerSet<Data> = {
         swSeStay: {
           en: '${dir1} ${sep} ${dir2} (Stay)',
           de: '${dir1} ${sep} ${dir2} (Stehen bleiben)',
+          ja: '${dir1} ${sep} ${dir2} (そのまま)',
         },
         separator: {
           en: ' => ',
@@ -379,6 +380,7 @@ const triggerSet: TriggerSet<Data> = {
         text: {
           en: 'Launch Forward (Aim for uncracked tile)',
           de: 'Schlag Vorwärts (Ziel auf eine ganze Fläche)',
+          ja: '前方吹き飛ばし (割れていない床を狙って)',
         },
       },
     },
@@ -392,6 +394,7 @@ const triggerSet: TriggerSet<Data> = {
         text: {
           en: '${target} Launch',
           de: '${target} Start',
+          ja: '${target} に吹き飛ばし',
         },
       },
     },
@@ -405,6 +408,7 @@ const triggerSet: TriggerSet<Data> = {
         text: {
           en: 'Stand on uncracked tile',
           de: 'Steh auf einer ganzen Fläche',
+          ja: '割れてない床に立って',
         },
       },
     },
@@ -418,6 +422,7 @@ const triggerSet: TriggerSet<Data> = {
         text: {
           en: '${target} Stun',
           de: '${target} Betäubung',
+          ja: '${target} にスタン',
         },
       },
     },
@@ -489,7 +494,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Role positions',
           de: 'Rollenposition',
           fr: 'Positions par rôle',
-          ja: 'ロール特定位置へ',
+          ja: 'ロールの担当位置へ',
           cn: '去指定位置',
           ko: '직업별 산개위치로',
         },


### PR DESCRIPTION
This PR adds Japanese translations to the existing R1S triggers.
Please review and let me know if any adjustments are needed.

## Changes

- Added Japanese translations for `R1S Mouser`
- Added Japanese translations for `R1S Elevate and Eviscerate Launch Self`
- Added Japanese translations for `R1S Elevate and Eviscerate Launch Other`
- Added Japanese translations for `R1S Elevate and Eviscerate Stun Self`
- Added Japanese translations for `R1S Elevate and Eviscerate Stun Other`
- Improved existing Japanese translation for `R1S Splintering Nails` to sound more natural

