### PR TITLE
raidboss: variable-length arrow substitution in tts

### DIFF
--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -1541,8 +1541,8 @@ export class PopupText {
       // * Korean TTS reads wrong with '1번째'
       triggerHelper.ttsText = triggerHelper.ttsText.replace('1번째', '첫번째');
       // * arrows at the front or the end are directions, e.g. "east =>"
-      triggerHelper.ttsText = triggerHelper.ttsText.replace(/[-=]>\s*$/g, '');
-      triggerHelper.ttsText = triggerHelper.ttsText.replace(/^\s*<[-=]/g, '');
+      triggerHelper.ttsText = triggerHelper.ttsText.replace(/[-=]+>\s*$/g, '');
+      triggerHelper.ttsText = triggerHelper.ttsText.replace(/^\s*<[-=]+/g, '');
       // * arrows in the middle are a sequence, e.g. "in => out => spread"
       const arrowReplacement = {
         en: ' then ',


### PR DESCRIPTION
As discussed in #458 and #464.

Right now, tts will strip an arrow (`<=`, `<-`, `=>`, or `->`) at the beginning or end of an output string so it does not get spoken.  Arrows in the middle of a string are spoken as `then` (translated as needed).

This allows the beginning/end arrows to be variable length (e.g., `<==` or `<---`) and still be stripped, so we don't end up with partial substitution weirdness (e.g., tts speaking `equals` when `<==` is stripped to `=`).  