### PR TITLE
build: release bump 0.32.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cactbot",
-  "version": "0.32.7",
+  "version": "0.32.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cactbot",
-      "version": "0.32.7",
+      "version": "0.32.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@fast-csv/parse": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cactbot",
-  "version": "0.32.7",
-  "releaseSummary": "more savage, i18n",
+  "version": "0.32.8",
+  "releaseSummary": "more Savage, Strayborough Deadwalk, Worqor Lar Dor normal, A-rank Hunts, more i18n",
   "releaseInDraft": "true",
   "license": "Apache-2.0",
   "type": "module",

--- a/plugin/CactbotEventSource/Properties/AssemblyInfo.cs
+++ b/plugin/CactbotEventSource/Properties/AssemblyInfo.cs
@@ -21,5 +21,5 @@ using System.Runtime.InteropServices;
 // - Revision
 // GitHub has only 3 version components, so Revision should always be 0.
 // CactbotOverlay and CactbotEventSource version should match.
-[assembly: AssemblyVersion("0.32.7.0")]
-[assembly: AssemblyFileVersion("0.32.7.0")]
+[assembly: AssemblyVersion("0.32.8.0")]
+[assembly: AssemblyFileVersion("0.32.8.0")]

--- a/plugin/CactbotOverlay/Properties/AssemblyInfo.cs
+++ b/plugin/CactbotOverlay/Properties/AssemblyInfo.cs
@@ -20,5 +20,5 @@ using System.Runtime.InteropServices;
 // - Build Number
 // - Revision
 // GitHub has only 3 version components, so Revision should always be 0.
-[assembly: AssemblyVersion("0.32.7.0")]
-[assembly: AssemblyFileVersion("0.32.7.0")]
+[assembly: AssemblyVersion("0.32.8.0")]
+[assembly: AssemblyFileVersion("0.32.8.0")]


### PR DESCRIPTION
If #386 is ready before the servers come up, that could be included as well.

includes:
- more Savage
- Strayborough Deadwalk
- Worqor Lar Dor normal
- A-rank Hunts
- more i18n