### PR TITLE
util: fix null check in find_missing_translations

### DIFF
--- a/util/find_missing_timeline_translations.ts
+++ b/util/find_missing_timeline_translations.ts
@@ -16,7 +16,7 @@ import { TimelineParser, TimelineReplacement } from '../ui/raidboss/timeline_par
 import { ErrorFuncType } from './find_missing_translations';
 
 const isKeyOf = <T>(key: unknown, obj: T): key is keyof T => {
-  if (typeof obj !== 'object')
+  if (typeof obj !== 'object' || obj === null)
     return false;
   if (Array.isArray(obj))
     return false;


### PR DESCRIPTION
In the spirit of dealing with pesky persistent TS compiler warnings, this adds an explicit null check in find_missing_translations.  
![image](https://github.com/user-attachments/assets/f67e39b6-04f6-4215-b445-e722a3239638)

(Gotta love historical JS quirks like 'null' having the same type tag as objects...)
