### PR TITLE
raidemulator: Fix bug with double seek in raidemulator

### DIFF
--- a/ui/raidboss/emulator/data/RaidEmulator.ts
+++ b/ui/raidboss/emulator/data/RaidEmulator.ts
@@ -40,6 +40,9 @@ export default class RaidEmulator extends EventBus {
       this.popupText?.setParserLanguage(enc.language);
     }
 
+    // Clear our current timestamp early to prevent issues with double seek on load
+    this.currentLogTime = undefined;
+
     this.currentEncounter = new AnalyzedEncounter(this.options, enc, this, watchCombatantsOverride);
     void this.dispatch('preCurrentEncounterChanged', this.currentEncounter);
     void this.currentEncounter.analyze().then(() => {


### PR DESCRIPTION
This is the cause of raidemulator not seeking to the start of the fight properly when going from a newer encounter to an older encounter.

Basically, the previous encounter's timestamp was held when changing encounters, which causes the initial perspective selection to seek to that timestamp. If the previous encounter was before the new encounter, that's not a big problem since the seek would be capped to the start of the encounter.

But if the previous encounter's timestamp was later than the current encounter, the seek would succeed and be past the end of the newly loaded encounter.