### PR TITLE
raidboss: suppress multiple extra add callouts in titania

### DIFF
--- a/ui/raidboss/data/05-shb/trial/titania-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/titania-ex.ts
@@ -41,6 +41,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'TitaniaEx Mist Failure',
       type: 'AddedCombatant',
       netRegex: { name: 'Spirit Of Dew', capture: false },
+      suppressSeconds: 3,
       response: Responses.killExtraAdd(),
     },
     {


### PR DESCRIPTION
If players fail the water puddle mechanic, Titania spawns an extra add
for each missed puddle. If many puddles fail, this results in several
triggers overlapping producing an extremely loud noise.

Add suppressSeconds to the trigger to prevent multiple callouts from
overlapping.

We could try to collect the data and call out how many were spawned, but
I think players can use their eyes.

This is mostly a problem when doing the fight with a low number of
players unsynced. Most of the puddles will fail and all the near
simultaneous overlapped triggers create a loud popping sound.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
