### PR TITLE
oopsy: fix lower-case player id

### DIFF
--- a/ui/oopsyraidsy/damage_tracker.ts
+++ b/ui/oopsyraidsy/damage_tracker.ts
@@ -753,7 +753,7 @@ export class DamageTracker {
     this.job = e.detail.job;
     this.role = Util.jobToRole(this.job);
     this.ReloadTriggers();
-    this.playerStateTracker.SetPlayerId(e.detail.id.toString(16));
+    this.playerStateTracker.SetPlayerId(e.detail.id.toString(16).toUpperCase());
   }
 
   ProcessDataFiles(): void {

--- a/ui/oopsyraidsy/player_state_tracker.ts
+++ b/ui/oopsyraidsy/player_state_tracker.ts
@@ -211,7 +211,7 @@ export class PlayerStateTracker {
   }
 
   OnAddedCombatant(_line: string, splitLine: string[]): void {
-    const id = splitLine[logDefinitions.AddedCombatant.fields.id];
+    const id = splitLine[logDefinitions.AddedCombatant.fields.id]?.toUpperCase();
     const name = splitLine[logDefinitions.AddedCombatant.fields.name];
     const worldIdStr = splitLine[logDefinitions.AddedCombatant.fields.worldId];
     const jobStr = splitLine[logDefinitions.AddedCombatant.fields.job];
@@ -280,6 +280,7 @@ export class PlayerStateTracker {
   }
 
   SetPlayerId(id: string): void {
+    id = id.toUpperCase();
     if (this.myPlayerId === id)
       return;
     this.myPlayerId = id;


### PR DESCRIPTION
Closes #467.

This fixes the extraneous '???' entry that was showing up in oopsy mistake reporting.  The fix to party list handling in #447 ensures that the current player's id will always be in the party list.  However, oopsy's identification of the current player can come from `onPlayerChangedEvent` as well as `ChangePrimaryPlayer` lines, and in the former case, the player id was in lowercase, causing an extraneous entry in the player list when the current player was then (re-)added (in uppercase) from `PartyList`/`AddCombatant` lines.  This PR ensures that the current player id will always be in uppercase (and does so in several places to future-proof `PlayerStateTracker` and `DamageTracker` if those classes get used elsewhere later).

Massive thanks to @xiashtra who did the debugging, identified the cause, and tested the fix.