### PR TITLE
raidboss: fix mistaken translation edit to Atticus

### DIFF
--- a/ui/raidboss/data/07-dt/hunts/heritage_found.ts
+++ b/ui/raidboss/data/07-dt/hunts/heritage_found.ts
@@ -362,27 +362,27 @@ const triggerSet: TriggerSet<Data> = {
           fr: 'Départ ${dir3} => ${dir1} => ${dir2} (Continuez à tourner)',
         },
         earlyDelay: {
-          en: 'Start ${dir3} => ${dir1} (für 2) => ${dir3} => ${dir2}',
+          en: 'Start ${dir3} => ${dir1} (for 2) => ${dir3} => ${dir2}',
           de: 'Start ${dir3} => ${dir1} (für 2) => ${dir3} => ${dir2}',
           fr: 'Départ ${dir3} => ${dir1} (für 2) => ${dir3} => ${dir2}',
         },
         lateDelay1: {
-          en: 'Start ${dir3} => ${dir1} => ${dir2} (für 2) => ${dir1}',
+          en: 'Start ${dir3} => ${dir1} => ${dir2} (for 2) => ${dir1}',
           de: 'Start ${dir3} => ${dir1} => ${dir2} (für 2) => ${dir1}',
           fr: 'Départ ${dir3} => ${dir1} => ${dir2} (für 2) => ${dir1}',
         },
         lateDelay3: {
-          en: 'Start ${dir3} => ${dir1} => ${dir2} (für 2) => ${dir3}',
+          en: 'Start ${dir3} => ${dir1} => ${dir2} (for 2) => ${dir3}',
           de: 'Start ${dir3} => ${dir1} => ${dir2} (für 2) => ${dir3}',
           fr: 'Départ ${dir3} => ${dir1} => ${dir2} (für 2) => ${dir3}',
         },
         bigDelay2: {
-          en: 'Start ${dir3} => ${dir1} (für 3) => ${dir2}',
+          en: 'Start ${dir3} => ${dir1} (for 3) => ${dir2}',
           de: 'Start ${dir3} => ${dir1} (für 3) => ${dir2}',
           fr: 'Départ ${dir3} => ${dir1} (für 3) => ${dir2}',
         },
         bigDelay3: {
-          en: 'Start ${dir3} => ${dir1} (für 3) => ${dir3}',
+          en: 'Start ${dir3} => ${dir1} (for 3) => ${dir3}',
           de: 'Start ${dir3} => ${dir1} (für 3) => ${dir3}',
           fr: 'Départ ${dir3} => ${dir1} (für 3) => ${dir3}',
         },


### PR DESCRIPTION
#409 mistakenly edited the `en` strings for these callouts -- this reverts the `en` strings back to what they were previously. 

@Akurosia - could you please double-check and confirm that `Start` in the `de` strings is correct and doesn't need translation?

@mooondark - you also have the `für` in #411 - I think that might need to be changed for `fr`?