### PR TITLE
raidboss: fix R1S stored quad leaps

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r1s.ts
+++ b/ui/raidboss/data/07-dt/raid/r1s.ts
@@ -546,13 +546,13 @@ const triggerSet: TriggerSet<Data> = {
             data.storedLeaps.quadCross.resolved = true;
             let dir: 'dirE' | 'dirW';
 
-            if (data.storedLeaps.oneTwoPaw.northSouth === 'north') {
-              if (data.storedLeaps.oneTwoPaw.leftRight === 'left')
+            if (data.storedLeaps.quadCross.northSouth === 'north') {
+              if (data.storedLeaps.quadCross.leftRight === 'left')
                 dir = 'dirE';
               else
                 dir = 'dirW';
             } else {
-              if (data.storedLeaps.oneTwoPaw.leftRight === 'left')
+              if (data.storedLeaps.quadCross.leftRight === 'left')
                 dir = 'dirW';
               else
                 dir = 'dirE';


### PR DESCRIPTION
Currently,the direction of the quad cross clones is incorrect. I think this was a slight oversight by Valarnin when coding. When determining quad cross, the position of `quadCross` should be used for judgment, not `oneTwoPaw`.