### PR TITLE
raidboss/oopsy: add Everkeep (normal) package

### DIFF
--- a/resources/outputs.ts
+++ b/resources/outputs.ts
@@ -1002,6 +1002,10 @@ export default {
     cn: ' => ',
     ko: ' => ',
   },
+  // for combo mechanics/names
+  and: {
+    en: ' + ',
+  },
   // Literal numbers.
   num0: numberToOutputString(0),
   num1: numberToOutputString(1),

--- a/ui/oopsyraidsy/data/07-dt/trial/zoraal-ja.ts
+++ b/ui/oopsyraidsy/data/07-dt/trial/zoraal-ja.ts
@@ -1,0 +1,34 @@
+import ZoneId from '../../../../../resources/zone_id';
+import { OopsyData } from '../../../../../types/data';
+import { OopsyTriggerSet } from '../../../../../types/oopsy';
+
+export type Data = OopsyData;
+
+// TODO: Add trigger for missing Duty's Edge (party stack)
+
+const triggerSet: OopsyTriggerSet<Data> = {
+  zoneId: ZoneId.Everkeep,
+  damageWarn: {
+    'ZoraalJa Double-Edged Swords': '9352', // half-room cleave
+    'ZoraalJa Shadow Burst': '934D', // exploding adds - circle AoEs
+    'ZoraalJa Vorpal Trail 1': '9528', // collapsing swords - first set
+    'ZoraalJa Vorpal Trail 2': '9350', // collapsing swords - subsequent cleaves
+
+    'ZoraalJa Smiting Circuit Outside': '9366', // conut AoE
+    'ZoraalJa Smiting Circuit Inside': '9367', // point-blank circle AoE
+    'ZoraalJa Chasm of Vollok': '9358', // sword on main platform
+    'ZoraalJa Chasm of Vollok Mirror': '935A', // sword from mirror platform
+    'ZoraalJa Forged Track': '9361', // sword line cleave from mirror platform
+
+    'ZoraalJa Half Full': '936A', // half-room cleave
+    'ZoraalJa Half Circuit Left/Right': '936D', // half-room cleave
+    'ZoraalJa Half Circuit Dynamo': '936E', // donut AoE
+    'ZoraalJa Half Circuit Chariot': '936F', // point-blank circle AoE
+  },
+  shareWarn: {
+    'ZoraalJa Fire III': '9378', // spread AoEs
+  },
+  soloWarn: {},
+};
+
+export default triggerSet;

--- a/ui/raidboss/data/07-dt/trial/zoraal-ja.ts
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja.ts
@@ -426,6 +426,13 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
+      id: 'ZoraalJa Duty\'s Edge',
+      type: 'Ability',
+      // 9374 is the self-targeted ability; 8A#F is the player-targeeted stack marker (no 0x14 line though)
+      netRegex: { id: '8AEF', source: 'Zoraal Ja' },
+      response: Responses.stackMarkerOn(),
+    },
+    {
       id: 'ZoraalJa Half Full Right Sword',
       type: 'StartsUsing',
       netRegex: { id: '9368', source: 'Zoraal Ja', capture: false },

--- a/ui/raidboss/data/07-dt/trial/zoraal-ja.ts
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja.ts
@@ -1,0 +1,581 @@
+import Outputs from '../../../../../resources/outputs';
+import { Responses } from '../../../../../resources/responses';
+import { Directions } from '../../../../../resources/util';
+import ZoneId from '../../../../../resources/zone_id';
+import { RaidbossData } from '../../../../../types/data';
+import { TriggerSet } from '../../../../../types/trigger';
+
+// TODO: Possibly add combo outputs for Vorpal/Double-Edged & Burst/Double-Edged?
+
+const syncPlatforms = ['northwest', 'northeast', 'southwest', 'southeast'] as const;
+type Platform = typeof syncPlatforms[number] | 'none';
+
+const tileNames = [
+  'northCorner',
+  'northwestNorth',
+  'northeastNorth',
+  'northwestWest',
+  'insideNorth',
+  'northeastEast',
+  'westCorner',
+  'insideWest',
+  'insideEast',
+  'eastCorner',
+  'southwestWest',
+  'insideSouth',
+  'southeastEast',
+  'southwestSouth',
+  'southeastSouth',
+  'southCorner',
+] as const;
+
+type TileName = typeof tileNames[number] | 'unknown';
+type TileMap = { [y: number]: { [x: number]: TileName } };
+
+const syncTilesMap: TileMap = {
+  // y1: { x1: tileName, x2: tileName, etc. }
+  // Use rounded ints for all positions to avoid fuzzy floating point values on StartsUsing lines
+  89: { 100: 'northCorner' },
+  93: {
+    96: 'northwestNorth',
+    104: 'northeastNorth',
+  },
+  96: {
+    93: 'northwestWest',
+    100: 'insideNorth',
+    107: 'northeastEast',
+  },
+  100: {
+    89: 'westCorner',
+    96: 'insideWest',
+    104: 'insideEast',
+    111: 'eastCorner',
+  },
+  104: {
+    93: 'southwestWest',
+    100: 'insideSouth',
+    107: 'southeastEast',
+  },
+  107: {
+    96: 'southwestSouth',
+    104: 'southeastSouth',
+  },
+  111: { 100: 'southCorner' },
+};
+
+type MappedTile = {
+  tile: TileName;
+  from: Platform;
+};
+const findClosestTile: (
+  x: number,
+  y: number,
+  isMirror: boolean,
+  isForgedTrack: boolean,
+) => MappedTile = (x, y, isMirror, isForgedTrack) => {
+  const ret: MappedTile = {
+    tile: 'unknown',
+    from: 'none',
+  };
+
+  // Tiles are 5x5; mirror plat tiles are offset by 3 tiles from their main platform counterpart
+  // During Forged Track, Fang actors are positioned at the back edge, so we need a slightly
+  // larger adjustment value.
+  const adjustValue = isForgedTrack
+    ? 22.98 // sqrt(5^2 + 5^2) * 3.25
+    : 21.21; // sqrt(5^2 + 5^2) * 3
+
+  if (isMirror) {
+    if (x < 100 && y < 100) { // NW mirror platform
+      x += adjustValue;
+      y += adjustValue;
+      ret.from = 'northwest';
+    } else if (x < 100) { // SW mirror platform
+      x += adjustValue;
+      y -= adjustValue;
+      ret.from = 'southwest';
+    } else if (y < 100) { // NE mirror platform
+      x -= adjustValue;
+      y += adjustValue;
+      ret.from = 'northeast';
+    } else { // SE mirror platform
+      x -= adjustValue;
+      y -= adjustValue;
+      ret.from = 'southeast';
+    }
+  }
+
+  const tileValues = Object.keys(syncTilesMap).map(Number);
+  const closestX = tileValues.reduce((a, b) => Math.abs(b - x) < Math.abs(a - x) ? b : a);
+  const closestY = tileValues.reduce((a, b) => Math.abs(b - y) < Math.abs(a - y) ? b : a);
+
+  const possibleTiles = syncTilesMap[closestY];
+  if (possibleTiles === undefined) {
+    return ret;
+  }
+  const closestTile = possibleTiles[closestX];
+  if (closestTile === undefined) {
+    return ret;
+  }
+  ret.tile = closestTile;
+  return ret;
+};
+
+// Forged Track:
+// * In normal mode, the forged tracks always have the same pattern.
+//     - The NW/SE platforms have "wide XX" tethers (row 1->3, row 2->4, row 3->1, row 4->2)
+//     - The NE/SW platforms have "small XX" tethers (row 1->2, row 2->1, row 3->4, row 4->3)
+// * Forged Track initially fires from one platform, but later instances fire from multiple
+//   platforms simultaneously.
+// * There are multiple safe tiles each time, but calling multiple tiles will be confusing
+//   to the player, as we have to use directions + modifiers to properly identify each tile.
+//   To simplify this, because at least one of the inner four cardinal tiles is always safe,
+//   just call that. (PRs/user config options welcome!)
+
+// To determine the safe inner tile(s), given the fixed track patterns, we only care about swords
+// on corner tiles of mirror platforms (as they are the only ones that can cleave the inner 4 tiles).
+// If we know the sword platform and the corner the sword is placed in, we can map that through the
+// track patterns to specific inner tiles that are no longer safe.
+const cornerTiles = ['northCorner', 'eastCorner', 'southCorner', 'westCorner'] as const;
+type CornerTile = typeof cornerTiles[number];
+const isCornerTile = (t: TileName): t is CornerTile => cornerTiles.includes(t as CornerTile);
+
+// insideTiles: array order matters - lower idx values will be called first if safe
+const insideTiles = ['insideNorth', 'insideSouth', 'insideEast', 'insideWest'] as const;
+type InsideTile = typeof insideTiles[number];
+
+const forgedTrackCleaveMap: {
+  [K in Exclude<Platform, 'none'>]: Partial<Record<CornerTile, InsideTile[]>>;
+} = {
+  'northeast': { // small XX
+    'northCorner': ['insideNorth', 'insideWest'],
+    'eastCorner': ['insideEast', 'insideSouth'],
+  },
+  'southeast': { // wide XX
+    'eastCorner': ['insideSouth', 'insideWest'],
+    'southCorner': ['insideNorth', 'insideEast'],
+  },
+  'southwest': { // small XX
+    'southCorner': ['insideSouth', 'insideEast'],
+    'westCorner': ['insideWest', 'insideNorth'],
+  },
+  'northwest': { // wide XX
+    'westCorner': ['insideNorth', 'insideEast'],
+    'northCorner': ['insideWest', 'insideSouth'],
+  },
+};
+
+export interface Data extends RaidbossData {
+  bitterReapingTargets: string[];
+  seenFirstSync: boolean; // all future Chasm of Vollok swords are on mirror platforms
+  unsafeTiles: MappedTile[];
+  halfCircuitSafeSide?: 'left' | 'right';
+}
+
+const triggerSet: TriggerSet<Data> = {
+  id: 'Everkeep',
+  zoneId: ZoneId.Everkeep,
+  timelineFile: 'zoraal-ja.txt',
+  initData: () => ({
+    bitterReapingTargets: [],
+    seenFirstSync: false,
+    chasmOfVollokCount: 0,
+    unsafeTiles: [],
+  }),
+  triggers: [
+    // ********** PHASE 1 ********** //
+    {
+      id: 'ZoraalJa Soul Overflow',
+      type: 'StartsUsing',
+      netRegex: { id: '934B', source: 'Zoraal Ja', capture: false },
+      response: Responses.aoe(),
+    },
+    {
+      id: 'ZoraalJa Calamity\'s Edge',
+      type: 'StartsUsing',
+      netRegex: { id: '934C', source: 'Zoraal Ja', capture: false },
+      response: Responses.aoe(),
+    },
+    {
+      id: 'ZoraalJa Patricidal Pique',
+      type: 'StartsUsing',
+      netRegex: { id: '9353', source: 'Zoraal Ja' },
+      response: Responses.tankBuster(),
+    },
+    {
+      // Two invisible actors both use same cast id; we can determine order
+      // based on heading of the first actor to cast.
+      id: 'ZoraalJa Double-Edged Swords',
+      type: 'StartsUsingExtra',
+      netRegex: { id: '9352' },
+      durationSeconds: 7.3,
+      suppressSeconds: 4,
+      alertText: (_data, matches, output) => {
+        const hdgNum = Directions.hdgTo4DirNum(parseFloat(matches.heading));
+        return hdgNum === 0 ? output.backThenFront!() : output.frontThenBack!();
+      },
+      outputStrings: {
+        frontThenBack: Outputs.frontThenBack,
+        backThenFront: Outputs.backThenFront,
+      },
+    },
+    {
+      id: 'ZoraalJa Shadow Burst',
+      type: 'StartsUsing',
+      netRegex: { id: '934D', source: 'Shadow of Tural', capture: false },
+      delaySeconds: 3,
+      suppressSeconds: 1,
+      infoText: (_data, _matches, output) => output.away!(),
+      outputStrings: {
+        away: {
+          en: 'Away from adds',
+        },
+      },
+    },
+    {
+      id: 'ZoraalJa Vorpal Trail First',
+      type: 'StartsUsing',
+      netRegex: { id: '934E', source: 'Zoraal Ja', capture: false },
+      durationSeconds: 9.5,
+      infoText: (_data, _matches, output) => output.dodgeCombo!(),
+      outputStrings: {
+        dodgeCombo: {
+          en: 'Dodge contracting swords (front/back combo after)',
+        },
+      },
+    },
+    {
+      id: 'ZoraalJa Vorpal Trail Subsequent',
+      type: 'StartsUsing',
+      netRegex: { id: '934E', source: 'Zoraal Ja', capture: false },
+      delaySeconds: 11.5, // use the original cast + delay
+      durationSeconds: 9.5,
+      infoText: (_data, _matches, output) => output.dodge!(),
+      outputStrings: {
+        dodge: {
+          en: 'Dodge expanding swords',
+        },
+      },
+    },
+
+    // ********** PHASE 2 ********** //
+    {
+      id: 'ZoraalJa Soul Overflow Phase Transition',
+      type: 'StartsUsing',
+      netRegex: { id: '9370', source: 'Zoraal Ja', capture: false },
+      response: Responses.bigAoe('alert'),
+    },
+    {
+      id: 'ZoraalJa Dawn of an Age',
+      type: 'StartsUsing',
+      netRegex: { id: '9354', source: 'Zoraal Ja', capture: false },
+      response: Responses.aoe(),
+    },
+    {
+      id: 'ZoraalJa Actualize',
+      type: 'StartsUsing',
+      netRegex: { id: '9356', source: 'Zoraal Ja', capture: false },
+      response: Responses.aoe(),
+    },
+    {
+      id: 'ZoraalJa Smiting Circuit Outside',
+      type: 'StartsUsing',
+      netRegex: { id: '9366', source: 'Zoraal Ja', capture: false },
+      response: Responses.getUnder('alert'),
+    },
+    {
+      id: 'ZoraalJa Smiting Circuit Inside',
+      type: 'StartsUsing',
+      netRegex: { id: '9367', source: 'Zoraal Ja', capture: false },
+      response: Responses.getOut(),
+    },
+    {
+      id: 'ZoraalJa Bitter Reaping Collect',
+      type: 'StartsUsing',
+      netRegex: { id: '937A', source: 'Zoraal Ja' },
+      run: (data, matches) => data.bitterReapingTargets.push(matches.target),
+    },
+    {
+      id: 'ZoraalJa Bitter Reaping',
+      type: 'StartsUsing',
+      netRegex: { id: '937A', source: 'Zoraal Ja', capture: false },
+      delaySeconds: 0.2,
+      suppressSeconds: 1,
+      infoText: (data, _matches, output) => {
+        if (data.bitterReapingTargets.includes(data.me))
+          return output.busterOnYou!();
+        const players = data.bitterReapingTargets.map((x) => data.party.member(x).nick).join(
+          output.and!(),
+        );
+        return output.busters!({ player: players });
+      },
+      run: (data) => data.bitterReapingTargets = [],
+      outputStrings: {
+        busterOnYou: Outputs.tankBusterOnYou,
+        busters: Outputs.tankBusterOnPlayer,
+        and: Outputs.and,
+      },
+    },
+    {
+      id: 'ZoraalJa Sync Tracker',
+      type: 'StartsUsing',
+      netRegex: { id: '9359', source: 'Zoraal Ja', capture: false },
+      run: (data) => data.seenFirstSync = true,
+    },
+    {
+      id: 'ZoraalJa Chasm of Vollok Sword Collect',
+      type: 'StartsUsing',
+      netRegex: { id: '9358', source: 'Fang' },
+      run: (data, matches) => {
+        const swordX = parseFloat(matches.x);
+        const swordY = parseFloat(matches.y);
+        const mappedTile = findClosestTile(swordX, swordY, data.seenFirstSync, false);
+        if (mappedTile.tile === 'unknown')
+          return;
+        data.unsafeTiles.push(mappedTile);
+      },
+    },
+    {
+      id: 'ZoraalJa Chasm of Vollok',
+      type: 'StartsUsing',
+      netRegex: { id: '9358', source: 'Fang', capture: false },
+      delaySeconds: 0.2,
+      suppressSeconds: 1,
+      alertText: (data, _matches, output) => {
+        const unsafeTiles = data.unsafeTiles.map((t) => t.tile);
+        const safeCorner = cornerTiles.filter((tile) => !unsafeTiles.includes(tile));
+        if (safeCorner.length !== 1)
+          return;
+
+        const safe0 = safeCorner[0] ?? 'unknown';
+        return output[safe0]!();
+      },
+      run: (data) => data.unsafeTiles = [],
+      outputStrings: {
+        northCorner: Outputs.north,
+        eastCorner: Outputs.east,
+        southCorner: Outputs.south,
+        westCorner: Outputs.west,
+        unknown: {
+          en: 'Avoid swords',
+        },
+      },
+    },
+    {
+      id: 'ZoraalJa Forged Track Sword Collect',
+      type: 'StartsUsing',
+      netRegex: { id: '9361', source: 'Fang' },
+      run: (data, matches) => {
+        const swordX = parseFloat(matches.x);
+        const swordY = parseFloat(matches.y);
+        const mappedTile = findClosestTile(swordX, swordY, true, true);
+        if (mappedTile.tile === 'unknown')
+          return;
+        data.unsafeTiles.push(mappedTile);
+      },
+    },
+    {
+      id: 'ZoraalJa Forged Track',
+      type: 'StartsUsing',
+      netRegex: { id: '9361', source: 'Fang', capture: false },
+      delaySeconds: 2, // small delay to prevent overlapping calls when these happen in seq
+      durationSeconds: 10.5,
+      suppressSeconds: 1,
+      alertText: (data, _matches, output) => {
+        let possibleSafeTiles = [...insideTiles];
+        data.unsafeTiles.forEach((t) => {
+          const platform = t.from;
+          const tile = t.tile;
+          if (platform === 'none' || !isCornerTile(tile))
+            return;
+
+          const unsafeTiles = forgedTrackCleaveMap[platform][tile] ?? [];
+          possibleSafeTiles = possibleSafeTiles.filter((t) => !unsafeTiles.includes(t));
+        });
+
+        if (possibleSafeTiles.length > 2) {
+          console.error(`Unexpected excess safe tiles: ${possibleSafeTiles.join(',')}`);
+          return output.unknown!();
+        }
+        // There are 2 safe tiles when only 1 platform is firing; when 2 platforms are firing,
+        // only 1 inside tile is safe.  In either case, call the first safe tile in the array
+        // (using array order to prioritize).
+        const safe0 = possibleSafeTiles[0] ?? 'unknown';
+        if (safe0 === 'unknown')
+          console.error(`Could not determine safe tile - no remaining safe tiles found`);
+
+        return output[safe0]!();
+      },
+      run: (data) => data.unsafeTiles = [],
+      outputStrings: {
+        insideNorth: {
+          en: 'Inner North Diamond',
+        },
+        insideEast: {
+          en: 'Inner East Diamond',
+        },
+        insideSouth: {
+          en: 'Inner South Diamond',
+        },
+        insideWest: {
+          en: 'Inner West Diamond',
+        },
+        unknown: {
+          en: 'Avoid Line Cleaves',
+        },
+      },
+    },
+    {
+      id: 'ZoraalJa Half Full Right Sword',
+      type: 'StartsUsing',
+      netRegex: { id: '9368', source: 'Zoraal Ja', capture: false },
+      alertText: (_data, _matches, output) => output.left!(),
+      outputStrings: {
+        left: Outputs.left,
+      },
+    },
+    {
+      id: 'ZoraalJa Half Full Left Sword',
+      type: 'StartsUsing',
+      netRegex: { id: '9369', source: 'Zoraal Ja', capture: false },
+      alertText: (_data, _matches, output) => output.right!(),
+      outputStrings: {
+        right: Outputs.right,
+      },
+    },
+    {
+      id: 'Zoraal Ja Ex Half Circuit Left/Right Collect',
+      type: 'StartsUsing',
+      // 936B - Right Sword (left safe)
+      // 936C - Left Sword (right safe)
+      netRegex: { id: ['936B', '936C'], source: 'Zoraal Ja' },
+      run: (data, matches) => data.halfCircuitSafeSide = matches.id === '936B' ? 'left' : 'right',
+    },
+    {
+      id: 'Zoraal Ja Ex Half Circuit',
+      type: 'StartsUsing',
+      // 936E - Swords Out (in safe)
+      // 936F - Swords In (out safe)
+      netRegex: { id: ['936E', '936F'], source: 'Zoraal Ja' },
+      delaySeconds: 0.3, // let Left/Right Collect run first
+      alertText: (data, matches, output) => {
+        const inOut = matches.id === '936E' ? output.in!() : output.out!();
+        if (data.halfCircuitSafeSide === undefined)
+          return inOut;
+        return output.combo!({ inOut: inOut, side: output[data.halfCircuitSafeSide]!() });
+      },
+      outputStrings: {
+        left: {
+          en: 'Boss\'s Left',
+          de: 'Links vom Boss',
+          fr: 'À gauche du boss',
+          ja: 'ボスの左側',
+          cn: 'BOSS左侧',
+          ko: '보스 왼쪽',
+        },
+        right: {
+          en: 'Boss\'s Right',
+          de: 'Rechts vom Boss',
+          fr: 'À droite du boss',
+          ja: 'ボスの右側',
+          cn: 'BOSS右侧',
+          ko: '보스 오른쪽',
+        },
+        in: Outputs.getUnder,
+        out: Outputs.out,
+        combo: {
+          en: '${inOut} + ${side}',
+          de: '${inOut} + ${side}',
+          fr: '${inOut} + ${side}',
+          ja: '${inOut} + ${side}',
+          cn: '${inOut} + ${side}',
+          ko: '${inOut} + ${side}',
+        },
+      },
+    },
+  ],
+  timelineReplace: [
+    {
+      'locale': 'de',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Fang': 'Reißzahn',
+        'Zoraal Ja': 'Zoraal Ja',
+      },
+      'replaceText': {
+        'Actualize': 'Verwirklichung',
+        'Blade Warp': 'Klingensprung',
+        'Chasm of Vollok': 'Klippe von Vollok',
+        'Dawn of an Age': 'Dämmerung eines Zeitalters',
+        'Duty\'s Edge': 'Pflichtes Schneide',
+        'Forged Track': 'Unbestimmter Pfad',
+        'Half Circuit': 'Halbe Runde',
+        'Half Full': 'Halbes Ganzes',
+        'Sync(?![-h])': 'Synchro',
+        '(?<! )Vollok': 'Vollok',
+      },
+    },
+    {
+      'locale': 'fr',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Fang': 'crochet',
+        'Zoraal Ja': 'Zoraal Ja',
+      },
+      'replaceText': {
+        'Actualize': 'Actualisation',
+        'Blade Warp': 'Invocation incisive',
+        'Chasm of Vollok': 'Trappe de Vollok',
+        'Dawn of an Age': 'Âge de l\'aurore',
+        'Duty\'s Edge': 'Devoir d\'acier',
+        'Forged Track': 'Traque incisive',
+        'Half Circuit': 'Demi-circuit',
+        'Half Full': 'Demi-plénitude',
+        'Sync(?![-h])': 'Synchronisation',
+        '(?<! )Vollok': 'Vollok',
+      },
+    },
+    {
+      'locale': 'ja',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Fang': '双牙剣',
+        'Zoraal Ja': 'ゾラージャ',
+      },
+      'replaceText': {
+        'Actualize': 'アクチュアライズ',
+        'Blade Warp': 'サモンエッジ',
+        'Chasm of Vollok': 'ピット・オブ・ヴォロク',
+        'Dawn of an Age': 'ドーン・エイジ',
+        'Duty\'s Edge': 'デューティエッジ',
+        'Forged Track': 'エッジトラック',
+        'Half Circuit': 'ルーズハーフ・サーキット',
+        'Half Full': 'ルーズハーフ',
+        'Sync(?![-h])': 'シンクロナス',
+        '(?<! )Vollok': 'エッジ・ザ・ヴォロク',
+      },
+    },
+    {
+      'locale': 'cn',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Fang': '双牙剑',
+        'Zoraal Ja': '佐拉加',
+      },
+      'replaceText': {
+        'Actualize': '自我实现',
+        'Blade Warp': '利刃召唤',
+        'Chasm of Vollok': '无敌裂斩',
+        'Dawn of an Age': '新曦世纪',
+        'Duty\'s Edge': '责任之刃',
+        'Forged Track': '利刃冲',
+        'Half Circuit': '回旋半身残',
+        'Half Full': '半身残',
+        'Sync(?![-h])': '同步',
+        '(?<! )Vollok': '无敌刃',
+      },
+    },
+  ],
+};
+
+export default triggerSet;

--- a/ui/raidboss/data/07-dt/trial/zoraal-ja.ts
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja.ts
@@ -444,7 +444,7 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'Zoraal Ja Ex Half Circuit Left/Right Collect',
+      id: 'ZoraalJa Half Circuit Left/Right Collect',
       type: 'StartsUsing',
       // 936B - Right Sword (left safe)
       // 936C - Left Sword (right safe)
@@ -452,7 +452,7 @@ const triggerSet: TriggerSet<Data> = {
       run: (data, matches) => data.halfCircuitSafeSide = matches.id === '936B' ? 'left' : 'right',
     },
     {
-      id: 'Zoraal Ja Ex Half Circuit',
+      id: 'ZoraalJa Half Circuit',
       type: 'StartsUsing',
       // 936E - Swords Out (in safe)
       // 936F - Swords In (out safe)

--- a/ui/raidboss/data/07-dt/trial/zoraal-ja.txt
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja.txt
@@ -1,0 +1,188 @@
+### Everkeep
+# ZoneId: 1200
+
+# -ii 9351 93A6 9364 9365 9366 9367 937A 936A 936B 936C 936E 936F 9375 9376 8AEF
+# -ic "Fang"
+# -p 9370:300
+
+hideall "--Reset--"
+hideall "--sync--"
+
+##### PHASE 1 #####
+
+0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
+8.8 "--sync--" StartsUsing { id: "934B", source: "Zoraal Ja" }
+13.8 "Soul Overflow" Ability { id: "934B", source: "Zoraal Ja" }
+21.1 "--center--" Ability { id: "98E1", source: "Zoraal Ja" }
+27.4 "Double-edged Swords (first)" Ability { id: "9352", source: "Zoraal Ja" } window 5,1
+29.7 "Double-edged Swords (second)" #Ability { id: "9352", source: "Zoraal Ja" }
+37.9 "Patricidal Pique" Ability { id: "9353", source: "Zoraal Ja" }
+41.1 "--sync--" Ability { id: "98E1", source: "Zoraal Ja" }
+47.2 "Soul Overflow" Ability { id: "934B", source: "Zoraal Ja" }
+64.3 "Calamity's Edge" Ability { id: "934C", source: "Zoraal Ja" }
+73.1 "Burst" Ability { id: "934D", source: "Shadow of Tural" }
+78.5 "Patricidal Pique" Ability { id: "9353", source: "Zoraal Ja" }
+82.6 "--sync--" Ability { id: "98E1", source: "Zoraal Ja" }
+
+# The same ids get used for the Fang swords in close proximity, making syncs unreliable.
+87.5 "Vorpal Trail (contracting)" Ability { id: "934E", source: "Zoraal Ja" } duration 8.5
+95.5 "--sync--" Ability { id: "98E1", source: "Zoraal Ja" }
+98.0 "Vorpal Trail (expanding)" duration 8.5
+101.7 "Double-edged Swords (first)" Ability { id: "9352", source: "Zoraal Ja" } window 5,1
+103.9 "Double-edged Swords (second)" #Ability { id: "9352", source: "Zoraal Ja" }
+109.2 "--sync--" Ability { id: "98E1", source: "Zoraal Ja" }
+115.4 "Soul Overflow" Ability { id: "934B", source: "Zoraal Ja" }
+126.5 "Calamity's Edge" Ability { id: "934C", source: "Zoraal Ja" }
+134.8 "Double-edged Swords (first)" Ability { id: "9352", source: "Zoraal Ja" } window 5,1
+135.5 "Burst" Ability { id: "934D", source: "Shadow of Tural" }
+137.3 "Double-edged Swords (second)" #Ability { id: "9352", source: "Zoraal Ja" }
+
+# mini-loop until phase jump
+144.5 "--sync--" Ability { id: "98E1", source: "Zoraal Ja" }
+149.5 "Vorpal Trail (contracting)" Ability { id: "934E", source: "Zoraal Ja" } duration 8.5
+157.5 "--sync--" Ability { id: "98E1", source: "Zoraal Ja" }
+160.0 "Vorpal Trail (expanding)" duration 8.5
+163.9 "Double-edged Swords (first)" Ability { id: "9352", source: "Zoraal Ja" } window 5,1
+166.1 "Double-edged Swords (second)" #Ability { id: "9352", source: "Zoraal Ja" }
+175.3 "Calamity's Edge" Ability { id: "934C", source: "Zoraal Ja" }
+180.4 "--sync--" Ability { id: "98E1", source: "Zoraal Ja" } forcejump 144.5
+
+##### INTERMISSION #####
+
+293.0 "--sync--" StartsUsing { id: "9370", source: "Zoraal Ja" } window 293,1
+300.0 "Soul Overflow" Ability { id: "9370", source: "Zoraal Ja" }
+300.0 "--untargetable--"
+381.8 "--targetable--"
+
+##### PHASE 2 #####
+# Use NpcYell to detect the start of Phase 2 (since fight can reset to here)
+# Zoraal Ja: "This power is proof of my authority!"
+391.3 "--sync--" NpcYell { npcNameId: "2493", npcYellId: "44BF" } window 391.3,20
+399.0 "--sync--" Ability { id: "9355", source: "Zoraal Ja" }
+407.1 "Smiting Circuit" Ability { id: "9363", source: "Zoraal Ja" }
+418.1 "Smiting Circuit" Ability { id: "9363", source: "Zoraal Ja" }
+425.2 "--sync--" Ability { id: "9355", source: "Zoraal Ja" }
+433.3 "Dawn of an Age" Ability { id: "9354", source: "Zoraal Ja" }
+
+# platforms mini-phase 1
+447.4 "Vollok" Ability { id: "9357", source: "Zoraal Ja" }
+457.0 "Bitter Reaping" Ability { id: "9379", source: "Zoraal Ja" }
+465.7 "Vollok" Ability { id: "9357", source: "Zoraal Ja" }
+473.8 "Sync" Ability { id: "9359", source: "Zoraal Ja" }
+481.8 "Chasm of Vollok" Ability { id: "935A", source: "Zoraal Ja" }
+490.0 "Sync" Ability { id: "9359", source: "Zoraal Ja" }
+498.0 "Chasm of Vollok" Ability { id: "935A", source: "Zoraal Ja" }
+505.2 "Gateway" Ability { id: "935B", source: "Zoraal Ja" }
+513.3 "Blade Warp" Ability { id: "935E", source: "Zoraal Ja" }
+521.4 "Forged Track" Ability { id: "935F", source: "Zoraal Ja" }
+530.1 "--sync--" Ability { id: "9360", source: "Zoraal Ja" }
+534.7 "Forged Track" Ability { id: "935F", source: "Zoraal Ja" }
+543.4 "--sync--" Ability { id: "9360", source: "Zoraal Ja" }
+549.0 "Actualize" Ability { id: "9356", source: "Zoraal Ja" }
+556.2 "--sync--" Ability { id: "9355", source: "Zoraal Ja" }
+
+# arena mini-phase 1
+563.5 "Half Full" Ability { id: ["9368", "9369"], source: "Zoraal Ja" }
+575.0 "Half Circuit" Ability { id: "936D", source: "Zoraal Ja" }
+580.8 "Fire III" Ability { id: "9378", source: "Zoraal Ja" }
+587.2 "Half Circuit" Ability { id: "936D", source: "Zoraal Ja" }
+594.2 "--sync--" Ability { id: "9355", source: "Zoraal Ja" }
+
+# START OF LOOP
+602.3 "Dawn of an Age" Ability { id: "9354", source: "Zoraal Ja" }
+
+# platforms mini-phase 2
+616.4 "Gateway" Ability { id: "935B", source: "Zoraal Ja" }
+624.5 "Blade Warp" Ability { id: "935E", source: "Zoraal Ja" }
+632.6 "Forged Track" Ability { id: "935F", source: "Zoraal Ja" }
+641.3 "--sync--" Ability { id: "9360", source: "Zoraal Ja" }
+642.9 "Forged Track" Ability { id: "935F", source: "Zoraal Ja" }
+651.6 "--sync--" Ability { id: "9360", source: "Zoraal Ja" }
+657.1 "Duty's Edge (x4)" Ability { id: "9374", source: "Zoraal Ja" } duration 6.7
+672.9 "Vollok" Ability { id: "9357", source: "Zoraal Ja" }
+681.5 "Bitter Reaping" Ability { id: "9379", source: "Zoraal Ja" }
+691.3 "Sync" Ability { id: "9359", source: "Zoraal Ja" }
+699.3 "Chasm of Vollok" Ability { id: "935A", source: "Zoraal Ja" }
+699.5 "Sync" Ability { id: "9359", source: "Zoraal Ja" }
+703.7 "--sync--" Ability { id: "9355", source: "Zoraal Ja" }
+707.5 "Chasm of Vollok" Ability { id: "935A", source: "Zoraal Ja" }
+711.1 "Half Full" Ability { id: ["9368", "9369"], source: "Zoraal Ja" }
+719.1 "Duty's Edge (x4)" Ability { id: "9374", source: "Zoraal Ja" } duration 6.7
+735.9 "Actualize" Ability { id: "9356", source: "Zoraal Ja" }
+
+# arena mini-phase 2
+743.0 "--sync--" Ability { id: "9355", source: "Zoraal Ja" }
+751.4 "Half Circuit" Ability { id: "936D", source: "Zoraal Ja" }
+757.2 "Fire III" Ability { id: "9378", source: "Zoraal Ja" }
+763.6 "Half Circuit" Ability { id: "936D", source: "Zoraal Ja" }
+773.8 "Bitter Reaping" Ability { id: "9379", source: "Zoraal Ja" }
+781.6 "--sync--" Ability { id: "9355", source: "Zoraal Ja" }
+789.7 "Dawn of an Age" Ability { id: "9354", source: "Zoraal Ja" } forcejump 602.3
+# END OF LOOP
+
+# IGNORED ABILITIES
+# 8AEF --sync--
+# 9351 Double-edged Swords (cast)
+# 9364 Smiting Circuit (vfx?)
+# 9365 Smiting Circuit (vfx?)
+# 9366 Smiting Circuit (donut/damage - sync to 9363 cast instead)
+# 9367 Smiting Circuit (point-blank/damage - sync to 9363 cast instead)
+# 936A Half Full (damage)
+# 936B Half Circuit (vfx; right cleave)
+# 936C Half Circuit (vfx; left cleave)
+# 936E Half Circuit (dynamo; concurrent with 936D)
+# 936F Half Circuit (chariot; conccurrent with 936D)
+# 9375 Duty's Edge (vfx)
+# 9376 Duty's Edge (damage)
+# 937A Bitter Reaping (damage)
+# 93A6 攻撃 (phase 2 autos)
+
+# ALL ENCOUNTER ABILITIES
+# 1961 attack
+# 8AEF --sync--
+# 934B Soul Overflow
+# 934C Calamity's Edge
+# 934D Burst
+# 934E Vorpal Trail
+# 934F Vorpal Trail
+# 9350 Vorpal Trail
+# 9351 Double-edged Swords
+# 9352 Double-edged Swords
+# 9353 Patricidal Pique
+# 9354 Dawn of an Age
+# 9355 --sync--
+# 9356 Actualize
+# 9357 Vollok
+# 9358 Chasm of Vollok
+# 9359 Sync
+# 935A Chasm of Vollok
+# 935B Gateway
+# 935E Blade Warp
+# 935F Forged Track
+# 9360 --sync--
+# 9361 Forged Track
+# 9362 Forged Track
+# 9363 Smiting Circuit
+# 9364 Smiting Circuit
+# 9365 Smiting Circuit
+# 9366 Smiting Circuit
+# 9367 Smiting Circuit
+# 9368 Half Full
+# 9369 Half Full
+# 936A Half Full
+# 936B Half Circuit
+# 936C Half Circuit
+# 936D Half Circuit
+# 936E Half Circuit
+# 936F Half Circuit
+# 9370 Soul Overflow
+# 9374 Duty's Edge
+# 9375 Duty's Edge
+# 9376 Duty's Edge
+# 9378 Fire III
+# 9379 Bitter Reaping
+# 937A Bitter Reaping
+# 93A6 攻撃
+# 9527 Vorpal Trail
+# 9528 Vorpal Trail
+# 98E1 --sync--

--- a/ui/raidboss/data/07-dt/trial/zoraal-ja.txt
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja.txt
@@ -17,20 +17,20 @@ hideall "--sync--"
 27.4 "Double-edged Swords (first)" Ability { id: "9352", source: "Zoraal Ja" } window 5,1
 29.7 "Double-edged Swords (second)" #Ability { id: "9352", source: "Zoraal Ja" }
 37.9 "Patricidal Pique" Ability { id: "9353", source: "Zoraal Ja" }
-41.1 "--sync--" Ability { id: "98E1", source: "Zoraal Ja" }
+41.1 "--center--" Ability { id: "98E1", source: "Zoraal Ja" }
 47.2 "Soul Overflow" Ability { id: "934B", source: "Zoraal Ja" }
 64.3 "Calamity's Edge" Ability { id: "934C", source: "Zoraal Ja" }
 73.1 "Burst" Ability { id: "934D", source: "Shadow of Tural" }
 78.5 "Patricidal Pique" Ability { id: "9353", source: "Zoraal Ja" }
-82.6 "--sync--" Ability { id: "98E1", source: "Zoraal Ja" }
+82.6 "--center--" Ability { id: "98E1", source: "Zoraal Ja" }
 
 # The same ids get used for the Fang swords in close proximity, making syncs unreliable.
 87.5 "Vorpal Trail (contracting)" Ability { id: "934E", source: "Zoraal Ja" } duration 8.5
-95.5 "--sync--" Ability { id: "98E1", source: "Zoraal Ja" }
+95.5 "--center--" Ability { id: "98E1", source: "Zoraal Ja" }
 98.0 "Vorpal Trail (expanding)" duration 8.5
 101.7 "Double-edged Swords (first)" Ability { id: "9352", source: "Zoraal Ja" } window 5,1
 103.9 "Double-edged Swords (second)" #Ability { id: "9352", source: "Zoraal Ja" }
-109.2 "--sync--" Ability { id: "98E1", source: "Zoraal Ja" }
+109.2 "--center--" Ability { id: "98E1", source: "Zoraal Ja" }
 115.4 "Soul Overflow" Ability { id: "934B", source: "Zoraal Ja" }
 126.5 "Calamity's Edge" Ability { id: "934C", source: "Zoraal Ja" }
 134.8 "Double-edged Swords (first)" Ability { id: "9352", source: "Zoraal Ja" } window 5,1
@@ -38,14 +38,14 @@ hideall "--sync--"
 137.3 "Double-edged Swords (second)" #Ability { id: "9352", source: "Zoraal Ja" }
 
 # mini-loop until phase jump
-144.5 "--sync--" Ability { id: "98E1", source: "Zoraal Ja" }
+144.5 "--center--" Ability { id: "98E1", source: "Zoraal Ja" }
 149.5 "Vorpal Trail (contracting)" Ability { id: "934E", source: "Zoraal Ja" } duration 8.5
-157.5 "--sync--" Ability { id: "98E1", source: "Zoraal Ja" }
+157.5 "--center--" Ability { id: "98E1", source: "Zoraal Ja" }
 160.0 "Vorpal Trail (expanding)" duration 8.5
 163.9 "Double-edged Swords (first)" Ability { id: "9352", source: "Zoraal Ja" } window 5,1
 166.1 "Double-edged Swords (second)" #Ability { id: "9352", source: "Zoraal Ja" }
 175.3 "Calamity's Edge" Ability { id: "934C", source: "Zoraal Ja" }
-180.4 "--sync--" Ability { id: "98E1", source: "Zoraal Ja" } forcejump 144.5
+180.4 "--center--" Ability { id: "98E1", source: "Zoraal Ja" } forcejump 144.5
 
 ##### INTERMISSION #####
 
@@ -58,10 +58,10 @@ hideall "--sync--"
 # Use NpcYell to detect the start of Phase 2 (since fight can reset to here)
 # Zoraal Ja: "This power is proof of my authority!"
 391.3 "--sync--" NpcYell { npcNameId: "2493", npcYellId: "44BF" } window 391.3,20
-399.0 "--sync--" Ability { id: "9355", source: "Zoraal Ja" }
+399.0 "--center--" Ability { id: "9355", source: "Zoraal Ja" }
 407.1 "Smiting Circuit" Ability { id: "9363", source: "Zoraal Ja" }
 418.1 "Smiting Circuit" Ability { id: "9363", source: "Zoraal Ja" }
-425.2 "--sync--" Ability { id: "9355", source: "Zoraal Ja" }
+425.2 "--center--" Ability { id: "9355", source: "Zoraal Ja" }
 433.3 "Dawn of an Age" Ability { id: "9354", source: "Zoraal Ja" }
 
 # platforms mini-phase 1
@@ -79,14 +79,14 @@ hideall "--sync--"
 534.7 "Forged Track" Ability { id: "935F", source: "Zoraal Ja" }
 543.4 "--sync--" Ability { id: "9360", source: "Zoraal Ja" }
 549.0 "Actualize" Ability { id: "9356", source: "Zoraal Ja" }
-556.2 "--sync--" Ability { id: "9355", source: "Zoraal Ja" }
+556.2 "--center--" Ability { id: "9355", source: "Zoraal Ja" }
 
 # arena mini-phase 1
 563.5 "Half Full" Ability { id: ["9368", "9369"], source: "Zoraal Ja" }
 575.0 "Half Circuit" Ability { id: "936D", source: "Zoraal Ja" }
 580.8 "Fire III" Ability { id: "9378", source: "Zoraal Ja" }
 587.2 "Half Circuit" Ability { id: "936D", source: "Zoraal Ja" }
-594.2 "--sync--" Ability { id: "9355", source: "Zoraal Ja" }
+594.2 "--center--" Ability { id: "9355", source: "Zoraal Ja" }
 
 # START OF LOOP
 602.3 "Dawn of an Age" Ability { id: "9354", source: "Zoraal Ja" }
@@ -104,19 +104,19 @@ hideall "--sync--"
 691.3 "Sync" Ability { id: "9359", source: "Zoraal Ja" }
 699.3 "Chasm of Vollok" Ability { id: "935A", source: "Zoraal Ja" }
 699.5 "Sync" Ability { id: "9359", source: "Zoraal Ja" }
-703.7 "--sync--" Ability { id: "9355", source: "Zoraal Ja" }
+703.7 "--center--" Ability { id: "9355", source: "Zoraal Ja" }
 707.5 "Chasm of Vollok" Ability { id: "935A", source: "Zoraal Ja" }
 711.1 "Half Full" Ability { id: ["9368", "9369"], source: "Zoraal Ja" }
 719.1 "Duty's Edge (x4)" Ability { id: "9374", source: "Zoraal Ja" } duration 6.7
 735.9 "Actualize" Ability { id: "9356", source: "Zoraal Ja" }
 
 # arena mini-phase 2
-743.0 "--sync--" Ability { id: "9355", source: "Zoraal Ja" }
+743.0 "--center--" Ability { id: "9355", source: "Zoraal Ja" }
 751.4 "Half Circuit" Ability { id: "936D", source: "Zoraal Ja" }
 757.2 "Fire III" Ability { id: "9378", source: "Zoraal Ja" }
 763.6 "Half Circuit" Ability { id: "936D", source: "Zoraal Ja" }
 773.8 "Bitter Reaping" Ability { id: "9379", source: "Zoraal Ja" }
-781.6 "--sync--" Ability { id: "9355", source: "Zoraal Ja" }
+781.6 "--center--" Ability { id: "9355", source: "Zoraal Ja" }
 789.7 "Dawn of an Age" Ability { id: "9354", source: "Zoraal Ja" } forcejump 602.3
 # END OF LOOP
 
@@ -150,7 +150,7 @@ hideall "--sync--"
 # 9352 Double-edged Swords
 # 9353 Patricidal Pique
 # 9354 Dawn of an Age
-# 9355 --sync--
+# 9355 --sync-- (re-center)
 # 9356 Actualize
 # 9357 Vollok
 # 9358 Chasm of Vollok
@@ -185,4 +185,4 @@ hideall "--sync--"
 # 93A6 攻撃
 # 9527 Vorpal Trail
 # 9528 Vorpal Trail
-# 98E1 --sync--
+# 98E1 --sync-- (re-center)


### PR DESCRIPTION
Tested in emulator and in game.

This re-uses a lot of the tile calculation logic I did for EverkeepEx, but determining/calling safe spots is handled a little differently because the forged track patterns are both fixed and simpler.  For calling Forged Track, it will call a single inner safe tile regardless of how many tiles are actually safe, with priority given to the inner N/S tiles.  I *think* this probably fine, but given the recent discussion on #429 & #431, I wanted to mention that.  If folks prefer a different priority order, feel free to PR a config option, but I think this is fine for an initial pass at least.