### PR TITLE
raidemulator: fix overworld combat incorrect zone detection

### DIFF
--- a/ui/raidboss/emulator/data/LogEventHandler.ts
+++ b/ui/raidboss/emulator/data/LogEventHandler.ts
@@ -19,9 +19,9 @@ export default class LogEventHandler extends EventBus {
       if (res) {
         this.endFight();
       } else if (lineObj instanceof LineEvent0x01) {
+        this.endFight();
         this.currentZoneId = lineObj.zoneId;
         this.currentZoneName = lineObj.zoneName;
-        this.endFight();
       }
     }
   }


### PR DESCRIPTION
Noticed this while working on the hunt marks, but raid emulator incorrectly detects the zone information for overworld hunt marks -- it will always assign the encounter to the zone you change to after the encounter ends.

This should fix the issue.  And testing a mix of overworld/instance content logs from the last week shows zone info being correctly detected.  (Related: there also seems to be an issue with correct party detection in overworld content, but I'll look into that later.) 