### PR TITLE
raidboss: add sidewise spark configuration option

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r4n.ts
+++ b/ui/raidboss/data/07-dt/raid/r4n.ts
@@ -183,8 +183,8 @@ const triggerSet: TriggerSet<Data> = {
       type: 'select',
       options: {
         en: {
-          'Sequence of moves as cleaves finish': 'sequence',
           'Collect all cleaves and call once': 'collected',
+          'Sequence of moves as cleaves finish': 'sequence',
         },
       },
       default: 'collected',

--- a/ui/raidboss/data/07-dt/raid/r4n.ts
+++ b/ui/raidboss/data/07-dt/raid/r4n.ts
@@ -1,7 +1,7 @@
 import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
 import { Responses } from '../../../../../resources/responses';
-import { Directions } from '../../../../../resources/util';
+import { DirectionOutputCardinal, Directions } from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { PluginCombatantState } from '../../../../../types/event';
@@ -45,16 +45,18 @@ const directionOutputStrings = {
   },
 } as const;
 
+type StoredCleave = {
+  id: number;
+  dir: 'left' | 'right';
+};
+
 export interface Data extends RaidbossData {
   expectedBlasts: 0 | 3 | 4 | 5;
   storedBlasts: B9AMapValues[];
   // expectedCleaves is either 1 or 5, due to the amount of time between the first
   // and second clone cleaves at the start of the encounter
   expectedCleaves: 1 | 5;
-  storedCleaves: {
-    id: number;
-    dir: 'left' | 'right';
-  }[];
+  storedCleaves: StoredCleave[];
   actors: PluginCombatantState[];
   sidewiseSparkCounter: number;
   storedWitchHuntCast?: NetMatches['StartsUsingExtra'];
@@ -76,6 +78,20 @@ const isEffectB9AValue = (value: string | undefined): value is B9AMapValues => {
   if (value === undefined)
     return false;
   return Object.values<string>(effectB9AMap).includes(value);
+};
+
+const getCleaveDirs = (
+  actors: PluginCombatantState[],
+  storedCleaves: StoredCleave[],
+): DirectionOutputCardinal[] => {
+  return storedCleaves.map((entry) => {
+    const actor = actors.find((actor) => actor.ID === entry.id);
+    if (actor === undefined)
+      return 'unknown';
+    const actorFacing = Directions.hdgTo4DirNum(actor.Heading);
+    const offset = entry.dir === 'left' ? 1 : -1;
+    return Directions.outputFromCardinalNum((actorFacing + 4 + offset) % 4);
+  });
 };
 
 const npcYellData = {
@@ -190,16 +206,10 @@ const triggerSet: TriggerSet<Data> = {
       durationSeconds: 7.3,
       suppressSeconds: 1,
       infoText: (data, _matches, output) => {
-        const dirs = data.storedCleaves.map((entry) => {
-          const actor = data.actors.find((actor) => actor.ID === entry.id);
-          if (actor === undefined)
-            return output.unknown!();
-          const actorFacing = Directions.hdgTo4DirNum(actor.Heading);
-          const offset = entry.dir === 'left' ? 1 : -1;
-          return Directions.outputFromCardinalNum((actorFacing + 4 + offset) % 4);
-        }).map((dir) => output[dir]!());
+        const dirs = getCleaveDirs(data.actors, data.storedCleaves);
+        const mappedDirs = dirs.map((dir) => output[dir]!());
 
-        return output.combo!({ dirs: dirs.join(output.separator!()) });
+        return output.combo!({ dirs: mappedDirs.join(output.separator!()) });
       },
       run: (data) => {
         if (data.expectedCleaves === 1)
@@ -261,14 +271,7 @@ const triggerSet: TriggerSet<Data> = {
         if (data.sidewiseSparkCounter === 0)
           return ['92BC', '92BE'].includes(matches.id) ? output.goLeft!() : output.goRight!();
 
-        const dirs = data.storedCleaves.map((entry) => {
-          const actor = data.actors.find((actor) => actor.ID === entry.id);
-          if (actor === undefined)
-            return output.unknown!();
-          const actorFacing = Directions.hdgTo4DirNum(actor.Heading);
-          const offset = entry.dir === 'left' ? 1 : -1;
-          return Directions.outputFromCardinalNum((actorFacing + 4 + offset) % 4);
-        });
+        const dirs = getCleaveDirs(data.actors, data.storedCleaves);
 
         dirs.push(['92BC', '92BE'].includes(matches.id) ? 'dirW' : 'dirE');
 

--- a/ui/raidboss/data/07-dt/raid/r4n.ts
+++ b/ui/raidboss/data/07-dt/raid/r4n.ts
@@ -89,6 +89,7 @@ const isEffectB9AValue = (value: string | undefined): value is B9AMapValues => {
 const getCleaveDirs = (
   actors: PluginCombatantState[],
   storedCleaves: StoredCleave[],
+  mode: 'collapse' | 'keepAll',
 ): DirectionOutput8[] => {
   const dirs: DirectionOutput8[] = storedCleaves.map((entry) => {
     const actor = actors.find((actor) => actor.ID === entry.id);
@@ -99,7 +100,7 @@ const getCleaveDirs = (
     return Directions.outputFromCardinalNum((actorFacing + 4 + offset) % 4);
   });
 
-  if (dirs.length === 1)
+  if (mode === 'keepAll' || dirs.length === 1)
     return dirs;
 
   // Check if all directions lead to the same intercard. If so, there's no
@@ -250,7 +251,10 @@ const triggerSet: TriggerSet<Data> = {
       durationSeconds: 7.3,
       suppressSeconds: 1,
       infoText: (data, _matches, output) => {
-        const dirs = getCleaveDirs(data.actors, data.storedCleaves);
+        const mode = data.triggerSetConfig.sidewiseSpark === 'collected'
+          ? 'keepAll'
+          : 'collapse';
+        const dirs = getCleaveDirs(data.actors, data.storedCleaves, mode);
         const mappedDirs = dirs.map((dir) => output[dir]!());
 
         return output.combo!({ dirs: mappedDirs.join(output.separator!()) });
@@ -323,7 +327,7 @@ const triggerSet: TriggerSet<Data> = {
           id: actorID,
         });
 
-        const dirs: DirectionOutput8[] = getCleaveDirs(data.actors, data.storedCleaves);
+        const dirs: DirectionOutput8[] = getCleaveDirs(data.actors, data.storedCleaves, 'collapse');
         if (dirs.length === 1) {
           // Stop any future callouts, since we know its safe to stay now
           data.storedCleaves = [];
@@ -353,7 +357,7 @@ const triggerSet: TriggerSet<Data> = {
         if (data.storedCleaves.length === 0)
           return;
 
-        const dirs = getCleaveDirs(data.actors, data.storedCleaves);
+        const dirs = getCleaveDirs(data.actors, data.storedCleaves, 'collapse');
         const mappedDirs = dirs.map((dir) => output[dir]!());
 
         return output.combo!({ dirs: mappedDirs.join(output.separator!()) });

--- a/ui/raidboss/data/07-dt/raid/r4n.ts
+++ b/ui/raidboss/data/07-dt/raid/r4n.ts
@@ -99,6 +99,9 @@ const getCleaveDirs = (
     return Directions.outputFromCardinalNum((actorFacing + 4 + offset) % 4);
   });
 
+  if (dirs.length === 1)
+    return dirs;
+
   // Check if all directions lead to the same intercard. If so, there's no
   // reason to call a sequence. We don't need to check the cardinals,
   // because it will only be true either when there is exactly one element,

--- a/ui/raidboss/data/07-dt/raid/r4n.ts
+++ b/ui/raidboss/data/07-dt/raid/r4n.ts
@@ -272,23 +272,6 @@ const triggerSet: TriggerSet<Data> = {
         const dirs = getCleaveDirs(data.actors, data.storedCleaves, mode);
         const mappedDirs = dirs.map((dir) => output[dir]!());
 
-        const cleaves: number = data.storedCleaves.length;
-        if (dirs.length === 1 && cleaves > 1) {
-          const cleaveNums: { [key: number]: string } = {
-            2: output.num2!(),
-            3: output.num3!(),
-            4: output.num4!(),
-            5: output.num5!(),
-          };
-
-          if (cleaves in cleaveNums) {
-            return output.numHits!({
-              dir: mappedDirs[0],
-              num: cleaveNums[cleaves],
-            });
-          }
-        }
-
         return output.combo!({ dirs: mappedDirs.join(output.separator!()) });
       },
       run: (data) => {

--- a/ui/raidboss/data/07-dt/raid/r4n.ts
+++ b/ui/raidboss/data/07-dt/raid/r4n.ts
@@ -6,7 +6,7 @@ import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { PluginCombatantState } from '../../../../../types/event';
 import { NetMatches } from '../../../../../types/net_matches';
-import { TriggerSet } from '../../../../../types/trigger';
+import { FullLocaleText, TriggerSet } from '../../../../../types/trigger';
 
 // TODO: Map out MapEffect data if needed? Might be useful for prep for savage.
 // TODO: Better triggers for Bewitching Flight, collector for the loop to combine trigger with clone
@@ -37,6 +37,14 @@ const directionOutputStrings = {
   },
   intercardStay: {
     en: '${dir} => Stay',
+  },
+  numHits: {
+    en: '${dir} x${num}',
+    de: '${dir} x${num}',
+    fr: '${dir} x${num}',
+    ja: '${dir} x${num}',
+    cn: '${dir} x${num}',
+    ko: '${dir} x${num}',
   },
   combo: {
     en: '${dirs}',
@@ -257,6 +265,23 @@ const triggerSet: TriggerSet<Data> = {
         const dirs = getCleaveDirs(data.actors, data.storedCleaves, mode);
         const mappedDirs = dirs.map((dir) => output[dir]!());
 
+        const cleaves: number = data.storedCleaves.length;
+        if (dirs.length === 1 && cleaves > 1) {
+          const cleaveNums: { [key: number]: FullLocaleText } = {
+            2: Outputs.num1,
+            3: Outputs.num2,
+            4: Outputs.num4,
+            5: Outputs.num5,
+          };
+
+          if (cleaves in cleaveNums) {
+            return output.numHits!({
+              dir: mappedDirs[0],
+              num: cleaveNums[cleaves],
+            });
+          }
+        }
+
         return output.combo!({ dirs: mappedDirs.join(output.separator!()) });
       },
       run: (data) => {
@@ -359,6 +384,23 @@ const triggerSet: TriggerSet<Data> = {
 
         const dirs = getCleaveDirs(data.actors, data.storedCleaves, 'collapse');
         const mappedDirs = dirs.map((dir) => output[dir]!());
+
+        const cleaves: number = data.storedCleaves.length;
+        if (dirs.length === 1 && cleaves > 1) {
+          const cleaveNums: { [key: number]: FullLocaleText } = {
+            2: Outputs.num1,
+            3: Outputs.num2,
+            4: Outputs.num4,
+            5: Outputs.num5,
+          };
+
+          if (cleaves in cleaveNums) {
+            return output.numHits!({
+              dir: mappedDirs[0],
+              num: cleaveNums[cleaves],
+            });
+          }
+        }
 
         return output.combo!({ dirs: mappedDirs.join(output.separator!()) });
       },


### PR DESCRIPTION
This PR is an attempt to help improve the m4n sidewise spark callouts. In
particular, this PR does 2 major things:

1. Introduce a config for m4n
2. collapse sequence of cardinals directions

The configuration option adds a way to select how sidewise spark should be
called. It includes the 'collected' mode which is the current default, and the
'sequence' mode which is the new behavior.

The 'collected' mode makes one initial callout after 2 cleaves are detected,
and then a single callout for all the cleave safe spots as the boss starts
casting the final cleave.

The 'sequence' mode makes an initial callout after 2 cleaves as before. But
instead of a single cleave with all the options, it makes one callout with the
remaining safe spots after every cleave finishes.

In addition to the new configuration option, I added logic to collapse a
sequence of safe spots into a single intercardinal. This works by checking if
all the spots point to the same intercard.

This greatly simplifies the callouts in many cases, such as when most of the
cleaves are in the same directions.

There is one nit, which is that the sequence mode may not stop calling early
in certain cases, and may make a callout sequence like:

NE
NW
SW
SW
W

This is because I worried about clearing the sidewise spark cleaves array in
the hit trigger, due to the potential to accidentally clear the array when the
final hit has not yet been recorded.

Finally, this change has an added advantage that a sidewise spark from the
boss later in the fight does not get ignored anymore. That occured because the
callout for the boss sidewise spark was checking if the sidewiseSparkCounter
was 0. It assumed the fight only has one sidewise spark in this manner, but it
can infact happen again later in the fight.
