### PR TITLE
raidboss: R3S Tag Team 1/2, KB towers 2 lariat combo

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r3s.ts
+++ b/ui/raidboss/data/07-dt/raid/r3s.ts
@@ -351,11 +351,23 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'R3S Tag Team Clone',
       type: 'StartsUsing',
+      /*
+        Clones spawn on a random cardinal. They do one lariat dash across, then another one back.
+        There are two sets of IDs, one for Tag Team 1, and one for Tag Team 2.
+        IDs:
+        9B2C - TT1, Right -> Left
+        9B2E - TT1, Left -> Right
+        9BD8 - TT2, Right -> Left
+        9BDA - TT2, Left -> Right
+      */
       netRegex: { id: ['9B2C', '9B2E', '9BD8', '9BDA'], source: 'Brute Distortion', capture: true },
       condition: (data, matches) => {
         const x = parseFloat(matches.x);
         const y = parseFloat(matches.y);
         const cloneDir = Directions.xyTo8DirNum(x, y, 100, 100);
+        // Increment clockwise from our starting position to get the cleave direction.
+        // If this is a right cleave, increment by 6 (South + 6 = East)
+        // Otherwise, increment 2 positions (South + 2 = West)
         const cleaveAdjust = ['9B2C', '9BD8'].includes(matches.id) ? 6 : 2;
         const cleaveDir = (cloneDir + cleaveAdjust) % 8;
         data.tagTeamClones.push({
@@ -445,6 +457,18 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'R3S KB Towers 2 Lariat Combo',
       type: 'StartsUsing',
+      /*
+        Boss jumps to a random cardinal. Does one lariat dash across, then another one back.
+        IDs:
+        9AE8 - Right cleave, then right cleave again.
+             - If north, then east safe, then west. (go)
+        9AE9 - Right cleave, then left cleave.
+             - If north, then east safe, then east. (stay)
+        9AEA - Left cleave, then left cleave again.
+             - If north, then west safe, then east. (go)
+        9AEB - Left cleave, then right cleave.
+             - If north, then west safe, then west. (stay)
+      */
       netRegex: { id: ['9AE8', '9AE9', '9AEA', '9AEB'], source: 'Brute Bomber', capture: true },
       durationSeconds: 11,
       infoText: (_data, matches, output) => {
@@ -459,11 +483,15 @@ const triggerSet: TriggerSet<Data> = {
         let secondSafeSpots = [...firstSafeSpots];
 
         for (let idx = 0; idx < 5; ++idx) {
+          // Starting at boss position, treat the 5 positions clockwise as unsafe
+          // If this is a right cleave instead, then start opposite of boss
           const dir = (bossDir + (firstCleaveDir === 'left' ? 0 : 4) + idx) % 8;
           firstSafeSpots = firstSafeSpots.filter((spot) => spot !== dir);
         }
 
         for (let idx = 0; idx < 5; ++idx) {
+          // Starting opposite boss position, treat the 5 positions clockwise as unsafe
+          // If this is a right cleave instead, then start at boss
           const dir = (bossDir + (secondCleaveDir === 'right' ? 0 : 4) + idx) % 8;
           secondSafeSpots = secondSafeSpots.filter((spot) => spot !== dir);
         }

--- a/ui/raidboss/data/07-dt/raid/r3s.ts
+++ b/ui/raidboss/data/07-dt/raid/r3s.ts
@@ -1,16 +1,75 @@
 import Conditions from '../../../../../resources/conditions';
 import Outputs from '../../../../../resources/outputs';
+import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
 import { Responses } from '../../../../../resources/responses';
+import { Directions } from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
 
+type TagTeamClone = {
+  dir: number;
+  cleave: number;
+};
+
 export interface Data extends RaidbossData {
   phaseTracker: number;
+  tagTeamCloneTethered?: number;
+  tagTeamClones: TagTeamClone[];
 }
 
-// TODO: Lariat Combo during second KB towers?
 // TODO: <foo>boom Special delayed in/out triggers?
+
+const getSafeSpotsFromClones = (
+  myClone: TagTeamClone,
+  otherClone: TagTeamClone,
+  murderousMistDir?: number,
+): [number[], number] => {
+  let safeSpots = [...Array(8).keys()];
+
+  const lastSafeSpots = Array<number>(8).fill(0);
+
+  // Trim the three dirs that aren't getting hit by myClone
+  for (let idx = 0; idx < 3; ++idx) {
+    const dir = (myClone.cleave + 3 + idx) % 8;
+    safeSpots = safeSpots.filter((spot) => dir !== spot);
+  }
+
+  // Trim the five dirs that are getting hit by otherClone
+  for (let idx = 0; idx < 5; ++idx) {
+    const dir = (otherClone.cleave + 6 + idx) % 8;
+    safeSpots = safeSpots.filter((spot) => dir !== spot);
+    // Track that this spot is getting hit for the last safe spot calc
+    lastSafeSpots[dir]++;
+  }
+
+  // Handle Murderous Mist if that's getting passed in
+  if (murderousMistDir !== undefined) {
+    // Invert to get the "safe" spot behind boss
+    murderousMistDir = (murderousMistDir + 4) % 8;
+    safeSpots = safeSpots.filter((spot) => murderousMistDir !== spot);
+  }
+
+  // Figure out where our final safe spot is
+  for (let idx = 0; idx < 5; ++idx) {
+    const dir = (myClone.cleave + 6 + idx) % 8;
+    lastSafeSpots[dir]++;
+  }
+
+  const lastSafeSpot = (lastSafeSpots.findIndex((count) => count === 0) + 4) % 8;
+
+  return [safeSpots, lastSafeSpot];
+};
+
+const tagTeamOutputStrings = {
+  ...Directions.outputStrings8Dir,
+  safeDirs: {
+    en: 'Safe: ${dirs} => ${last}',
+  },
+  separator: {
+    en: '/',
+  },
+} as const;
 
 const triggerSet: TriggerSet<Data> = {
   id: 'AacLightHeavyweightM3Savage',
@@ -18,6 +77,7 @@ const triggerSet: TriggerSet<Data> = {
   timelineFile: 'r3s.txt',
   initData: () => ({
     phaseTracker: 0,
+    tagTeamClones: [],
   }),
   triggers: [
     {
@@ -102,20 +162,9 @@ const triggerSet: TriggerSet<Data> = {
       id: 'R3S Murderous Mist',
       type: 'StartsUsing',
       netRegex: { id: '93FE', source: 'Brute Bomber', capture: false },
-      infoText: (data, _matches, output) => {
-        if (data.phaseTracker > 0)
-          return output.getHit!();
-        return output.getBehind!();
-      },
+      infoText: (_data, _matches, output) => output.getBehind!(),
       outputStrings: {
         getBehind: Outputs.getBehind,
-        getHit: {
-          en: 'Get hit by mist',
-          de: 'Werde vom Nebel getroffen',
-          ja: 'ミストに当たって',
-          cn: '吃本体270度毒',
-          ko: '미스트 맞기',
-        },
       },
     },
     {
@@ -264,6 +313,198 @@ const triggerSet: TriggerSet<Data> = {
           ja: '外側 => 内側 => ノックバック => ペア',
           cn: '钢铁 => 月环 => 击退 => 双人分摊',
           ko: '밖으로 => 안으로 => 넉백 => 쉐어',
+        },
+      },
+    },
+    {
+      id: 'R3S Tag Team Tether',
+      type: 'Tether',
+      // The clone uses ID `0112`, the boss uses ID `0113`.
+      netRegex: { id: '0112', capture: true },
+      condition: Conditions.targetIsYou(),
+      promise: async (data, matches) => {
+        const actors = (await callOverlayHandler({
+          call: 'getCombatants',
+          ids: [parseInt(matches.sourceId, 16)],
+        })).combatants;
+
+        const actor = actors[0];
+
+        if (actors.length !== 1 || actor === undefined) {
+          console.error(`R3S Tag Team Tether: Wrong actor count ${actors.length}`);
+          return;
+        }
+
+        data.tagTeamCloneTethered = Directions.xyTo8DirNum(actor.PosX, actor.PosY, 100, 100);
+      },
+      infoText: (data, _matches, output) => {
+        const dir = output[Directions.outputFrom8DirNum(data.tagTeamCloneTethered ?? -1)]!();
+        return output.tetheredTo!({ dir: dir });
+      },
+      outputStrings: {
+        ...Directions.outputStringsCardinalDir,
+        tetheredTo: {
+          en: 'Tethered to ${dir} clone',
+        },
+      },
+    },
+    {
+      id: 'R3S Tag Team Clone',
+      type: 'StartsUsing',
+      netRegex: { id: ['9B2C', '9B2E', '9BD8', '9BDA'], source: 'Brute Distortion', capture: true },
+      condition: (data, matches) => {
+        const x = parseFloat(matches.x);
+        const y = parseFloat(matches.y);
+        const cloneDir = Directions.xyTo8DirNum(x, y, 100, 100);
+        const cleaveAdjust = ['9B2C', '9BD8'].includes(matches.id) ? 6 : 2;
+        const cleaveDir = (cloneDir + cleaveAdjust) % 8;
+        data.tagTeamClones.push({
+          cleave: cleaveDir,
+          dir: cloneDir,
+        });
+        if (data.phaseTracker === 1 && data.tagTeamClones.length === 2)
+          return true;
+        return false;
+      },
+      infoText: (data, _matches, output) => {
+        const myClone = data.tagTeamClones.find((clone) => clone.dir === data.tagTeamCloneTethered);
+        const otherClone = data.tagTeamClones.find((clone) =>
+          clone.dir !== data.tagTeamCloneTethered
+        );
+
+        if (myClone === undefined) {
+          console.error('R3S Tag Team Clone: Missing myClone', data.tagTeamClones);
+          return;
+        }
+
+        if (otherClone === undefined) {
+          console.error('R3S Tag Team Clone: Missing otherClone', data.tagTeamClones);
+          return;
+        }
+
+        const [safeSpots, lastSafeSpot] = getSafeSpotsFromClones(myClone, otherClone);
+
+        return output.safeDirs!({
+          dirs: safeSpots
+            .map((dir) => output[Directions.outputFrom8DirNum(dir)]!())
+            .join(output.separator!()),
+          last: output[Directions.outputFrom8DirNum(lastSafeSpot)]!(),
+        });
+      },
+      run: (data) => {
+        data.tagTeamCloneTethered = undefined;
+        data.tagTeamClones = [];
+      },
+      outputStrings: tagTeamOutputStrings,
+    },
+    {
+      id: 'R3S Tag Team Murderous Mist',
+      type: 'StartsUsingExtra',
+      netRegex: { id: '9BD7', capture: true },
+      // Sometimes this MM cast is before the clones, sometimes it's after
+      delaySeconds: 0.1,
+      infoText: (data, matches, output) => {
+        const myClone = data.tagTeamClones.find((clone) => clone.dir === data.tagTeamCloneTethered);
+        const otherClone = data.tagTeamClones.find((clone) =>
+          clone.dir !== data.tagTeamCloneTethered
+        );
+
+        if (myClone === undefined) {
+          console.error('R3S Tag Team Clone: Missing myClone', data.tagTeamClones);
+          return;
+        }
+
+        if (otherClone === undefined) {
+          console.error('R3S Tag Team Clone: Missing otherClone', data.tagTeamClones);
+          return;
+        }
+
+        const murderousMistDir = Directions.hdgTo8DirNum(parseFloat(matches.heading));
+
+        const [safeSpots, lastSafeSpot] = getSafeSpotsFromClones(
+          myClone,
+          otherClone,
+          murderousMistDir,
+        );
+
+        return output.safeDirs!({
+          dirs: safeSpots
+            .map((dir) => output[Directions.outputFrom8DirNum(dir)]!())
+            .join(output.separator!()),
+          last: output[Directions.outputFrom8DirNum(lastSafeSpot)]!(),
+        });
+      },
+      run: (data) => {
+        data.tagTeamCloneTethered = undefined;
+        data.tagTeamClones = [];
+      },
+      outputStrings: tagTeamOutputStrings,
+    },
+    {
+      id: 'R3S Lariat Combo Right Left',
+      type: 'StartsUsing',
+      netRegex: { id: ['9AE8', '9AE9', '9AEA', '9AEB'], source: 'Brute Bomber', capture: true },
+      infoText: (_data, matches, output) => {
+        const x = parseFloat(matches.x);
+        const y = parseFloat(matches.y);
+        const bossDir = Directions.xyTo8DirNum(x, y, 100, 100);
+
+        const firstCleaveDir = ['9AE8', '9AE9'].includes(matches.id) ? 'right' : 'left';
+        const secondCleaveDir = ['9AE8', '9AEB'].includes(matches.id) ? 'right' : 'left';
+
+        let firstSafeSpots = [...Array(8).keys()];
+        let secondSafeSpots = [...firstSafeSpots];
+
+        for (let idx = 0; idx < 5; ++idx) {
+          const dir = (bossDir + (firstCleaveDir === 'left' ? 0 : 4) + idx) % 8;
+          firstSafeSpots = firstSafeSpots.filter((spot) => spot !== dir);
+        }
+
+        for (let idx = 0; idx < 5; ++idx) {
+          const dir = (bossDir + (secondCleaveDir === 'right' ? 0 : 4) + idx) % 8;
+          secondSafeSpots = secondSafeSpots.filter((spot) => spot !== dir);
+        }
+
+        // Filter cards from first spots, need to get KB'd to intercard
+        firstSafeSpots = firstSafeSpots.filter((spot) => (spot % 2) !== 0);
+
+        // Only include card for second spot
+        secondSafeSpots = secondSafeSpots.filter((spot) => (spot % 2) === 0);
+
+        const [firstDir1, firstDir2] = firstSafeSpots;
+
+        const secondDir = secondSafeSpots[0];
+
+        if (firstDir1 === undefined || firstDir2 === undefined || secondDir === undefined) {
+          console.error(
+            'Failed to find safe dirs for second KB towers',
+            matches,
+            firstSafeSpots,
+            secondSafeSpots,
+          );
+          return output['unknown']!();
+        }
+
+        if (firstCleaveDir === secondCleaveDir) {
+          return output.comboGo!({
+            firstDir1: output[Directions.outputFrom8DirNum(firstDir1)]!(),
+            firstDir2: output[Directions.outputFrom8DirNum(firstDir2)]!(),
+            secondDir: output[Directions.outputFrom8DirNum(secondDir)]!(),
+          });
+        }
+        return output.comboStay!({
+          firstDir1: output[Directions.outputFrom8DirNum(firstDir1)]!(),
+          firstDir2: output[Directions.outputFrom8DirNum(firstDir2)]!(),
+          secondDir: output[Directions.outputFrom8DirNum(secondDir)]!(),
+        });
+      },
+      outputStrings: {
+        ...Directions.outputStrings8Dir,
+        comboGo: {
+          en: 'Knockback ${firstDir1}/${firstDir2} => Go ${secondDir}',
+        },
+        comboStay: {
+          en: 'Knockback ${firstDir1}/${firstDir2}, Stay ${secondDir}',
         },
       },
     },

--- a/ui/raidboss/data/07-dt/raid/r3s.ts
+++ b/ui/raidboss/data/07-dt/raid/r3s.ts
@@ -366,6 +366,7 @@ const triggerSet: TriggerSet<Data> = {
           return true;
         return false;
       },
+      durationSeconds: 10.7,
       infoText: (data, _matches, output) => {
         const myClone = data.tagTeamClones.find((clone) => clone.dir === data.tagTeamCloneTethered);
         const otherClone = data.tagTeamClones.find((clone) =>
@@ -403,6 +404,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { id: '9BD7', capture: true },
       // Sometimes this MM cast is before the clones, sometimes it's after
       delaySeconds: 0.1,
+      durationSeconds: 12.7,
       infoText: (data, matches, output) => {
         const myClone = data.tagTeamClones.find((clone) => clone.dir === data.tagTeamCloneTethered);
         const otherClone = data.tagTeamClones.find((clone) =>
@@ -441,9 +443,10 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: tagTeamOutputStrings,
     },
     {
-      id: 'R3S Lariat Combo Right Left',
+      id: 'R3S KB Towers 2 Lariat Combo',
       type: 'StartsUsing',
       netRegex: { id: ['9AE8', '9AE9', '9AEA', '9AEB'], source: 'Brute Bomber', capture: true },
+      durationSeconds: 11,
       infoText: (_data, matches, output) => {
         const x = parseFloat(matches.x);
         const y = parseFloat(matches.y);


### PR DESCRIPTION
Removed the phase check on `R3S Murderous Mist` as the later instance of this ability has a different ID.

I was only able to verify the `'9AEA', '9AEB'` IDs for Lariat Combo via VOD, because FF14 RNG is like that. I had a single pull that saw `9AE8` but that pull wiped before the second lariat so I couldn't verify the safe spots. (More FF14 RNG fun: Every single pull that got to this point in the fight, checking the VODs, had the boss jump to south. Except one pull where the boss jumped east. I didn't even realize the boss could jump somewhere else until I was reviewing the VODs.)

For TT1/TT2, there are separate IDs for TT1 vs TT2. I was able to verify all four IDs against VODs.