### PR TITLE
raidboss: fix race condition in EverkeepEx Forged Track

### DIFF
--- a/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.ts
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja-ex.ts
@@ -542,6 +542,8 @@ const triggerSet: TriggerSet<Data> = {
           data.lineCleaveSetup = 'swCross';
         else if (matches.location === '03')
           data.lineCleaveSetup = 'seCross';
+        else
+          console.error('Could not determine Forged Track setup.');
       },
     },
     {
@@ -571,8 +573,12 @@ const triggerSet: TriggerSet<Data> = {
         }
 
         const swordTile = findClosestTile(swordX, swordY);
-        if (swordTile === 'unknown')
+        if (swordTile === 'unknown') {
+          console.error(
+            `Could not map fire/wind sword at [x:${matches.x}, y: ${matches.y}] to tile.`,
+          );
           return;
+        }
 
         // To avoid repeated nested if/else statements, assume we're seeing fireInside.
         // At the end, check the real value, and if it's fireOutside, just flip this bool
@@ -600,8 +606,10 @@ const triggerSet: TriggerSet<Data> = {
           data.fireWindSafeDir = 'southwest';
         else if (swordTile === 'westCorner')
           data.fireWindSafeDir = 'northeast';
-        else
+        else {
+          console.error(`Could not determine fireWindSafeDir for swordTile ${swordTile}`);
           return;
+        }
 
         data.forgedTrackSafeTiles = forgedTrackSafeLanes[data.fireWindSafeDir];
 
@@ -615,10 +623,16 @@ const triggerSet: TriggerSet<Data> = {
       type: 'StartsUsing',
       netRegex: { id: '939C', source: 'Fang' },
       condition: (data, matches) => data.phase === 'swords' && parseFloat(matches.y) > 115, // line cleave swords
-      delaySeconds: 0.2, // let Fire/Wind Collect run first
+      delaySeconds: 0.4, // let Fire/Wind Collect run first
       run: (data, matches) => {
-        if (data.lineCleaveSetup === undefined || data.forgedTrackSafeTiles.length !== 4)
+        if (data.lineCleaveSetup === undefined || data.forgedTrackSafeTiles.length !== 4) {
+          console.error(
+            `Could not determine lineCleaveSetup (${
+              data.lineCleaveSetup ?? 'undef'
+            }) or valid safe tiles (${data.forgedTrackSafeTiles.join(',')}).`,
+          );
           return;
+        }
 
         const mirrorAdjust = 22.98; // sqrt(5^2 + 5^2) * 3.25
         const swordY = parseFloat(matches.y) - mirrorAdjust;
@@ -634,15 +648,21 @@ const triggerSet: TriggerSet<Data> = {
           lineCleavePlatform = 'southeast';
         }
         const swordTile = findClosestTile(swordX, swordY);
-        if (swordTile === 'unknown')
-          return `Unknown Tile`;
+        if (swordTile === 'unknown') {
+          console.error(`Could not map cleave sword at [x:${matches.x}, y: ${matches.y}] to tile.`);
+          return;
+        }
 
         const unsafeTiles = swordTile === 'southCorner'
           ? crossMapSouthCorner[data.lineCleaveSetup][lineCleavePlatform]
           : crossMap[data.lineCleaveSetup][swordTile];
 
-        if (unsafeTiles === undefined)
+        if (unsafeTiles === undefined) {
+          console.error(
+            `Could not determine unsafe tiles for cleave sword at [x:${matches.x}, y: ${matches.y}]`,
+          );
           return;
+        }
         data.unsafeTiles.push(...unsafeTiles);
       },
     },
@@ -651,7 +671,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'StartsUsing',
       netRegex: { id: '935F', source: 'Zoraal Ja', capture: false },
       condition: (data) => data.phase === 'swords',
-      delaySeconds: 0.4, // let the collectors finish
+      delaySeconds: 0.6, // let the collectors finish
       durationSeconds: 9,
       alertText: (data, _matches, output) => {
         if (data.fireWindEffect === undefined)
@@ -671,8 +691,11 @@ const triggerSet: TriggerSet<Data> = {
         const safeTiles = data.forgedTrackSafeTiles.filter((tile) =>
           !data.unsafeTiles.includes(tile)
         );
-        if (safeTiles.length !== 2)
-          return `WTF? ${safeTiles.length} = ${safeTiles.join('|')}`;
+        if (safeTiles.length !== 2) {
+          console.error(`Expected 2 safe tiles, got ${safeTiles.length}: ${safeTiles.join(',')}`);
+          return output.unknown!();
+        }
+
         const [safe0] = safeTiles;
         if (safe0 === undefined)
           return fireWindSafeOutput;


### PR DESCRIPTION
Cleaning up a (::cough::) stray error message I left in Forged Track that was never intended as a trigger output, and also fixed the race condition issue that was occasionally causing it to fire (along with slightly improved error logging.)