### PR TITLE
raidboss: add bewitching flight cast id

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r4s.ts
+++ b/ui/raidboss/data/07-dt/raid/r4s.ts
@@ -338,7 +338,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'R4S Bewitching Flight',
       type: 'StartsUsing',
-      netRegex: { id: '9671', source: 'Wicked Thunder', capture: false },
+      netRegex: { id: ['9671', '8DEF'], source: 'Wicked Thunder', capture: false },
       infoText: (_data, _matches, output) => output.avoid!(),
       outputStrings: {
         avoid: {


### PR DESCRIPTION
There are two situations for the Bewitching flightwhere where the missing one is supplemented