### PR TITLE
util: fix id bug in encounter tools

### DIFF
--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -318,7 +318,7 @@ export class EncounterFinder {
     this.currentZone = {
       zoneName: zoneName,
       startLine: line,
-      zoneId: parseInt(matches.id),
+      zoneId: parseInt(matches.id, 16),
       startTime: TLFuncs.dateFromMatches(matches),
     };
   }


### PR DESCRIPTION
Fixes a long-standing bug in `encounter_tools`, where the regex'd zoneId is not properly converted from hex to int.  This has been causing `make_timeline` to mis-identify the zoneId in the header of the console output.

(Very low impact bug, but I'm working on some timelines today and I've noticed this before, so just cleaning it up.)