### PR TITLE
i18n: Add Japanese translations for R3S new triggers

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r3s.ts
+++ b/ui/raidboss/data/07-dt/raid/r3s.ts
@@ -246,6 +246,7 @@ const triggerSet: TriggerSet<Data> = {
         text: {
           en: 'Out => In => Knockback => Partners',
           de: 'Raus => Rein => Rückstoß => Partner',
+          ja: '外側 => 内側 => ノックバック => ペア',
         },
       },
     },

--- a/ui/raidboss/data/07-dt/raid/r3s.ts
+++ b/ui/raidboss/data/07-dt/raid/r3s.ts
@@ -233,6 +233,7 @@ const triggerSet: TriggerSet<Data> = {
         text: {
           en: 'Out => In => Knockback => Spread',
           de: 'Raus => Rein => Rückstoß => Verteilen',
+          ja: '外側 => 内側 => ノックバック => 散開',
         },
       },
     },


### PR DESCRIPTION
This PR adds Japanese translations for the new triggers introduced in #309.

## Changes

- Add Japanese translation for `R3S Octoboom Bombarian Special`
- Add Japanese translation for `R3S Quadroboom Bombarian Special`