### PR TITLE
raidboss: call tower or spread during beat 2

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r2s.ts
+++ b/ui/raidboss/data/07-dt/raid/r2s.ts
@@ -9,6 +9,8 @@ export interface Data extends RaidbossData {
   partnersSpreadCounter: number;
   storedPartnersSpread?: 'partners' | 'spread';
   beat?: 1 | 2 | 3;
+  beatTwoOneStart?: boolean;
+  beatTwoSpreadCollect: string[];
 }
 
 const headMarkerData = {
@@ -30,6 +32,7 @@ const triggerSet: TriggerSet<Data> = {
   timelineFile: 'r2s.txt',
   initData: () => ({
     partnersSpreadCounter: 0,
+    beatTwoSpreadCollect: [],
   }),
   triggers: [
     {
@@ -67,8 +70,10 @@ const triggerSet: TriggerSet<Data> = {
         if (data.beat === 2) {
           if (matches.effectId === 'F52')
             return output.beatTwoZeroHearts!();
-          if (matches.effectId === 'F53')
+          if (matches.effectId === 'F53') {
+            data.beatTwoOneStart = true;
             return output.beatTwoOneHearts!();
+          }
         }
       },
       outputStrings: {
@@ -108,11 +113,32 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.tankCleave(),
     },
     {
+      id: 'R2S Headmarker Spread Collect',
+      type: 'HeadMarker',
+      netRegex: { id: headMarkerData.spreadMarker2, capture: true },
+      run: (data, matches) => data.beatTwoSpreadCollect.push(matches.target),
+    },
+    {
       id: 'R2S Headmarker Spread',
       type: 'HeadMarker',
       netRegex: { id: headMarkerData.spreadMarker2, capture: false },
-      suppressSeconds: 5,
-      response: Responses.spread(),
+      delaySeconds: 0.1,
+      alertText: (data, _matches, output) => {
+        if (data.beatTwoSpreadCollect.includes(data.me))
+          return output.avoidTowers!();
+        else if (data.beatTwoOneStart)
+          return output.towers!();
+      },
+      run: (data) => {
+        data.beatTwoSpreadCollect = [];
+        data.beatTwoOneStart = false;
+      },
+      outputStrings: {
+        avoidTowers: {
+          en: 'Spread -- Avoid Towers',
+        },
+        towers: Outputs.getTowers,
+      },
     },
     {
       id: 'R2S Headmarker Alarm Pheromones Puddle',


### PR DESCRIPTION
During Beat 2, players either start with zero or one heart. A lot of
mechanics happen in sequence, with players getting different mechanics
depending on how many hearts they started with.

First, players who start with 0 hearts get either:

1) stack markers which will grant 4 hearts spread out over everyone in
   the stack when it expires.

OR

2) repeatably targetted with puddle aoes they need to bait and drop.

Following this, players with 1 heart either:

1) get a spread marker which they need to move away from other players

OR

2) must grab a tower that spawns at the same time as the spread marker.

The spread markers appear later, around the end of when the baited
puddles and stack markers finish. Typically players with 1 heart stack
in the same spot away from the puddle/stack markers.

Currently there is a trigger that fires for everyone as soon as the
spread markers appear. This is not that useful since other players
finishing the stack and puddle baits do not need to spread, and players
who are supposed to grab towers do not get a reminder.

Instead of using a simple canned spread response, add a collector
trigger to collect the matches for the spread markers. In the main
trigger, use the collected data to determine whether to call spread or
towers. If the player was targeted by a spread marker, they need to
spread out and avoid the towers. Otherwise, players who started beat 2
with one heart need to soak the towers.