### PR TITLE
util: splitter/anonymizer fix

### DIFF
--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -717,12 +717,14 @@ const latestLogDefinitions = {
       targetId: 2,
       target: 3,
       id: 6,
+      data0: 7,
     },
     playerIds: {
       2: 3,
     },
+    possiblePlayerIds: [7],
     canAnonymize: true,
-    firstOptionalField: undefined,
+    firstOptionalField: 7,
     analysisOptions: {
       include: 'all',
       combatantIdFields: 2,

--- a/util/logtools/anonymizer.ts
+++ b/util/logtools/anonymizer.ts
@@ -13,7 +13,6 @@ import FakeNameGenerator from './fake_name_generator';
 import { Notifier } from './notifier';
 import { ReindexedLogDefs } from './splitter';
 
-
 // TODO: Anonymizer currently finds/replaces player ids (potentially paired with a player name).
 // There are a few edge cases (Countdown/CountdownCancel) where a player name may apepar
 // with no corresponding id (e.g. a blank id). We don't currently handle that scenario given the

--- a/util/logtools/anonymizer.ts
+++ b/util/logtools/anonymizer.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash';
+import _ from 'lodash';
 
 import logDefinitions, {
   LogDefFieldIdx,
@@ -12,6 +12,7 @@ import { UnreachableCode } from '../../resources/not_reached';
 import FakeNameGenerator from './fake_name_generator';
 import { Notifier } from './notifier';
 import { ReindexedLogDefs } from './splitter';
+
 
 // TODO: Anonymizer currently finds/replaces player ids (potentially paired with a player name).
 // There are a few edge cases (Countdown/CountdownCancel) where a player name may apepar
@@ -68,11 +69,11 @@ export default class Anonymizer {
   }
 
   isLogDefinition<K extends LogDefinitionName>(def: { name: K }): def is LogDefinition<K> {
-    return isEqual(def, logDefinitions[def.name]);
+    return _.isEqual(def, logDefinitions[def.name]);
   }
 
   isReindexedLogDefs(remap: Partial<ReindexedLogDefs>): remap is ReindexedLogDefs {
-    return Object.values(logDefinitions).every((d) => isEqual(remap[d.type], d));
+    return Object.values(logDefinitions).every((d) => _.isEqual(remap[d.type], d));
   }
 
   processLogDefs(): ReindexedLogDefs {

--- a/util/logtools/splitter.ts
+++ b/util/logtools/splitter.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash';
+import _ from 'lodash';
 
 import logDefinitions, {
   LogDefinition,
@@ -83,11 +83,11 @@ export default class Splitter {
   }
 
   isLogDefinition<K extends LogDefinitionName>(def: { name: K }): def is LogDefinition<K> {
-    return isEqual(def, logDefinitions[def.name]);
+    return _.isEqual(def, logDefinitions[def.name]);
   }
 
   isReindexedLogDefs(remap: Partial<ReindexedLogDefs>): remap is ReindexedLogDefs {
-    return Object.values(logDefinitions).every((d) => isEqual(remap[d.type], d));
+    return Object.values(logDefinitions).every((d) => _.isEqual(remap[d.type], d));
   }
 
   processAnalysisOptions(): ReindexedLogDefs {


### PR DESCRIPTION
On more recent versions of NodeJS, it will complain about using a named import from lodash (specifically, `isEqual` which is used in splitter & anonymizer for typeguards) because it is a CommonJS module.  This fix allows `split_log` to be run from the CLI (which is currently broken).

This also updates the logdef for 0x1B lines.  In R4S, one of the uncaptured params contains a duplicate of the actorId, which causes anonymizer to throw uncaught-player errors.  This adds that field as a `possiblePlayerId`, meaning it will be silently anonymized if present but not included as a regex capture group.