### PR TITLE
oopsy: update buff map with DT/7.0 changes

### DIFF
--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -533,6 +533,11 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     type: 'heal',
     abilityId: '4085',
   },
+  {
+    id: 'Lux Solaris',
+    type: 'heal',
+    abilityId: '9085',
+  },
   // ************ RDM ************ //
   {
     id: 'Embolden',

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -62,6 +62,7 @@ export const missedEffectBuffMap: readonly MissableEffect[] = [
 ] as const;
 
 export const missedAbilityBuffMap: readonly MissableAbility[] = [
+  // ******************** Tanks ******************** //
   {
     // tank LB1
     id: 'Shield Wall',
@@ -74,12 +75,14 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     type: 'mitigation',
     abilityId: 'C6',
   },
+  // ************ PLD ************ //
   {
     // PLD LB3
     id: 'Last Bastion',
     type: 'mitigation',
     abilityId: 'C7',
   },
+  // ************ WAR ************ //
   {
     // WAR LB3
     id: 'Land Waker',
@@ -87,11 +90,23 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     abilityId: '1090',
   },
   {
+    id: 'Shake It Off',
+    type: 'mitigation',
+    abilityId: '1CDC',
+  },
+  // ************ DRK ************ //
+  {
     // DRK LB3
     id: 'Dark Force',
     type: 'mitigation',
     abilityId: '1091',
   },
+  {
+    id: 'Dark Missionary',
+    type: 'mitigation',
+    abilityId: '4057',
+  },
+  // ************ GNB ************ //
   {
     // GNB LB3
     id: 'Gunmetal Soul',
@@ -99,139 +114,12 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     abilityId: '42D1',
   },
   {
-    // GNB
     id: 'Heart Of Light',
     type: 'mitigation',
     abilityId: '3F20',
   },
-  {
-    // DRK
-    id: 'Dark Missionary',
-    type: 'mitigation',
-    abilityId: '4057',
-  },
-  {
-    // WAR
-    id: 'Shake It Off',
-    type: 'mitigation',
-    abilityId: '1CDC',
-  },
-  {
-    // DNC
-    id: 'Technical Finish',
-    type: 'damage',
-    // 81C2 is the correct Quadruple Technical Finish, others are Dinky Technical Finish.
-    // TODO: pre-6.4, these were the abilityIds, but there's no backwards compat support here
-    // See: https://github.com/quisquous/cactbot/issues/5415
-    // abilityId: ['3F41', '3F42', '3F43', '3F44'],
-    abilityId: ['81BF', '81C0', '81C1', '81C2'],
-  },
-  {
-    // DNC channeled shield
-    id: 'Improvised Finish',
-    type: 'mitigation',
-    abilityId: '64BD',
-  },
-  {
-    // DNC AoE heal (same ID from DNC and partner)
-    id: 'Curing Waltz',
-    type: 'heal',
-    abilityId: '3E8F',
-  },
-  {
-    // AST
-    id: 'Divination',
-    type: 'damage',
-    abilityId: '40A8',
-  },
-  {
-    // MNK
-    id: 'Brotherhood',
-    type: 'damage',
-    abilityId: '1CE4',
-  },
-  {
-    // DRG
-    id: 'Battle Litany',
-    type: 'damage',
-    abilityId: 'DE5',
-  },
-  {
-    // RDM
-    id: 'Embolden',
-    type: 'damage',
-    abilityId: '1D60',
-  },
-  {
-    // BRD
-    id: 'Battle Voice',
-    type: 'damage',
-    abilityId: '76',
-    // TODO: remove this line after 5.x is not supported anymore.
-    // Technically Battle Voice can't miss the bard itself, so this is a noop in 6.x.
-    ignoreSelf: true,
-  },
-  {
-    // BRD
-    id: 'Radiant Finale',
-    type: 'damage',
-    abilityId: '64B9',
-  },
-  {
-    // BRD
-    id: 'Nature\'s Minne',
-    type: 'heal',
-    abilityId: '1CF0',
-  },
-  {
-    // SMN (5.x ability, removed in Endwalker)
-    id: 'Devotion',
-    type: 'damage',
-    abilityId: '1D1A',
-  },
-  {
-    // SMN
-    id: 'Searing Light',
-    type: 'damage',
-    // TODO: 64C9 is 6.4, remove 64F2 once everything is on 6.4
-    abilityId: ['64F2', '64C9'],
-  },
-  {
-    // RPR
-    id: 'Arcane Circle',
-    type: 'damage',
-    abilityId: '5F55',
-  },
-  {
-    // BRD
-    id: 'Troubadour',
-    type: 'mitigation',
-    abilityId: '1CED',
-  },
-  {
-    // MCH
-    id: 'Tactician',
-    type: 'mitigation',
-    abilityId: '41F9',
-  },
-  {
-    // DNC
-    id: 'Shield Samba',
-    type: 'mitigation',
-    abilityId: '3E8C',
-  },
-  {
-    // RDM
-    id: 'Magick Barrier',
-    type: 'mitigation',
-    abilityId: '6501',
-  },
-  {
-    // MNK
-    id: 'Mantra',
-    type: 'heal',
-    abilityId: '41',
-  },
+
+  // ******************** Healers ******************** //
   {
     // heal LB1
     id: 'Healing Wind',
@@ -244,6 +132,7 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     type: 'heal',
     abilityId: 'CF',
   },
+  // ************ WHM ************ //
   {
     // WHM LB3
     id: 'Pulse of Life',
@@ -251,141 +140,49 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     abilityId: 'D0',
   },
   {
-    // SGE LB3
-    id: 'Techne Makre',
-    type: 'heal',
-    abilityId: '611B',
-  },
-  {
-    // SMN phoenix heal
-    id: 'Everlasting Flight',
-    type: 'heal',
-    abilityId: '4085',
-  },
-  {
-    // WHM
     id: 'Medica',
     type: 'heal',
     abilityId: '7C',
   },
   {
-    // WHM
     id: 'Medica II',
     type: 'heal',
     abilityId: '85',
   },
   {
-    // WHM
     id: 'Cure III',
     type: 'heal',
     abilityId: '83',
   },
   {
-    // WHM (same ID for damage component)
+    // (same ID for damage component)
     id: 'Assize',
     type: 'heal',
     abilityId: 'DF3',
   },
   {
-    // WHM
     id: 'Afflatus Rapture',
     type: 'heal',
     abilityId: '4096',
   },
   {
-    // WHM
     id: 'Temperance',
     type: 'mitigation',
     abilityId: '751',
   },
   {
-    // WHM
     id: 'Plenary Indulgence',
     type: 'heal',
     abilityId: '1D09',
   },
   {
-    // WHM
     // 6507 heal on tick
     // 6508 heal on expire
     id: 'Liturgy of the Bell',
     type: 'heal',
     abilityId: ['6507', '6508'],
   },
-  {
-    // SCH
-    id: 'Succor',
-    type: 'mitigation',
-    abilityId: 'BA',
-  },
-  {
-    // SCH
-    id: 'Indomitability',
-    type: 'heal',
-    abilityId: 'DFF',
-  },
-  {
-    // SCH
-    id: 'Deployment Tactics',
-    type: 'mitigation',
-    abilityId: 'E01',
-  },
-  {
-    // SCH
-    id: 'Whispering Dawn',
-    type: 'heal',
-    abilityId: '323',
-  },
-  {
-    // SCH
-    id: 'Fey Blessing',
-    type: 'heal',
-    abilityId: '40A0',
-  },
-  {
-    // SCH
-    id: 'Consolation',
-    type: 'mitigation',
-    abilityId: '40A3',
-  },
-  {
-    // SCH
-    id: 'Angel\'s Whisper',
-    type: 'heal',
-    abilityId: '40A6',
-  },
-  {
-    // SCH
-    id: 'Fey Illumination',
-    type: 'mitigation',
-    abilityId: '325',
-  },
-  {
-    // SCH
-    id: 'Seraphic Illumination',
-    type: 'mitigation',
-    abilityId: '40A7',
-  },
-  {
-    // SCH
-    // Technically the mitigation is "Desperate Measures", but it comes from
-    // the Expedient ability on each player and "Expedience" is the haste buff.
-    id: 'Expedient',
-    type: 'mitigation',
-    abilityId: '650C',
-  },
-  {
-    // SGE
-    id: 'Kerachole',
-    type: 'mitigation',
-    abilityId: '5EEA',
-  },
-  {
-    // SGE
-    id: 'Panhaima',
-    type: 'mitigation',
-    abilityId: '5EF7',
-  },
+  // ************ SCH ************ //
   {
     // SCH LB3
     id: 'Angel Feathers',
@@ -393,37 +190,95 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     abilityId: '1097',
   },
   {
-    // AST
+    id: 'Succor',
+    type: 'mitigation',
+    abilityId: 'BA',
+  },
+  {
+    id: 'Indomitability',
+    type: 'heal',
+    abilityId: 'DFF',
+  },
+  {
+    id: 'Deployment Tactics',
+    type: 'mitigation',
+    abilityId: 'E01',
+  },
+  {
+    id: 'Whispering Dawn',
+    type: 'heal',
+    abilityId: '323',
+  },
+  {
+    id: 'Fey Blessing',
+    type: 'heal',
+    abilityId: '40A0',
+  },
+  {
+    id: 'Consolation',
+    type: 'mitigation',
+    abilityId: '40A3',
+  },
+  {
+    id: 'Angel\'s Whisper',
+    type: 'heal',
+    abilityId: '40A6',
+  },
+  {
+    id: 'Fey Illumination',
+    type: 'mitigation',
+    abilityId: '325',
+  },
+  {
+    id: 'Seraphic Illumination',
+    type: 'mitigation',
+    abilityId: '40A7',
+  },
+  {
+    // Technically the mitigation is "Desperate Measures", but it comes from
+    // the Expedient ability on each player and "Expedience" is the haste buff.
+    id: 'Expedient',
+    type: 'mitigation',
+    abilityId: '650C',
+  },
+  // ************ AST ************ //
+  {
+    // AST LB3
+    id: 'Astral Stasis',
+    type: 'heal',
+    abilityId: '1098',
+  },
+  {
+    id: 'Divination',
+    type: 'damage',
+    abilityId: '40A8',
+  },
+  {
     id: 'Helios',
     type: 'heal',
     abilityId: 'E10',
   },
   {
-    // AST
     id: 'Aspected Helios',
     type: 'heal',
     abilityId: ['E11', '3200'],
   },
   {
-    // AST
     id: 'Celestial Opposition',
     type: 'heal',
     abilityId: '40A9',
   },
   {
-    // AST
     id: 'Stellar Burst',
     type: 'heal',
     abilityId: '1D10',
   },
   {
-    // AST
     id: 'Stellar Explosion',
     type: 'heal',
     abilityId: '1D11',
   },
   {
-    // AST
     // 40AD initial application
     // 40AE cure on manual trigger
     // same IDs for Horoscope Helios
@@ -432,110 +287,221 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     abilityId: ['40AD', '40AE'],
   },
   {
-    // AST
     id: 'Macrocosmos',
     type: 'heal',
     abilityId: '6512',
   },
   {
-    // AST
     id: 'Microcosmos',
     type: 'heal',
     abilityId: '6513',
   },
   {
-    // AST
     id: 'Lady of Crowns',
     type: 'heal',
     abilityId: '1D15',
   },
+  // ************ SGE ************ //
   {
-    // AST LB3
-    id: 'Astral Stasis',
+    // SGE LB3
+    id: 'Techne Makre',
     type: 'heal',
-    abilityId: '1098',
+    abilityId: '611B',
   },
   {
-    // SGE
+    id: 'Kerachole',
+    type: 'mitigation',
+    abilityId: '5EEA',
+  },
+  {
+    id: 'Panhaima',
+    type: 'mitigation',
+    abilityId: '5EF7',
+  },
+  {
     id: 'Prognosis',
     type: 'heal',
     abilityId: '5EDE',
   },
   {
-    // SGE
     id: 'Physis',
     type: 'heal',
     abilityId: '5EE0',
   },
   {
-    // SGE
     id: 'Eukrasian Prognosis',
     type: 'mitigation',
     abilityId: '5EE4',
   },
   {
-    // SGE
     id: 'Ixochole',
     type: 'heal',
     abilityId: '5EEB',
   },
   {
-    // SGE
     id: 'Pepsis',
     type: 'heal',
     abilityId: '5EED',
   },
   {
-    // SGE
     id: 'Physis II',
     type: 'heal',
     abilityId: '5EEE',
   },
   {
-    // SGE
     id: 'Holos',
     type: 'mitigation',
     abilityId: '5EF6',
   },
   {
-    // SGE
     id: 'Pneuma',
     type: 'heal',
     // 5EFE on enemies, and 6CB6 on friendlies.
     abilityId: '6CB6',
   },
+
+  // ******************** Melee DPS ******************** //
+  // ************ MNK ************ //
   {
-    // BLU
+    id: 'Brotherhood',
+    type: 'damage',
+    abilityId: '1CE4',
+  },
+  {
+    id: 'Mantra',
+    type: 'heal',
+    abilityId: '41',
+  },
+  // ************ DRG ************ //
+  {
+    id: 'Battle Litany',
+    type: 'damage',
+    abilityId: 'DE5',
+  },
+  // ************ RPR ************ //
+  {
+    id: 'Arcane Circle',
+    type: 'damage',
+    abilityId: '5F55',
+  },
+
+  // ******************** Physical Ranged DPS ******************** //
+  // ************ BRD ************ //
+  {
+    id: 'Battle Voice',
+    type: 'damage',
+    abilityId: '76',
+  },
+  {
+    id: 'Radiant Finale',
+    type: 'damage',
+    abilityId: '64B9',
+  },
+  {
+    id: 'Nature\'s Minne',
+    type: 'heal',
+    abilityId: '1CF0',
+  },
+  {
+    id: 'Troubadour',
+    type: 'mitigation',
+    abilityId: '1CED',
+  },
+  // ************ MCH ************ //
+  {
+    id: 'Tactician',
+    type: 'mitigation',
+    abilityId: '41F9',
+  },
+  // ************ DNC ************ //
+  {
+    id: 'Technical Finish',
+    type: 'damage',
+    // 81C2 is the correct Quadruple Technical Finish, others are Dinky Technical Finish.
+    // TODO: pre-6.4, these were the abilityIds, but there's no backwards compat support here
+    // See: https://github.com/quisquous/cactbot/issues/5415
+    // abilityId: ['3F41', '3F42', '3F43', '3F44'],
+    abilityId: ['81BF', '81C0', '81C1', '81C2'],
+  },
+  {
+    // Channeled shield
+    id: 'Improvised Finish',
+    type: 'mitigation',
+    abilityId: '64BD',
+  },
+  {
+    // AoE heal (same ID from DNC and partner)
+    id: 'Curing Waltz',
+    type: 'heal',
+    abilityId: '3E8F',
+  },
+  {
+    id: 'Shield Samba',
+    type: 'mitigation',
+    abilityId: '3E8C',
+  },
+
+  // ******************** Magical Ranged DPS ******************** //
+  // ************ SMN ************ //
+  {
+    // (5.x ability, removed in Endwalker)
+    id: 'Devotion',
+    type: 'damage',
+    abilityId: '1D1A',
+  },
+  {
+    id: 'Searing Light',
+    type: 'damage',
+    abilityId: '64C9',
+  },
+  {
+    // phoenix heal
+    id: 'Everlasting Flight',
+    type: 'heal',
+    abilityId: '4085',
+  },
+  // ************ RDM ************ //
+  {
+    id: 'Embolden',
+    type: 'damage',
+    abilityId: '1D60',
+  },
+  {
+    id: 'Magick Barrier',
+    type: 'mitigation',
+    abilityId: '6501',
+  },
+  // ************ BLU ************ //
+  {
     id: 'White Wind',
     type: 'heal',
     abilityId: '2C8E',
   },
   {
-    // BLU
     id: 'Gobskin',
     type: 'mitigation',
     abilityId: '4780',
   },
   {
-    // BLU
     id: 'Exuviation',
     type: 'heal',
     abilityId: '478E',
   },
   {
-    // BLU (only heals in heal mimic)
+    // only heals in heal mimic
     id: 'Stotram',
     type: 'heal',
     abilityId: '5B78',
   },
   {
-    // BLU
     id: 'Angel\'s Snack',
     type: 'heal',
     abilityId: '5AE8',
   },
+
+  // ******************** Field Operations & Misc. ******************** //
+  // ************ Bozja ************ //
   {
-    // Bozja
     id: 'Lost Aethershield',
     type: 'mitigation',
     abilityId: '5753',

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -34,16 +34,6 @@ export const missedEffectBuffMap: readonly MissableEffect[] = [
     ignoreSelf: true,
     collectSeconds: 15,
   },
-  {
-    // PLD
-    id: 'Divine Veil',
-    type: 'mitigation',
-    // TODO: 552 is 6.4, remove 2D7 once everything is on 6.4
-    // TODO: veil now applies to the paladin in ... 6.3?
-    effectId: ['2D7', '552'],
-    ignoreSelf: true,
-    collectSeconds: 2,
-  },
 
   // ******************** Healers ******************** //
   {
@@ -102,6 +92,11 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     id: 'Last Bastion',
     type: 'mitigation',
     abilityId: 'C7',
+  },
+  {
+    id: 'Divine Veil',
+    type: 'mitigation',
+    abilityId: 'DD4',
   },
   // ************ WAR ************ //
   {

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -166,6 +166,11 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     abilityId: '85',
   },
   {
+    "id": "Medica III",
+    "type": "heal",
+    "abilityId": "9092"
+  },
+  {
     id: 'Cure III',
     type: 'heal',
     abilityId: '83',

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -402,6 +402,11 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     abilityId: '5EE4',
   },
   {
+    id: 'Eukrasian Prognosis II',
+    type: 'mitigation',
+    abilityId: '90AA',
+  },
+  {
     id: 'Ixochole',
     type: 'heal',
     abilityId: '5EEB',

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -1,3 +1,9 @@
+// TODO: We could add BRD's songs (Minuet = 8A8, Ballad = 8A9, Paeon = 8AA),
+// but effect re-application lines are continuously sent by ACT (as this is a cancellable buff).
+// If we use a collectSeconds for the full duration, the 'missed' message is very delayed;
+// but any shorter, we'll get repeated 'missed' messages for the same buff.
+// Probably need to add support for a 'suppressSeconds' property...
+
 export type MissableBuffType = 'heal' | 'damage' | 'mitigation';
 
 export type MissableEffect = {
@@ -516,12 +522,6 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
 
   // ******************** Magical Ranged DPS ******************** //
   // ************ SMN ************ //
-  {
-    // (5.x ability, removed in Endwalker)
-    id: 'Devotion',
-    type: 'damage',
-    abilityId: '1D1A',
-  },
   {
     id: 'Searing Light',
     type: 'damage',

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -314,7 +314,7 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
   {
     id: 'Aspected Helios',
     type: 'heal',
-    abilityId: ['E11', '3200'],
+    abilityId: 'E11',
   },
   {
     id: 'Celestial Opposition',

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -359,6 +359,11 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     type: 'heal',
     abilityId: '1D15',
   },
+  {
+    id: 'Sun Sign',
+    type: 'mitigation',
+    abilityId: '90A7',
+  },
   // ************ SGE ************ //
   {
     // SGE LB3

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -555,6 +555,11 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     type: 'mitigation',
     abilityId: '877E',
   },
+  {
+    id: 'Starry Muse',
+    type: 'damage',
+    abilityId: '8773',
+  },
   // ************ BLU ************ //
   {
     id: 'White Wind',

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -427,6 +427,11 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     // 5EFE on enemies, and 6CB6 on friendlies.
     abilityId: '6CB6',
   },
+  {
+    id: 'Philosophia',
+    type: 'heal',
+    abilityId: '90AB',
+  },
 
   // ******************** Melee DPS ******************** //
   // ************ MNK ************ //

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -37,6 +37,14 @@ export const missedEffectBuffMap: readonly MissableEffect[] = [
 
   // ******************** Healers ******************** //
   {
+    // WHM
+    id: 'Asylum',
+    type: 'heal',
+    // 777 = you (bubble duration), 778 = you + others (healing).  Use both in case everybody is missed.
+    effectId: ['777', '778'],
+    collectSeconds: 24,
+  },
+  {
     // AST
     id: 'Collective Unconscious',
     type: 'mitigation',

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -1,8 +1,8 @@
 // TODO: We could add BRD's songs (Minuet = 8A8, Ballad = 8A9, Paeon = 8AA),
 // but effect re-application lines are continuously sent by ACT (as this is a cancellable buff).
-// If we use a collectSeconds for the full duration, the 'missed' message is very delayed;
+// If we use `collectSeconds` for the full duration, the 'missed' message will be very delayed;
 // but any shorter, we'll get repeated 'missed' messages for the same buff.
-// Probably need to add support for a 'suppressSeconds' property...
+// We probably need to add support for something like a 'suppressSeconds' property.
 
 export type MissableBuffType = 'heal' | 'damage' | 'mitigation';
 
@@ -24,11 +24,10 @@ export type MissableAbility = {
 
 export type MissableBuff = MissableAbility | MissableEffect;
 
-// missedEffectBuffMap is for buffs that are solely applied/measured by
-// `GainsEffect`/`LosesEffect` lines, e.g., where there is no corresponding
-// `Ability`/`NetworkAoEAbility` line to indicate the player received the effect.
-// These are commonly used for bubble-type AoE buffs, like WHM's Asylum.
-// If there is an ability line for each affected player, use missedAbilityBuffMap instead.
+// missedEffectBuffMap is for buffs that can be detected solely by `GainsEffect` lines,
+// where there is no corresponding `Ability` line to indicate the player received the effect.
+// These are predominantly bubble-type AoE buffs, like WHM's Asylum.
+// If there is an ability line for each affected player, use `missedAbilityBuffMap` instead.
 export const missedEffectBuffMap: readonly MissableEffect[] = [
   // ******************** Tanks ******************** //
   {
@@ -94,10 +93,9 @@ export const missedEffectBuffMap: readonly MissableEffect[] = [
   // ******************** Field Operations & Misc. ******************** //
 ] as const;
 
-// missedAbilityBuffMap is for buffs/effects that have a corresponding
-// `Ability` / `NetworkAoEAbility` for **each affected player**.  If the effect's application
-// to a particular player can only be measured by `GainsEffect`/`LosesEffect` lines, use
-// missedEffectBuffMap instead.
+// missedAbilityBuffMap is for buffs that have a corresponding Ability line for
+// each affected player.  If the effect's application to a particular player can only
+// be measured by `GainsEffect` lines, use `missedEffectBuffMap` instead.
 export const missedAbilityBuffMap: readonly MissableAbility[] = [
   // ******************** Tanks ******************** //
   {

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -89,11 +89,9 @@ export const missedEffectBuffMap: readonly MissableEffect[] = [
     effectId: 'A87',
     collectSeconds: 15,
   },
-
   // ******************** Magical Ranged DPS ******************** //
 
   // ******************** Field Operations & Misc. ******************** //
-
 ] as const;
 
 // missedAbilityBuffMap is for buffs/effects that have a corresponding
@@ -194,9 +192,9 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     abilityId: '85',
   },
   {
-    "id": "Medica III",
-    "type": "heal",
-    "abilityId": "9092"
+    'id': 'Medica III',
+    'type': 'heal',
+    'abilityId': '9092',
   },
   {
     id: 'Cure III',

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -52,6 +52,13 @@ export const missedEffectBuffMap: readonly MissableEffect[] = [
     collectSeconds: 2,
   },
   {
+    // SCH
+    id: 'Seraphism',
+    type: 'heal',
+    effectId: 'F2D',
+    collectSeconds: 2,
+  },
+  {
     // AST
     id: 'Collective Unconscious',
     type: 'mitigation',

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -289,6 +289,11 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     type: 'mitigation',
     abilityId: '650C',
   },
+  {
+    id: 'Accession',
+    type: 'heal',
+    abilityId: '9098',
+  },
   // ************ AST ************ //
   {
     // AST LB3

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -45,6 +45,13 @@ export const missedEffectBuffMap: readonly MissableEffect[] = [
     collectSeconds: 24,
   },
   {
+    // WHM
+    id: 'Temperance',
+    type: 'mitigation',
+    effectId: '751',
+    collectSeconds: 2,
+  },
+  {
     // AST
     id: 'Collective Unconscious',
     type: 'mitigation',
@@ -193,11 +200,6 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     id: 'Afflatus Rapture',
     type: 'heal',
     abilityId: '4096',
-  },
-  {
-    id: 'Temperance',
-    type: 'mitigation',
-    abilityId: '751',
   },
   {
     id: 'Plenary Indulgence',

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -231,6 +231,11 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     abilityId: 'BA',
   },
   {
+    id: 'Concitation',
+    type: 'mitigation',
+    abilityId: '9095',
+  },
+  {
     id: 'Indomitability',
     type: 'heal',
     abilityId: 'DFF',

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -317,6 +317,11 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     abilityId: 'E11',
   },
   {
+    id: 'Helios Conjunction',
+    type: 'heal',
+    abilityId: '90A6',
+  },
+  {
     id: 'Celestial Opposition',
     type: 'heal',
     abilityId: '40A9',

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -213,6 +213,11 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     type: 'heal',
     abilityId: ['6507', '6508'],
   },
+  {
+    id: 'Divine Caress',
+    type: 'mitigation',
+    abilityId: '9093',
+  },
   // ************ SCH ************ //
   {
     // SCH LB3

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -392,6 +392,11 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     abilityId: '5EE0',
   },
   {
+    id: 'Physis II',
+    type: 'heal',
+    abilityId: '5EEE',
+  },
+  {
     id: 'Eukrasian Prognosis',
     type: 'mitigation',
     abilityId: '5EE4',
@@ -405,11 +410,6 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     id: 'Pepsis',
     type: 'heal',
     abilityId: '5EED',
-  },
-  {
-    id: 'Physis II',
-    type: 'heal',
-    abilityId: '5EEE',
   },
   {
     id: 'Holos',

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -18,14 +18,13 @@ export type MissableAbility = {
 
 export type MissableBuff = MissableAbility | MissableEffect;
 
+// missedEffectBuffMap is for buffs that are solely applied/measured by
+// `GainsEffect`/`LosesEffect` lines, e.g., where there is no corresponding
+// `Ability`/`NetworkAoEAbility` line to indicate the player received the effect.
+// These are commonly used for bubble-type AoE buffs, like WHM's Asylum.
+// If there is an ability line for each affected player, use missedAbilityBuffMap instead.
 export const missedEffectBuffMap: readonly MissableEffect[] = [
-  {
-    // AST
-    id: 'Collective Unconscious',
-    type: 'mitigation',
-    effectId: '351',
-    collectSeconds: 20,
-  },
+  // ******************** Tanks ******************** //
   {
     // PLD
     id: 'Passage of Arms',
@@ -45,6 +44,17 @@ export const missedEffectBuffMap: readonly MissableEffect[] = [
     ignoreSelf: true,
     collectSeconds: 2,
   },
+
+  // ******************** Healers ******************** //
+  {
+    // AST
+    id: 'Collective Unconscious',
+    type: 'mitigation',
+    effectId: '351',
+    collectSeconds: 20,
+  },
+
+  // ******************** Melee DPS ******************** //
   {
     // RPR heal
     id: 'Crest of Time Returned',
@@ -52,6 +62,8 @@ export const missedEffectBuffMap: readonly MissableEffect[] = [
     effectId: 'A26',
     collectSeconds: 2,
   },
+
+  // ******************** Physical Ranged DPS ******************** //
   {
     // DNC channeled heal
     id: 'Improvisation',
@@ -59,8 +71,17 @@ export const missedEffectBuffMap: readonly MissableEffect[] = [
     effectId: 'A87',
     collectSeconds: 15,
   },
+
+  // ******************** Magical Ranged DPS ******************** //
+
+  // ******************** Field Operations & Misc. ******************** //
+
 ] as const;
 
+// missedAbilityBuffMap is for buffs/effects that have a corresponding
+// `Ability` / `NetworkAoEAbility` for **each affected player**.  If the effect's application
+// to a particular player can only be measured by `GainsEffect`/`LosesEffect` lines, use
+// missedEffectBuffMap instead.
 export const missedAbilityBuffMap: readonly MissableAbility[] = [
   // ******************** Tanks ******************** //
   {

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -556,6 +556,11 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     type: 'damage',
     abilityId: '8773',
   },
+  {
+    id: 'Star Prism',
+    type: 'heal',
+    abilityId: '877A', // 8779 is the damage component
+  },
   // ************ BLU ************ //
   {
     id: 'White Wind',

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -549,6 +549,12 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     type: 'mitigation',
     abilityId: '6501',
   },
+  // ************ PCT ************ //
+  {
+    id: 'Tempera Grassa',
+    type: 'mitigation',
+    abilityId: '877E',
+  },
   // ************ BLU ************ //
   {
     id: 'White Wind',

--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -46,7 +46,7 @@ export const missedEffectBuffMap: readonly MissableEffect[] = [
     // WHM
     id: 'Asylum',
     type: 'heal',
-    // 777 = you (bubble duration), 778 = you + others (healing).  Use both in case everybody is missed.
+    // 777 = you (bubble), 778 = you + others (healing).  Use both in case everybody is missed.
     effectId: ['777', '778'],
     collectSeconds: 24,
   },


### PR DESCRIPTION
The `diff` appears larger here than it really is because I reordered the buffs by role and added headings where appropriate to bring some order to the chaos.  
* `68fa295` and `b7b8fd3` are the re-ordering commits (with some added comments), but shouldn't have any substantive changes.
* The remainder are commits with individual buff changes.