### PR TITLE
raidboss: add r2s alert for dropping puddles

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r2s.ts
+++ b/ui/raidboss/data/07-dt/raid/r2s.ts
@@ -106,6 +106,18 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.spread(),
     },
     {
+      id: 'R2S Headmarker Alarm Pheromones Puddle',
+      type: 'HeadMarker',
+      netRegex: { id: headMarkerData.spreadMarker1, capture: true },
+      condition: Conditions.targetIsYou(),
+      alertText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Drop Puddle',
+        },
+      },
+    },
+    {
       id: 'R2S Headmarker Party Stacks',
       type: 'HeadMarker',
       netRegex: { id: headMarkerData.heartStackMarker, capture: false },

--- a/ui/raidboss/data/07-dt/raid/r2s.ts
+++ b/ui/raidboss/data/07-dt/raid/r2s.ts
@@ -113,7 +113,7 @@ const triggerSet: TriggerSet<Data> = {
       alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
-          en: 'Drop Puddle',
+          en: 'Drop Puddle Outside',
         },
       },
     },


### PR DESCRIPTION
During the 2nd Alarm Pheromones, players get targeted with a head marker
indicating that they will soon have a poison puddle drop on them. The
player needs to notice this, and then take the puddle out to the edge.

Add an alert for this headmarker to warn the player when the puddle is
about to drop on them.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
