### PR TITLE
test: add unit test for mid-sring long arrows

### DIFF
--- a/test/helper/test_trigger.ts
+++ b/test/helper/test_trigger.ts
@@ -553,6 +553,10 @@ const testTriggerFile = (file: string, info: TriggerSetInfo) => {
         // TODO: share this with popup-text.js?
         const paramRegex = /\${\s*([^}\s]+)\s*}/g;
 
+        // Test for long arrows (e.g. <---, ==>) in the middle of an output string
+        // that will cause bad tts output.
+        const longArrowRegex = /\S\s*(<[-=]{2,}|[-=]{2,}>)\s*\S/g;
+
         // key => [] of params
         const outputStringsParams: { [key: string]: string[] } = {};
 
@@ -577,6 +581,12 @@ const testTriggerFile = (file: string, info: TriggerSetInfo) => {
               );
               continue;
             }
+
+            if (longArrowRegex.test(template))
+              assert.fail(
+                `'${key}' in '${id}' outputStrings contains a mid-string long arrow: [${lang}]: '${template}'`,
+              );
+
 
             // Build params with a set for uniqueness, but store as an array later for ease of use.
             const params = new Set<string>();

--- a/test/helper/test_trigger.ts
+++ b/test/helper/test_trigger.ts
@@ -587,7 +587,6 @@ const testTriggerFile = (file: string, info: TriggerSetInfo) => {
                 `'${key}' in '${id}' outputStrings contains a mid-string long arrow: [${lang}]: '${template}'`,
               );
 
-
             // Build params with a set for uniqueness, but store as an array later for ease of use.
             const params = new Set<string>();
             template.replace(paramRegex, (fullMatch, key: string) => {

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.ts
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.ts
@@ -1613,7 +1613,7 @@ const triggerSet: TriggerSet<Data> = {
           de: 'Links vom Robot; Nach Außen schauen; 3. Fläche',
           fr: 'À gauche du Robot; Regardez à l\'extérieur; 3rd zone au sol',
           ja: '右上 外向き 懺悔3回目',
-          cn: '左-->机器人; 面向外侧; 水圈#3',
+          cn: '左->机器人; 面向外侧; 水圈#3',
           ko: '왼쪽 위 / 참회 #3',
         },
         marker2: {
@@ -1621,7 +1621,7 @@ const triggerSet: TriggerSet<Data> = {
           de: 'Hinten Rechts gegenüber vom Robot; zur Mitte schauen; 3. Fläche',
           fr: 'Revenez à l\'opposé droite du Robot; Regardez au milieu; 3rd zone au sol',
           ja: '左下 内向き 懺悔3回目',
-          cn: '右后<--机器人; 面向中间; 水圈#3',
+          cn: '右后<-机器人; 面向中间; 水圈#3',
           ko: '오른쪽 위 / 참회 #3',
         },
         marker3: {
@@ -1629,7 +1629,7 @@ const triggerSet: TriggerSet<Data> = {
           de: 'Hinten Links gegenüber vom Robot; keine Fläche',
           fr: 'Revenez à l\'opposé gauche du Robot; Pas de zone au sol',
           ja: '左上',
-          cn: '左后<--机器人; 无水圈',
+          cn: '左后<-机器人; 无水圈',
           ko: '왼쪽 아래',
         },
         marker4: {
@@ -1637,7 +1637,7 @@ const triggerSet: TriggerSet<Data> = {
           de: 'Rechts vom Robot; keine Fläche',
           fr: 'À droite du Robot; Pas de zone au sol',
           ja: '右下',
-          cn: '右-->机器人; 无水圈',
+          cn: '右->机器人; 无水圈',
           ko: '오른쪽 아래',
         },
         marker5: {
@@ -1645,7 +1645,7 @@ const triggerSet: TriggerSet<Data> = {
           de: 'Linke Robot Seite -> 1. Fläche',
           fr: 'Côté gauche du Robot-> 1st zone au sol',
           ja: '右ちょい上 懺悔1回目',
-          cn: '机器人左侧 --> 水圈#1',
+          cn: '机器人左侧 -> 水圈#1',
           ko: '왼쪽 / 참회 #1',
         },
         marker6: {
@@ -1653,7 +1653,7 @@ const triggerSet: TriggerSet<Data> = {
           de: 'Rechte Robot Seite -> 1. Fläche',
           fr: 'Côté droit du Robot-> 1st zone au sol',
           ja: '左ちょい上 懺悔1回目',
-          cn: '机器人右侧 --> 水圈#1',
+          cn: '机器人右侧 -> 水圈#1',
           ko: '오른쪽 / 참회 #1',
         },
         marker7: {
@@ -1661,7 +1661,7 @@ const triggerSet: TriggerSet<Data> = {
           de: 'Linke Robot Seite -> cardinal; 2. Fläche',
           fr: 'Côté gauche du Robot -> cardinal; 2nd zone au sol',
           ja: '右ちょい上 懺悔2回目',
-          cn: '机器人左侧 --> 边; 水圈#2',
+          cn: '机器人左侧 -> 边; 水圈#2',
           ko: '왼쪽 / 참회 #2',
         },
         marker8: {
@@ -1669,7 +1669,7 @@ const triggerSet: TriggerSet<Data> = {
           de: 'Rechte Robot Seite -> cardinal; 2. Fläche',
           fr: 'Côté droit du Robot -> cardinal; 2nd zone au sol',
           ja: '左ちょい上 懺悔2回目',
-          cn: '机器人右侧 --> 边; 水圈#2',
+          cn: '机器人右侧 -> 边; 水圈#2',
           ko: '오른쪽 / 참회 #2',
         },
       },


### PR DESCRIPTION
Per comment in #469 and discussion/fix in #465, this adds a unit test for mid-string long arrows (e.g. <--, ==+, etc.), as tts will not translate mid-string long arrows correctly.

(Running the unit test picked up a handful of mid-string long arrows in the TEA Wormhole trigger `cn` output strings, which are now fixed.)