### PR TITLE
build: Bump version to 0.32.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cactbot",
-  "version": "0.32.6",
+  "version": "0.32.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cactbot",
-      "version": "0.32.6",
+      "version": "0.32.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@fast-csv/parse": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "cactbot",
-  "version": "0.32.6",
-  "releaseSummary": "savage: add floor 4, more floors 1-3; alexandria; i18n",
-  "releaseInDraft": "false",
+  "version": "0.32.7",
+  "releaseSummary": "more savage, i18n",
+  "releaseInDraft": "true",
   "license": "Apache-2.0",
   "type": "module",
   "types": "./types",

--- a/plugin/CactbotEventSource/Properties/AssemblyInfo.cs
+++ b/plugin/CactbotEventSource/Properties/AssemblyInfo.cs
@@ -21,5 +21,5 @@ using System.Runtime.InteropServices;
 // - Revision
 // GitHub has only 3 version components, so Revision should always be 0.
 // CactbotOverlay and CactbotEventSource version should match.
-[assembly: AssemblyVersion("0.32.6.0")]
-[assembly: AssemblyFileVersion("0.32.6.0")]
+[assembly: AssemblyVersion("0.32.7.0")]
+[assembly: AssemblyFileVersion("0.32.7.0")]

--- a/plugin/CactbotOverlay/Properties/AssemblyInfo.cs
+++ b/plugin/CactbotOverlay/Properties/AssemblyInfo.cs
@@ -20,5 +20,5 @@ using System.Runtime.InteropServices;
 // - Build Number
 // - Revision
 // GitHub has only 3 version components, so Revision should always be 0.
-[assembly: AssemblyVersion("0.32.6.0")]
-[assembly: AssemblyFileVersion("0.32.6.0")]
+[assembly: AssemblyVersion("0.32.7.0")]
+[assembly: AssemblyFileVersion("0.32.7.0")]


### PR DESCRIPTION
Would like to get a version bump out asap to address the m/r4s i18n issues being reported in discord -- namely, that #334 hasn't made it into a release yet, so triggers aren't working for non-`en` parsing languages.

Releasing in draft so the release notes can be edited before publication, primarily so the release header can be adjusted based on the final PR merge list (esp. if #360 is merged).

(Closes #368).