### PR TITLE
resources: add NPC-source+target effects to analysis filter

### DIFF
--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -701,6 +701,10 @@ const latestLogDefinitions = {
           sourceId: '[E4].{7}',
           targetId: '1.{7}',
         },
+        { // effects applied by NPCs to other NPCs (including themselves)
+          sourceId: '4.{7}',
+          targetId: '4.{7}',
+        },
         { // known effectIds of interest
           effectId: ['B9A', '808'],
         },
@@ -804,6 +808,10 @@ const latestLogDefinitions = {
         { // effect from environment/NPC applied to player
           sourceId: '[E4].{7}',
           targetId: '1.{7}',
+        },
+        { // effects applied by NPCs to other NPCs (including themselves)
+          sourceId: '4.{7}',
+          targetId: '4.{7}',
         },
         { // known effectIds of interest
           effectId: ['B9A', '808'],


### PR DESCRIPTION
Small fix to the log splitter's analysis filter, based on something I noticed while doing the A-rank triggers yesterday.  Right now, the analysis filter does not include `GainsEffect`/`LosesEffect` lines that originate from an NPC (4.{7}) that are applied to an NPC, e.g., self-applied boss status effects.  This PR fixes that.

Extremely small overall impact to the number of lines that pass the filter, but they are important ones.