### PR TITLE
raidboss: Tweak Twilight Sabbath triggers

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r4s.ts
+++ b/ui/raidboss/data/07-dt/raid/r4s.ts
@@ -252,7 +252,8 @@ export interface Data extends RaidbossData {
   mustardBombTargets: string[];
   kindlingCauldronTargets: string[];
   aetherialEffect?: AetherialEffect;
-  twilightSafe: DirectionOutputIntercard[];
+  twilightSafeFirst: DirectionOutputIntercard[];
+  twilightSafeSecond: DirectionOutputIntercard[];
   replicaCleaveCount: number;
   secondTwilightCleaveSafe?: DirectionOutputIntercard;
   midnightCardFirst?: boolean;
@@ -297,7 +298,8 @@ const triggerSet: TriggerSet<Data> = {
       replicas: {},
       mustardBombTargets: [],
       kindlingCauldronTargets: [],
-      twilightSafe: Directions.outputIntercardDir,
+      twilightSafeFirst: Directions.outputIntercardDir,
+      twilightSafeSecond: Directions.outputIntercardDir,
       replicaCleaveCount: 0,
       sunriseCannons: [],
       seenFirstSunrise: false,
@@ -1410,51 +1412,74 @@ const triggerSet: TriggerSet<Data> = {
 
     // Twilight Sabbath
     {
-      id: 'R4S Wicked Fire',
-      type: 'StartsUsing',
-      netRegex: { id: '9630', source: 'Wicked Thunder', capture: false },
-      infoText: (_data, _matches, output) => output.bait!(),
-      outputStrings: {
-        bait: Outputs.baitPuddles,
-      },
-    },
-    {
       id: 'R4S Twilight Sabbath Sidewise Spark',
-      type: 'GainsEffect',
-      // count: 319 - add cleaves to its right, 31A - add cleaves to its left
-      netRegex: { effectId: '808', count: ['319', '31A'] },
+      type: 'ActorControlExtra',
+      // category: 0197 - PlayActionTimeline
+      // param1: 11D6 - first,  right cleave
+      // param1: 11D7 - second, right cleave
+      // param1: 11D8 - first,  left cleave
+      // param1: 11D9 - second, left cleave
+      netRegex: { category: '0197', param1: ['11D6', '11D7', '11D8', '11D9'] },
       condition: (data) => data.phase === 'twilight',
+      // delay 0.1s to prevent out-of-order line issues
+      delaySeconds: 0.1,
       alertText: (data, matches, output) => {
         data.replicaCleaveCount++;
-        const dir = data.replicas[matches.targetId]?.location;
+        const dir = data.replicas[matches.id]?.location;
         if (dir === undefined || !isCardinalDir(dir))
           return;
 
-        const cleaveDir = matches.count === '319' ? 'right' : 'left';
+        const cleaveDir = ['11D6', '11D7'].includes(matches.param1) ? 'right' : 'left';
         const unsafeDirs = replicaCleaveUnsafeMap[dir][cleaveDir];
-        data.twilightSafe = data.twilightSafe.filter((d) => !unsafeDirs.includes(d));
 
-        if (data.replicaCleaveCount !== 2)
-          return;
-        const [safe0] = data.twilightSafe;
-        if (safe0 === undefined)
-          return;
+        const firstSet = ['11D6', '11D8'].includes(matches.param1);
 
-        // on the first combo, set the second safe spot to unknown, and return the first safe spot
-        // for second combo, just store the safe spot for a combined call with Wicked Special
-        if (!data.secondTwilightCleaveSafe) {
-          data.secondTwilightCleaveSafe = 'unknown';
-          return output[safe0]!();
+        if (firstSet) {
+          data.twilightSafeFirst = data.twilightSafeFirst.filter((d) => !unsafeDirs.includes(d));
+        } else {
+          data.twilightSafeSecond = data.twilightSafeSecond.filter((d) => !unsafeDirs.includes(d));
         }
-        data.secondTwilightCleaveSafe = safe0;
+
+        // Once we have all four accounted for, set our second spot for use in Wicked Special combo,
+        // and then return our first safe spot
+        if (data.replicaCleaveCount !== 4)
+          return;
+
+        const [safeSecond] = data.twilightSafeSecond;
+
+        data.secondTwilightCleaveSafe = safeSecond;
+
+        if (data.secondTwilightCleaveSafe === undefined) {
+          data.secondTwilightCleaveSafe = 'unknown';
+        }
+
+        const [safeFirst] = data.twilightSafeFirst;
+
+        // If we couldn't find the first safe spot, at least remind players to bait puddles
+        if (safeFirst === undefined)
+          return output.bait!();
+
+        return output.combo!({ bait: output.bait!(), dir: output[safeFirst]!() });
       },
       run: (data) => {
-        if (data.replicaCleaveCount !== 2)
+        if (data.replicaCleaveCount !== 4)
           return;
         data.replicaCleaveCount = 0;
-        data.twilightSafe = Directions.outputIntercardDir;
+        data.twilightSafeFirst = Directions.outputIntercardDir;
+        data.twilightSafeSecond = Directions.outputIntercardDir;
       },
-      outputStrings: Directions.outputStringsIntercardDir,
+      outputStrings: {
+        ...Directions.outputStringsIntercardDir,
+        bait: Outputs.baitPuddles,
+        combo: {
+          en: '${bait} => ${dir}',
+          de: '${bait} => ${dir}',
+          fr: '${bait} => ${dir}',
+          ja: '${bait} => ${dir}',
+          cn: '${bait} => ${dir}',
+          ko: '${bait} => ${dir}',
+        },
+      },
     },
     {
       id: 'R4S Twilight Sabbath + Wicked Special',

--- a/ui/raidboss/data/07-dt/raid/r4s.ts
+++ b/ui/raidboss/data/07-dt/raid/r4s.ts
@@ -1423,6 +1423,7 @@ const triggerSet: TriggerSet<Data> = {
       condition: (data) => data.phase === 'twilight',
       // delay 0.1s to prevent out-of-order line issues
       delaySeconds: 0.1,
+      durationSeconds: 9,
       alertText: (data, matches, output) => {
         data.replicaCleaveCount++;
         const dir = data.replicas[matches.id]?.location;
@@ -1459,7 +1460,11 @@ const triggerSet: TriggerSet<Data> = {
         if (safeFirst === undefined)
           return output.bait!();
 
-        return output.combo!({ bait: output.bait!(), dir: output[safeFirst]!() });
+        return output.combo!({
+          bait: output.bait!(),
+          dir1: output[safeFirst]!(),
+          dir2: output[data.secondTwilightCleaveSafe]!(),
+        });
       },
       run: (data) => {
         if (data.replicaCleaveCount !== 4)
@@ -1472,12 +1477,12 @@ const triggerSet: TriggerSet<Data> = {
         ...Directions.outputStringsIntercardDir,
         bait: Outputs.baitPuddles,
         combo: {
-          en: '${bait} => ${dir}',
-          de: '${bait} => ${dir}',
-          fr: '${bait} => ${dir}',
-          ja: '${bait} => ${dir}',
-          cn: '${bait} => ${dir}',
-          ko: '${bait} => ${dir}',
+          en: '${bait} => ${dir1} => ${dir2}',
+          de: '${bait} => ${dir1} => ${dir2}',
+          fr: '${bait} => ${dir1} => ${dir2}',
+          ja: '${bait} => ${dir1} => ${dir2}',
+          cn: '${bait} => ${dir1} => ${dir2}',
+          ko: '${bait} => ${dir1} => ${dir2}',
         },
       },
     },


### PR DESCRIPTION
This PR detects safe spots for Twilight Sabbath earlier, and combines the bait trigger with the first safe direction trigger.

This one goes out to people with high latency or inconsistent ping, who don't have enough time to react to the safe direction trigger that currently exists.

Only tested in RaidEmulator so far, will test in-game during reclears on Tuesday (unless someone else can test before then).

Current triggers:
![image](https://github.com/user-attachments/assets/22956994-0371-48ad-a519-9bd3253511a3)

New triggers:
![image](https://github.com/user-attachments/assets/2a585fde-c618-43d3-b6cf-a2c830adc509)