### PR TITLE
raidboss: add Kirlirger (S-rank: Urqopacha)

### DIFF
--- a/ui/raidboss/data/07-dt/hunts/urqopacha.ts
+++ b/ui/raidboss/data/07-dt/hunts/urqopacha.ts
@@ -5,8 +5,6 @@ import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
 
-// TODO: Add triggers for Kirlirger the Abhorrent (S-Rank)
-
 type ForcedMarch = 'forward' | 'backward' | 'left' | 'right';
 const effectIdToForcedMarchDir: { [id: string]: ForcedMarch } = {
   871: 'forward', // Forward March
@@ -210,7 +208,102 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { id: '9A41', source: 'Queen Hawk' },
       response: Responses.tankBuster(),
     },
+
     // ****** S-RANK: Kirlirger the Abhorrent ****** //
+    {
+      id: 'Hunt Kirlirger Fullmoon Fury',
+      type: 'StartsUsing',
+      netRegex: { id: '9A28', source: 'Kirlirger the Abhorrent', capture: false },
+      response: Responses.getOut(),
+    },
+    {
+      id: 'Hunt Kirlirger Discordant Moon',
+      type: 'StartsUsing',
+      netRegex: { id: '9A29', source: 'Kirlirger the Abhorrent', capture: false },
+      response: Responses.getUnder('alert'),
+    },
+    {
+      id: 'Hunt Kirlirger Fighter\'s Flourish',
+      type: 'StartsUsing',
+      netRegex: { id: '9A2A', source: 'Kirlirger the Abhorrent', capture: false },
+      response: Responses.getBehind(),
+    },
+    {
+      id: 'Hunt Kirlirger Discordant Flourish',
+      type: 'StartsUsing',
+      netRegex: { id: '9A2B', source: 'Kirlirger the Abhorrent', capture: false },
+      response: Responses.goFront('alert'),
+    },
+    {
+      id: 'Hunt Kirlirger Enervating Gloom',
+      type: 'StartsUsing',
+      netRegex: { id: '9A38', source: 'Kirlirger the Abhorrent' },
+      response: Responses.stackMarkerOn('info'),
+    },
+    {
+      id: 'Hunt Kirlirger Flying Fist',
+      type: 'StartsUsing',
+      netRegex: { id: '9A64', source: 'Kirlirger the Abhorrent', capture: false },
+      response: Responses.awayFromFront(),
+    },
+    {
+      id: 'Hunt Kirlirger Odious Uproar',
+      type: 'StartsUsing',
+      netRegex: { id: '9A39', source: 'Kirlirger the Abhorrent', capture: false },
+      response: Responses.aoe(),
+    },
+    // After the opening trio, Kirlirger will do 3 casts of Honor's Accord or Dishonor's Accord.
+    // They each apply the same Honor's Accord buff, but the original cast order determines
+    // whether his next three casts will do the correct attack or the opposite attack (Kefka style).
+    // We don't need to track the casts or buffs -- we can just use cast ids.
+    {
+      id: 'Hunt Kirlirger Fullmoon Fury Honor',
+      type: 'StartsUsing',
+      netRegex: { id: '9A23', source: 'Kirlirger the Abhorrent', capture: false },
+      response: Responses.getOut(),
+    },
+    {
+      id: 'Hunt Kirlirger Fullmoon Fury Dishonor',
+      type: 'StartsUsing',
+      netRegex: { id: '9A27', source: 'Kirlirger the Abhorrent', capture: false },
+      response: Responses.getUnder('alert'),
+    },
+    {
+      id: 'Hunt Kirlirger Discordant Moon Honor',
+      type: 'StartsUsing',
+      netRegex: { id: '9BC3', source: 'Kirlirger the Abhorrent', capture: false },
+      response: Responses.getUnder('alert'),
+    },
+    {
+      id: 'Hunt Kirlirger Discordant Moon Dishonor',
+      type: 'StartsUsing',
+      netRegex: { id: '9A3C', source: 'Kirlirger the Abhorrent', capture: false },
+      response: Responses.getOut(),
+    },
+    {
+      id: 'Hunt Kirlirger Fighter\'s Flourish Honor',
+      type: 'StartsUsing',
+      netRegex: { id: '9A31', source: 'Kirlirger the Abhorrent', capture: false },
+      response: Responses.getBehind(),
+    },
+    {
+      id: 'Hunt Kirlirger Fighter\'s Flourish Dishonor',
+      type: 'StartsUsing',
+      netRegex: { id: '9A35', source: 'Kirlirger the Abhorrent', capture: false },
+      response: Responses.goFront('alert'),
+    },
+    {
+      id: 'Hunt Kirlirger Discordant Flourish Honor',
+      type: 'StartsUsing',
+      netRegex: { id: '9BC5', source: 'Kirlirger the Abhorrent', capture: false },
+      response: Responses.goFront('alert'),
+    },
+    {
+      id: 'Hunt Kirlirger Discordant Flourish Dishonor',
+      type: 'StartsUsing',
+      netRegex: { id: '9A72', source: 'Kirlirger the Abhorrent', capture: false },
+      response: Responses.getBehind(),
+    },
   ],
   timelineReplace: [
     {


### PR DESCRIPTION
There's some weird gaps and sequencing in the ability ids used for the Honor's Accord/Dishonor's Accord-based attacks.  But all were verified across nearly a dozen logged kills, and all were copied/pasted directly from logs -- so no typos, I promise.