### PR TITLE
raidboss: avoid multiple callouts during r2s cone tankbuster

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r2s.ts
+++ b/ui/raidboss/data/07-dt/raid/r2s.ts
@@ -11,6 +11,7 @@ export interface Data extends RaidbossData {
   beat?: 1 | 2 | 3;
   beatTwoOneStart?: boolean;
   beatTwoSpreadCollect: string[];
+  tankLaserCollect: string[];
 }
 
 const headMarkerData = {
@@ -33,6 +34,7 @@ const triggerSet: TriggerSet<Data> = {
   initData: () => ({
     partnersSpreadCounter: 0,
     beatTwoSpreadCollect: [],
+    tankLaserCollect: [],
   }),
   triggers: [
     {
@@ -107,10 +109,28 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.sharedTankBuster(),
     },
     {
-      id: 'R2S Headmarker Cone Tankbuster',
+      id: 'R2S Headmarker Cone Tankbuster Collect',
       type: 'HeadMarker',
       netRegex: { id: headMarkerData.tankLaser, capture: true },
-      response: Responses.tankCleave(),
+      run: (data, matches) => data.tankLaserCollect.push(matches.target),
+    },
+    {
+      id: 'R2S Headmarker Cone Tankbuster',
+      type: 'HeadMarker',
+      netRegex: { id: headMarkerData.tankLaser, capture: false },
+      delaySeconds: 0.1,
+      suppressSeconds: 5,
+      alertText: (data, _matches, output) => {
+        if (data.tankLaserCollect.includes(data.me))
+          return output.cleaveOnYou!();
+
+        return output.avoidCleave!();
+      },
+      run: (data) => data.tankLaserCollect = [],
+      outputStrings: {
+        cleaveOnYou: Outputs.tankCleaveOnYou,
+        avoidCleave: Outputs.avoidTankCleave,
+      },
     },
     {
       id: 'R2S Headmarker Spread Collect',


### PR DESCRIPTION
The cone tankbuster during r2s appears on both tanks. This results in
the callout for the tankbuster triggering twice, with an overlapping
sound effect and multiple messages on screen.

Setting suppressSeconds would resolve the multiple callouts, but
prevents correctly calling out "tank cleave on YOU".

All of the tank buster cleaves happen simultaneously. Add a collector
trigger to collect the targets of the tank buster. Add delaySeconds to
the tankbuster trigger to give time for the collector to execute.

Replace the check against the target with a check on whether the
collected targets includes the active player. This ensures that the
correct message is displayed, and prevents the overlapping of
simultaneous triggers.

I chose not to add a check on the size of the laser collect, as this
will at least allow it to make some noise if for some reason the log
didn't include all of the expected tank busters.