### PR TITLE
raidboss: call to get towers after poison n pop expires

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r2s.ts
+++ b/ui/raidboss/data/07-dt/raid/r2s.ts
@@ -12,6 +12,7 @@ export interface Data extends RaidbossData {
   beatTwoOneStart?: boolean;
   beatTwoSpreadCollect: string[];
   tankLaserCollect: string[];
+  beatThreePoisonPopped: string[];
 }
 
 const headMarkerData = {
@@ -35,6 +36,7 @@ const triggerSet: TriggerSet<Data> = {
     partnersSpreadCounter: 0,
     beatTwoSpreadCollect: [],
     tankLaserCollect: [],
+    beatThreePoisonPopped: [],
   }),
   triggers: [
     {
@@ -300,6 +302,29 @@ const triggerSet: TriggerSet<Data> = {
           ko: '쉐어',
         },
         unknown: Outputs.unknown,
+      },
+    },
+    {
+      id: 'R2S Poison n Pop Towers Collect',
+      type: 'LosesEffect',
+      netRegex: { effectId: 'F5E', capture: true },
+      run: (data, matches) => data.beatThreePoisonPopped.push(matches.target),
+    },
+    {
+      id: 'R2S Poison n Pop Towers',
+      type: 'LosesEffect',
+      netRegex: { effectId: 'F5E', capture: false },
+      delaySeconds: 0.1,
+      suppressSeconds: 5,
+      alertText: (data, _matches, output) => {
+        if (data.beatThreePoisonPopped.includes(data.me))
+          return;
+
+        return output.towers!();
+      },
+      run: (data) => data.beatThreePoisonPopped = [],
+      outputStrings: {
+        towers: Outputs.getTowers,
       },
     },
     {


### PR DESCRIPTION
During beat 3, players get a "Poison 'n' Pop" debuff. When this debuff
expires on a player, a huge aoe will trigger. 4 players get a long
version of this debuff, and 4 players get a short version of this
debuff. When each set expires, the 4 players who didn't get hit by an
aoe need to quickly run from the middle to grab a tower.

Use a collec trigger to capture when players lose the debuff effect.
Then in the callout trigger, inform anyone else not in the collected
list to get their tower.

Ideally, we could add a trigger to inform when the players should go out
with their tower. This is tricky, as it either needs to be called after
a stage combo, or somehow timer based. Both of these are tricky to
implement, so have been left as a futer improvement.