### PR TITLE
raidboss: include safe players when calling pass debuff

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r4s.ts
+++ b/ui/raidboss/data/07-dt/raid/r4s.ts
@@ -1287,10 +1287,17 @@ const triggerSet: TriggerSet<Data> = {
       delaySeconds: 0.2,
       suppressSeconds: 1,
       infoText: (data, _matches, output) => {
-        if (data.mustardBombTargets.includes(data.me))
-          return output.passDebuff!();
-        else if (!data.kindlingCauldronTargets.includes(data.me))
+        if (data.mustardBombTargets.includes(data.me)) {
+          const safePlayers = data.party.partyNames.filter((m) =>
+            !data.kindlingCauldronTargets.includes(m) &&
+            !data.mustardBombTargets.includes(m)
+          );
+          const toStr = safePlayers.map((m) => data.party.member(m).nick).join(', ');
+
+          return output.passDebuff!({ to: toStr });
+        } else if (!data.kindlingCauldronTargets.includes(data.me)) {
           return output.getDebuff!();
+        }
       },
       run: (data) => {
         data.mustardBombTargets = [];
@@ -1298,12 +1305,12 @@ const triggerSet: TriggerSet<Data> = {
       },
       outputStrings: {
         passDebuff: {
-          en: 'Pass Debuff',
-          de: 'Debuff übergeben',
-          fr: 'Donner le debuff',
-          ja: 'デバフを渡して',
-          cn: '传火',
-          ko: '디버프 전달',
+          en: 'Pass Debuff (${to})',
+          de: 'Debuff übergeben (${to})',
+          fr: 'Donner le debuff (${to})',
+          ja: 'デバフを渡して (${to})',
+          cn: '传火 (${to})',
+          ko: '디버프 전달 (${to})',
         },
         getDebuff: {
           en: 'Get Debuff',


### PR DESCRIPTION
After mustard bomb goes off, the tanks need to transfer a debuff to one
of the players who was not hit by kindling cauldron. Currently we just
call out "pass debuff".

We already have the data required to determine who is safe to pass the
debuff to. Filter the list of party names to and include the shortened
names of the players who its safe to pass to.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
