### PR TITLE
raidboss: fix cast ID for Aglaia Double Immolation

### DIFF
--- a/ui/raidboss/data/06-ew/alliance/aglaia.ts
+++ b/ui/raidboss/data/06-ew/alliance/aglaia.ts
@@ -250,7 +250,8 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Aglaia Lions Double Immolation',
       type: 'StartsUsing',
-      netRegex: { id: '7177', source: ['Lion of Aglaia', 'Lioness of Aglaia'], capture: false },
+      netRegex: { id: '71D7', source: ['Lion of Aglaia', 'Lioness of Aglaia'], capture: false },
+      // 71D7 = visible cast from both adds, 71D8 = actual damage source
       response: Responses.aoe(),
     },
     {


### PR DESCRIPTION
Seems that this typo has been there since the initial trigger set was added in quisquous/cactbot#4276.