### PR TITLE
build: Update actions/setup-node to v4

### DIFF
--- a/.github/actions/setup-js-env/action.yml
+++ b/.github/actions/setup-js-env/action.yml
@@ -3,7 +3,7 @@ description: "run actions/setup-node and `npm ci`"
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '20'
         cache: 'npm'


### PR DESCRIPTION
~~Update the typedef for node to v20, and~~ update the action.yml file to use setup-node@v4 which bumps its own dependencies to use node v20.

This fixes a warning during action builds, as well as aligning type hints more correctly with what the internal node types are.

(node v20 was required as of https://github.com/OverlayPlugin/cactbot/commit/4c5cf21e06e024f0133357cbce487c338d0ea960, but for some reason the action wasn't updated at the time)