### PR TITLE
raidboss: Additional M/R2S triggers

### DIFF
--- a/resources/outputs.ts
+++ b/resources/outputs.ts
@@ -190,6 +190,14 @@ export default {
     cn: '分散',
     ko: '산개',
   },
+  defamationOnYou: {
+    en: 'Defamation on YOU',
+    de: 'Ehrenstrafe aud DIR',
+    fr: 'Diffamation sur VOUS',
+    ja: '自分に巨大な爆発',
+    cn: '大圈点名',
+    ko: '광역징 대상자',
+  },
   protean: {
     en: 'Protean',
     de: 'Himmelsrichtungen',

--- a/ui/raidboss/data/07-dt/raid/r2s.ts
+++ b/ui/raidboss/data/07-dt/raid/r2s.ts
@@ -8,7 +8,6 @@ import { TriggerSet } from '../../../../../types/trigger';
 // TODO:
 //  - Beat 1: Track player hearts and only fire `Headmarker Party Stacks` based on <=2 hearts?
 //     - Related: Perhaps call 'Don't stack' if player has 3 hearts?
-//  - Beat 2: Add a 'Soak Tower' call for 1-heart players that don't get a spread?
 
 export interface Data extends RaidbossData {
   partnersSpreadCounter: number;
@@ -170,6 +169,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'HeadMarker',
       netRegex: { id: headMarkerData.spreadMarker2, capture: false },
       delaySeconds: 0.1,
+      suppressSeconds: 1,
       alertText: (data, _matches, output) => {
         if (data.beatTwoSpreadCollect.includes(data.me))
           return output.avoidTowers!();

--- a/ui/raidboss/data/07-dt/raid/r2s.ts
+++ b/ui/raidboss/data/07-dt/raid/r2s.ts
@@ -486,10 +486,11 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { effectId: 'F5E' },
       condition: Conditions.targetIsYou(),
       // short debuffs are 26s, longs are 46s
-      run: (data, matches) => data.poisonDebuff = parseFloat(matches.duration) > 30 ? 'long' : 'short',
+      run: (data, matches) =>
+        data.poisonDebuff = parseFloat(matches.duration) > 30 ? 'long' : 'short',
     },
     {
-      id: 'R2S Poison First Defamation',
+      id: 'R2S Poison First Defamations',
       type: 'GainsEffect',
       netRegex: { effectId: 'F5E', capture: false },
       delaySeconds: 20, // 6 sec. before expiration
@@ -503,7 +504,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: poisonOutputStrings,
     },
     {
-      id: 'R2S Poison Second Defamation',
+      id: 'R2S Poison Second Defamations',
       type: 'GainsEffect',
       netRegex: { effectId: 'F5E', capture: false },
       delaySeconds: 40, // 6 sec. before expiration
@@ -522,6 +523,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { effectId: 'F5E' },
       // use condition instead of suppress to prevent race condition with Poison Debuff Tracker
       condition: Conditions.targetIsYou(),
+      // delay until the opposite (short/long) debuff resolves
       delaySeconds: (data) => data.poisonDebuff === 'long' ? 26 : 46,
       alertText: (data, _matches, output) => {
         // if no poison debuff, there really can't be an accurate call anyway
@@ -568,7 +570,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { effectId: ['F5C', 'F5D'] },
       condition: Conditions.targetIsYou(),
       delaySeconds: (_data, matches) => parseFloat(matches.duration) - 9,
-      alertText: (data, matches, output) => {
+      alertText: (data, _matches, output) => {
         let partner = output.unknown!();
         const myType = data.beelovedType;
         if (myType === undefined)
@@ -579,7 +581,8 @@ const triggerSet: TriggerSet<Data> = {
           return output.merge!({ player: partner });
 
         const partnerType = myType === 'alpha' ? 'beta' : 'alpha';
-        partner = data.party.member(data.beelovedDebuffs[partnerType][orderIdx]).nick ?? output.unknown!();
+        partner = data.party.member(data.beelovedDebuffs[partnerType][orderIdx]).nick ??
+          output.unknown!();
         return output.merge!({ player: partner });
       },
       outputStrings: {
@@ -592,7 +595,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'R2S Beeloved Venom Other Merge',
       type: 'GainsEffect',
-      // only fire on the Alpha debuffs, so the trigger fires once per merge
+      // only fire on the Alpha debuffs so the trigger fires once per merge
       netRegex: { effectId: 'F5C' },
       delaySeconds: (_data, matches) => parseFloat(matches.duration) - 9,
       infoText: (data, matches, output) => {

--- a/ui/raidboss/data/07-dt/raid/r2s.ts
+++ b/ui/raidboss/data/07-dt/raid/r2s.ts
@@ -39,14 +39,7 @@ const headMarkerData = {
 } as const;
 
 const poisonOutputStrings = {
-  defamationOnYou: {
-    en: 'Defamation on YOU',
-    de: 'Ehrenstrafe aud DIR',
-    fr: 'Diffamation sur VOUS',
-    ja: '自分の巨大な爆発',
-    cn: '大圈点名',
-    ko: '광역징 대상자',
-  },
+  defamationOnYou: Outputs.defamationOnYou,
   defamations: {
     en: 'Defamations',
   },
@@ -569,7 +562,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'GainsEffect',
       netRegex: { effectId: ['F5C', 'F5D'] },
       condition: Conditions.targetIsYou(),
-      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 9,
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 10,
       alertText: (data, _matches, output) => {
         let partner = output.unknown!();
         const myType = data.beelovedType;
@@ -587,7 +580,7 @@ const triggerSet: TriggerSet<Data> = {
       },
       outputStrings: {
         merge: {
-          en: 'Merge w/ ${player}',
+          en: 'Merge Soon w/ ${player}',
         },
         unknown: Outputs.unknown,
       },
@@ -597,7 +590,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'GainsEffect',
       // only fire on the Alpha debuffs so the trigger fires once per merge
       netRegex: { effectId: 'F5C' },
-      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 9,
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 10,
       infoText: (data, matches, output) => {
         const duration = parseFloat(matches.duration);
         const orderIdx = beelovedDebuffDurationOrder.indexOf(duration);

--- a/ui/raidboss/data/07-dt/raid/r2s.ts
+++ b/ui/raidboss/data/07-dt/raid/r2s.ts
@@ -229,11 +229,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'R2S Drop of Venom',
       type: 'StartsUsing',
       netRegex: { id: '9185', source: 'Honey B. Lovely', capture: false },
-      infoText: (data, _matches, output) => {
-        // don't display a 'Stored' trigger for the first two, as the mech resolves immediately
-        if (data.partnersSpreadCounter > 2)
-          return output.text!();
-      },
+      infoText: (_data, _matches, output) => output.text!(),
       run: (data) => data.storedPartnersSpread = 'partners',
       outputStrings: {
         text: {
@@ -249,11 +245,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'R2S Splash of Venom',
       type: 'StartsUsing',
       netRegex: { id: '9184', source: 'Honey B. Lovely', capture: false },
-      infoText: (data, _matches, output) => {
-        // don't display a 'Stored' trigger for the first two, as the mech resolves immediately
-        if (data.partnersSpreadCounter > 2)
-          return output.text!();
-      },
+      infoText: (_data, _matches, output) => output.text!(),
       run: (data) => data.storedPartnersSpread = 'spread',
       outputStrings: {
         text: {
@@ -269,7 +261,6 @@ const triggerSet: TriggerSet<Data> = {
       id: 'R2S Drop of Love',
       type: 'StartsUsing',
       netRegex: { id: '9B09', source: 'Honey B. Lovely', capture: false },
-      // no need for conditional on data.partnersSpreadCounter, as these happen later in the fight
       infoText: (_data, _matches, output) => output.text!(),
       run: (data) => data.storedPartnersSpread = 'partners',
       outputStrings: {
@@ -286,7 +277,6 @@ const triggerSet: TriggerSet<Data> = {
       id: 'R2S Spread Love',
       type: 'StartsUsing',
       netRegex: { id: '9B08', source: 'Honey B. Lovely', capture: false },
-      // no need for conditional on data.partnersSpreadCounter, as these happen later in the fight
       infoText: (_data, _matches, output) => output.text!(),
       run: (data) => data.storedPartnersSpread = 'spread',
       outputStrings: {

--- a/ui/raidboss/data/07-dt/raid/r2s.ts
+++ b/ui/raidboss/data/07-dt/raid/r2s.ts
@@ -5,6 +5,11 @@ import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
 
+// TODO:
+//  - Beat 1: Track player hearts and only fire `Headmarker Party Stacks` based on <=2 hearts?
+//     - Related: Perhaps call 'Don't stack' if player has 3 hearts?
+//  - Beat 2: Add a 'Soak Tower' call for 1-heart players that don't get a spread?
+
 export interface Data extends RaidbossData {
   partnersSpreadCounter: number;
   storedPartnersSpread?: 'partners' | 'spread';


### PR DESCRIPTION
Finally getting around to PRing some additional triggers:
* Revises the 'Stored: ' partner/spread call to an `infoText` and suppresses it for the first two occurrences (since Tempting Twist/Honey Beeline happen immediately after).
* Adds an `infoText` with the subsequent positioning + partner/spread at the beginning of Tempting Twist and Honey Beeline, followed by an explicit `alertText` with that info when the first part of the mechanic resolves.
* Lists some possible TODOs for beat1 & beat2.
* Adds defamation/in/towers calls during beat3.  (NB: I had this mostly worked up before #349, but if people prefer that approach + some added handling for defamations, I can remove it from this PR before merging.)
* Adds callouts for "curtain call" (aka Beeloved Venom).  On this, I added a 'Marge w/ X` alert for the active player, as well as info alerts for other merges that should happen not involving the active player.  On the latter, I could see some disagreement about whether that info is useful or not, so happy to adjust/remove that if folks don't like.

(NB2: This PR doesn't address/replace anything in #339 or #343 -- I had in my notes to do things similarly to those, but since there are already PRs, I think it makes sense to work with those.)

This looks fine in vod/RE, but probably could use a proofread and some in-game testing.  I may be able to test a little later tonight, but would be great if others can poke at it too.