### PR TITLE
raidboss: prioritize north/south during Chasm of Vollok

### DIFF
--- a/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.ts
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.ts
@@ -433,8 +433,8 @@ const triggerSet: TriggerSet<Data> = {
       alertText: (data, matches, output) => {
         // To make this call somewhat reasonable, use the following priority system
         // for calling a safe tile, depending on sword cleave:
-        //   1. insideEast/insideWest
-        //   2. insideNorth/insideSouth, lean E/W
+        //   1. insideNorth/insideSouth, lean E/W
+        //   2. insideEast/insideWest
         //   3. If all inside are bad, the outer intercard pairs (E/W depending on cleave)
         const safeSide = matches.id === '9368' ? 'west' : 'east';
         const leanOutput = matches.id === '9368' ? output.leanWest!() : output.leanEast!();
@@ -443,12 +443,12 @@ const triggerSet: TriggerSet<Data> = {
         if (safeTiles.length !== 8)
           return;
 
-        if (safeSide === 'west' && safeTiles.includes('insideWest'))
+        if (safeTiles.includes('insideNorth'))
+          return output.insideNS!({ lean: leanOutput });
+        else if (safeSide === 'west' && safeTiles.includes('insideWest'))
           return output.insideWest!();
         else if (safeSide === 'east' && safeTiles.includes('insideEast'))
           return output.insideEast!();
-        else if (safeTiles.includes('insideNorth'))
-          return output.insideNS!({ lean: leanOutput });
         else if (safeSide === 'east')
           return output.intercardsEast!();
         return output.intercardsWest!();


### PR DESCRIPTION
For Zoraal Ja EX, the sword cleave callout currently prioritizes calling
the safe spot in order of:

1) inside east/west
2) the north or south corner, leaning to avoid the cleaves
3) finally the outer intercard pairs

This works, but most parties have the party stack south with the main
tank at the north. Calling the safe spot with north or south tile first
is less movement for both the maintank and party.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
