### PR TITLE
raidboss: update Left/Right Roll calls for consistency

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r4s.ts
+++ b/ui/raidboss/data/07-dt/raid/r4s.ts
@@ -952,13 +952,13 @@ const triggerSet: TriggerSet<Data> = {
       id: 'R4S Left Roll',
       type: 'Ability',
       netRegex: { id: '95D3', source: 'Wicked Thunder', capture: false },
-      response: Responses.goLeft(),
+      response: Responses.goWest(),
     },
     {
       id: 'R4S Right Roll',
       type: 'Ability',
       netRegex: { id: '95D2', source: 'Wicked Thunder', capture: false },
-      response: Responses.goRight(),
+      response: Responses.goEast(),
     },
     {
       id: 'R4S Electron Stream Debuff',


### PR DESCRIPTION
Changes M4S Left/Right Roll calls to be consistent with M4N (uses `<= Get Left/West` and `Get Right/East =>` instead of just `Left` and `Right`).