### PR TITLE
raidboss: add support for live countdowns

### DIFF
--- a/docs/RaidbossGuide.md
+++ b/docs/RaidbossGuide.md
@@ -88,6 +88,7 @@ This is just a grab bag of miscellaneous thoughts about triggers.
 
 - triggers should be timed so that when the text appears it it safe to do that mechanic, e.g. if there's a stack=>spread don't call spread until the stack has gone off
 - use `delaySeconds` sparingly; it's more reliable to trigger off of ability or damage than a delay from a much earlier cast or ability (the stack=>spread example calling spread would use the stack damage)
+- use `countdownSeconds` sparingly: it's best for overlapping mechanics that require timed pre-positioing (e.g. Forced March, stuns, etc.), or mechanics that do not correspond to a timeline entry
 - knockbacks generally use 5s of delay to make sure that when the trigger text appears it is safe to hit the button
 - prefer using a normal trigger over a timeline trigger, as timeline triggers can be inconsistent from unknown hp pushes
 - always use `suppressSeconds` for timeline triggers (TODO: make this automatic or suppress until the next jump)
@@ -258,6 +259,7 @@ Timeline triggers (whose regex matches timeline text) are in their own section.
   delaySeconds: 0,
   durationSeconds: 3,
   suppressSeconds: 0,
+  countdownSeconds: 5,
   promise: function(data, matches, output) { return promise to wait for resolution of },
   sound: '',
   soundVolume: 1,
@@ -363,6 +365,21 @@ The time to wait begins at the time of the initial regex match
 and is unaffected by presence or absence of a delaySeconds value.
 Once a trigger with this element activates,
 it will not activate again until after its timeout period is over.
+
+**countdownSeconds**
+Displays a running countdown in tenths-of-a-second increments (x.y)
+for the specified number of seconds.
+May be a number or a `function(data, matches, output)`.
+The time begins to run at the time the trigger output is created,
+following the expiration of any `delaySeconds` value and after any `promise` is returned.
+If `countdownSeconds` is larger than the specified (or default) `durationSeconds`,
+the trigger duration will be extended to match the countdown.
+If the countdown is smaller than the duration, the countdown will stop at (0.0),
+and will continue to be displayed asa such until the duration expires.
+By default, the countdown is appended to the trigger text,
+but if `{{CD}}` is present in the output string, the countdown will be placed there instead.
+If `countdownSeconds` is set (or overriden) to 0, a countdown will not be displayed.
+Neither the substitution marker (`{{CD}}`) nor the countdown value itself is output by tts.
 
 **sound**
 Sound file to play, or one of 'Info', 'Alert', 'Alarm', or 'Long'.
@@ -546,6 +563,7 @@ Trigger elements are evaluated in this order, and must be listed in this order:
 - durationSeconds
 - suppressSeconds
 - (the delaySeconds occurs here)
+- countdownSeconds
 - promise
 - (awaiting the promise occurs here)
 - sound

--- a/docs/RaidbossGuide.md
+++ b/docs/RaidbossGuide.md
@@ -375,7 +375,7 @@ following the expiration of any `delaySeconds` value and after any `promise` is 
 If `countdownSeconds` is larger than the specified (or default) `durationSeconds`,
 the trigger duration will be extended to match the countdown.
 If the countdown is smaller than the duration, the countdown will stop at (0.0),
-and will continue to be displayed asa such until the duration expires.
+and will continue to be displayed as such until the duration expires.
 By default, the countdown is appended to the trigger text,
 but if `{{CD}}` is present in the output string, the countdown will be placed there instead.
 If `countdownSeconds` is set (or overriden) to 0, a countdown will not be displayed.

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -148,6 +148,7 @@ type BaseNetTrigger<Data extends RaidbossData, Type extends TriggerTypes> = {
   // Leave undefined to preserve defaults and default overrides
   durationSeconds?: TriggerField<Data, NetMatches[Type], number | undefined>;
   suppressSeconds?: TriggerField<Data, NetMatches[Type], number>;
+  countdownSeconds?: TriggerField<Data, NetMatches[Type], number>;
   promise?: TriggerField<Data, NetMatches[Type], Promise<void>>;
   // Leave undefined to preserve defaults and default overrides
   sound?: TriggerField<Data, NetMatches[Type], string | undefined>;

--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -375,6 +375,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         countdown: {
           en: '${player} started ${seconds}s countdown',
+          // or inline: '${player} started {{CD}} countdown',
           de: '${player} startet ${seconds}s countdown',
           fr: '${player} a démarré un compte à rebours de ${seconds}s',
           ja: '${player} が ${seconds} 秒のカウントダウンを開始しました',

--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -369,6 +369,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Test Countdown',
       type: 'Countdown',
       netRegex: { result: '00' },
+      countdownSeconds: (_data, matches) => parseFloat(matches.countdownTime),
       infoText: (_data, matches, output) =>
         output.countdown!({ player: matches.name, seconds: matches.countdownTime }),
       outputStrings: {


### PR DESCRIPTION
Something that's been lingering on my to do list for a while, but some of the conversations on PRs today made me finally get to it.  This adds an optional trigger property `countdownSeconds:`, which supports either a number or a `(data, matches) =>` function.  If specified, it will append a live countdown (floating point, tenths place) to any popup text generated by that trigger.  (As currently written, the countdown portion of the text will not be output via tts, because that gets pretty messy.)

I added a demo of this to the countdown start trigger in Summerford Farms, so this can be easily tested with the usual `/cd 5` there.

The only significant judgment call (which I'm very open to revisiting) was how to handle potential interactions between `countdownSeconds` and `durationSeconds` (either specified on trigger, in user config, or the default).  As written:
  * If the trigger's duration equals or exceeds the countdown, the countdown will simply stop at `(0.0)` and will continue to be displayed until the duration ends and the popup text disappears.
  * If the trigger's countdown exceeds the duration, the countdown value will override the duration (default or specified) and keep the popup text displayed until the countdown reaches 0.0.  This seemed to make the most sense to me, but again, very open to revisiting.

This may not be something that gets frequent use, but I think there are use cases where a callout needs to be resolved by a particular time (whether tied to a timeline entry or not), and without an obvious visual cue/castbar in game. So this could provide additional info in certain circumstances to players about when to do something (like, say, merge debuffs for a curtain call mechanic...)

Wanted to get this up for input, but if folks like the idea, I can update the docs to reflect this capability once merged.