### PR TITLE
raidemulator: re-order validation checks for delay prop

### DIFF
--- a/ui/raidboss/emulator/overrides/RaidEmulatorPopupText.ts
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorPopupText.ts
@@ -203,7 +203,7 @@ export default class RaidEmulatorPopupText extends StubbedPopupText {
       ? triggerHelper.valueOrFunction(triggerHelper.trigger.delaySeconds)
       : 0;
 
-    if (delay === undefined || delay === null || delay <= 0 || typeof delay !== 'number')
+    if (delay === undefined || delay === null || typeof delay !== 'number' || delay <= 0)
       return;
 
     let ret: Promise<void>;


### PR DESCRIPTION
This fixes a pesky TS compiler warning about doing a number comparison before the type is constrained:
![image](https://github.com/user-attachments/assets/0751fad8-e67c-4917-9aee-2be4226aa77a)
