### PR TITLE
raidboss: r4s sunrise sabbath fix

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r4s.ts
+++ b/ui/raidboss/data/07-dt/raid/r4s.ts
@@ -1735,6 +1735,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { id: '4.{7}', category: actorControlCategoryMap.setModelState, param1: '1C' },
       condition: (data) => data.phase === 'sunrise' && !data.seenFirstSunrise,
       // they both face opposite or adjacent, so we only need one to resolve the mechanic
+      delaySeconds: 0.2,
       suppressSeconds: 1,
       run: (data, matches) => {
         const id = matches.id;


### PR DESCRIPTION
Fixes #361.

The issue occurs because in some (but apparently not all) logs, the `ActorSetPos` and `ActorControlExtra` packets that are needed to identify the jumping clone and its position are ordered differently.  Adding a short delay to `R4S Sunrise Sabbath Jumping Clone Collect 1` (to ensure the related `ActorSetPos` collector processes first) seems to fix the issue -- and because both collectors happen ~3s before the cannon color collect and subsequent callout trigger, this added delay doesn't delay the mechanic callout at all.

This fixes the issue in the log @valarnin passed along, but additional in-game validation couldn't hurt.