### PR TITLE
raidboss: use suppressSeconds to avoid double-callout stacks

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r2s.ts
+++ b/ui/raidboss/data/07-dt/raid/r2s.ts
@@ -109,6 +109,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'R2S Headmarker Party Stacks',
       type: 'HeadMarker',
       netRegex: { id: headMarkerData.heartStackMarker, capture: false },
+      suppressSeconds: 1,
       infoText: (_data, _matches, output) => output.stacks!(),
       outputStrings: {
         stacks: Outputs.stacks,


### PR DESCRIPTION
The party stack head marker appears on multiple players, and pops at the
same time. This produces a much louder sound than usual due to the
sounds overlapping. There's no reason to tell the player about the
stacks twice. Avoid this by supressing the trigger after the first one.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
