### PR TITLE
raidboss: Fix issue with KR/CN compatibility

### DIFF
--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -492,7 +492,8 @@ const latestLogDefinitions = {
     },
     blankFields: [6, 47, 48],
     canAnonymize: true,
-    firstOptionalField: undefined,
+    // @TODO: Set this back to `undefined` after KR/CN have access to the new fields
+    firstOptionalField: 47,
     analysisOptions: {
       include: 'filter',
       filters: { sourceId: '4.{7}' }, // NPC abilities only

--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -555,7 +555,8 @@ const latestLogDefinitions = {
     },
     blankFields: [6, 47, 48],
     canAnonymize: true,
-    firstOptionalField: undefined,
+    // @TODO: Set this back to `undefined` after KR/CN have access to the new fields
+    firstOptionalField: 47,
     analysisOptions: {
       include: 'filter',
       filters: { sourceId: '4.{7}' }, // NPC abilities only


### PR DESCRIPTION
Fixes #327
Fixes #328 

Changed capture regex does not reference the new fields unless they're required for the trigger. If the new fields are required for a trigger to be handled, the new fields can be included as parameters with wildcard matches, but those triggers will not work for KR/CN users.

![image](https://github.com/user-attachments/assets/24a93ab0-5eb1-4e4c-9fc7-9cce468f58d8)
