### PR TITLE
r1s: fix nailchipper quadruple crossing callouts

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r1s.ts
+++ b/ui/raidboss/data/07-dt/raid/r1s.ts
@@ -232,7 +232,7 @@ const headMarkerData = {
   // Vfx Path: tank_lockon02k1
   tankbuster: '00DA',
   // Vfx Path: lockon8_t0w
-  lineStack: '00F4',
+  nailchipper: '00F4',
   // Vfx Path: loc05sp_05a_se_p
   spreadMarker: '0178',
   // Vfx Path: m0884_vanish_7sec_p1
@@ -352,11 +352,31 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'R1S Headmarker Line Stack',
+      id: 'R1S Headmarker Nailchipper',
       type: 'HeadMarker',
-      netRegex: { id: headMarkerData.lineStack, capture: true },
+      netRegex: { id: headMarkerData.nailchipper, capture: true },
+      durationSeconds: 5,
       suppressSeconds: 5,
-      response: Responses.stackMarkerOn(),
+      alertText: (data, matches, output) => {
+        // Nailchipper (and the associated head marker) either goes on all
+        // support or all dps. If the nailchippers went on the same role
+        // (support or DPS) as the player, then they can't be hit by the
+        // next Quadruple Crossing. If the nailchippers went on the opposite
+        // role, then the player must go in and bait the next quadruple
+        // crossing.
+        if (data.party.isDPS(matches.target))
+          return output.dps!();
+
+        return output.support!();
+      },
+      outputStrings: {
+        support: {
+          en: 'Support out',
+        },
+        dps: {
+          en: 'DPS out',
+        },
+      },
     },
     {
       id: 'R1S Headmarker Spread Markers',


### PR DESCRIPTION
During the Leaping Quadruple Crossing given by one of Black Cat's
clones, players are hit by Nailchipper and given a headmarker which
indicates that they will do a mini explosion and will die if they get
hit by the next Quadruple Crossing bait. The markers always go either on
all DPS or on all support players.

Currently, when this marker goes out, cactbot incorrectly calls out
"stack on <player>" for whichever player happens to be first in the data
log. This could in theory be used to see who has the nailchippers and
processed into a decision of whether to go in or out. However, using the
term "stack" is very odd since it is *not* a stack mechanic.

Instead, check what role the target is. Based on this, alert either
"Support out" or "DPS out".

We could complicate this further by checking the role of the player and
alerting either in our out, (or some other alert such as baiting).
While this could be doable its more complicated to get correct.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
