### PR TITLE
oopsy: add new helpers for missed/multiple events

### DIFF
--- a/test/helper/test_oopsy.ts
+++ b/test/helper/test_oopsy.ts
@@ -154,8 +154,9 @@ const testOopsyFile = (file: string, info: OopsyTriggerSetInfo) => {
 
     const abilityIdToId: { [abilityid: string]: string } = {};
     for (const field of oopsyMistakeMapKeys) {
-      for (const [id, abilityId] of Object.entries(triggerSet[field] ?? {})) {
+      for (const [id, detail] of Object.entries(triggerSet[field] ?? {})) {
         // Ignore TODOs from `util/sync_files.ts` that haven't been filled out.
+        const abilityId = typeof detail === 'string' ? detail : detail.id;
         if (abilityId.startsWith('TODO'))
           continue;
         const prevId = abilityIdToId[abilityId];

--- a/types/data.d.ts
+++ b/types/data.d.ts
@@ -58,6 +58,7 @@ export interface OopsyData {
   IsPlayerId: (x?: string) => boolean;
   DamageFromMatches: (matches: NetMatches['Ability']) => number;
   options: OopsyOptions;
+  collectors?: { [mistakeId: string]: string[] };
 
   /** @deprecated Use parseFloat instead */
   ParseLocaleFloat: (string: string) => number;

--- a/types/oopsy.d.ts
+++ b/types/oopsy.d.ts
@@ -116,6 +116,7 @@ export type MistakeDetails = {
 export type CollectMistakeDetails = MistakeDetails & {
   collectSeconds?: number; // time to collect before reporting
   suppressSeconds?: number; // time until the same mistake can be re-collected and reported
+  minCount?: number; // for `multipleX` triggers, the # of hits before a mistake is reported
 };
 
 export type MistakeMap = { [mistakeId: string]: string | MistakeDetails };

--- a/types/oopsy.d.ts
+++ b/types/oopsy.d.ts
@@ -31,7 +31,9 @@ export type InternalOopsyTriggerType =
   | 'Damage'
   | 'GainsEffect'
   | 'Share'
-  | 'Solo';
+  | 'Solo'
+  | 'Missed'
+  | 'Multiple';
 
 export type DeathReportData = {
   lang: Lang;
@@ -103,7 +105,21 @@ export type OopsyTrigger<Data extends OopsyData> =
     id: string;
   };
 
-type MistakeMap = { [mistakeId: string]: string };
+type MistakeRole = 'tank' | 'healer' | 'dps';
+
+export type MistakeDetails = {
+  id: string;
+  onlyForRole?: MistakeRole | MistakeRole[]; // only a mistake if player is in this/these roles
+  text?: LocaleText; // override default text for this mistake type
+};
+
+export type CollectMistakeDetails = MistakeDetails & {
+  collectSeconds?: number; // time to collect before reporting
+  suppressSeconds?: number; // time until the same mistake can be re-collected and reported
+};
+
+export type MistakeMap = { [mistakeId: string]: string | MistakeDetails };
+export type CollectMistakeMap = { [mistakeId: string]: string | CollectMistakeDetails };
 
 export type DataInitializeFunc<Data extends OopsyData> = () => Omit<Data, keyof OopsyData>;
 
@@ -124,6 +140,10 @@ export type OopsyMistakeMapFields = {
   shareFail?: MistakeMap;
   soloWarn?: MistakeMap;
   soloFail?: MistakeMap;
+  missedWarn?: CollectMistakeMap;
+  missedFail?: CollectMistakeMap;
+  multipleWarn?: CollectMistakeMap;
+  multipleFail?: CollectMistakeMap;
 };
 
 type SimpleOopsyTriggerSet<Data extends OopsyData> = {

--- a/ui/oopsyraidsy/damage_tracker.ts
+++ b/ui/oopsyraidsy/damage_tracker.ts
@@ -58,6 +58,7 @@ const collectMistakeDefaults = {
   id: 'DUMMY_VALUE', // gets set later
   collectSeconds: 1.5,
   suppressSeconds: 1.5,
+  minCount: 2,
 };
 
 const actorControlFadeInCommandPre62 = '40000010';
@@ -741,6 +742,7 @@ export class DamageTracker {
           // TODO: Add support for alliances if/once we have a config option?
           const trackList = data.party.partyNames_;
           const targeted = (data.collectors ??= {})[sanitizedMistakeId] ??= [];
+          const minCount = mistakeDetails.minCount; // for 'multiple'-type triggers
 
           let mistakePlayers: string[] = [];
           let triggerType: InternalOopsyTriggerType = 'Damage'; // default
@@ -754,7 +756,7 @@ export class DamageTracker {
           } else if (helperType === 'multiple') {
             triggerType = 'Multiple';
             mistakePlayers = trackList.filter(
-              (name) => targeted.filter((target) => target === name).length > 1,
+              (name) => targeted.filter((target) => target === name).length >= minCount,
             );
           }
 

--- a/ui/oopsyraidsy/oopsy_common.ts
+++ b/ui/oopsyraidsy/oopsy_common.ts
@@ -168,3 +168,20 @@ export const GetShareMistakeText = (
     ko: `${localeText['ko'] ?? localeText['en']} (같이 맞음: ${numTargets}명)`,
   };
 };
+
+export const GetMissedMistakeText = (ability: string | LocaleText): LocaleText => {
+  const localeText: LocaleText = typeof ability === 'string' ? { en: ability } : ability;
+  return {
+    en: `missed ${localeText['en']}`,
+  };
+};
+
+export const GetMultipleMistakeText = (
+  ability: string | LocaleText,
+  numHits: number,
+): LocaleText => {
+  const localeText: LocaleText = typeof ability === 'string' ? { en: ability } : ability;
+  return {
+    en: `${localeText['en']} (hit x${numHits})`,
+  };
+};

--- a/ui/oopsyraidsy/player_state_tracker.ts
+++ b/ui/oopsyraidsy/player_state_tracker.ts
@@ -156,17 +156,17 @@ export class PlayerStateTracker {
     this.triggerSets.push(set);
     for (const set of this.triggerSets) {
       for (const value of Object.values(set.damageWarn ?? {}))
-        this.mistakeDamageMap[value] = 'warn';
+        this.mistakeDamageMap[typeof value === 'object' ? value.id : value] = 'warn';
       for (const value of Object.values(set.damageFail ?? {}))
-        this.mistakeDamageMap[value] = 'fail';
+        this.mistakeDamageMap[typeof value === 'object' ? value.id : value] = 'fail';
       for (const value of Object.values(set.shareWarn ?? {}))
-        this.mistakeShareMap[value] = 'warn';
+        this.mistakeShareMap[typeof value === 'object' ? value.id : value] = 'warn';
       for (const value of Object.values(set.shareFail ?? {}))
-        this.mistakeShareMap[value] = 'fail';
+        this.mistakeShareMap[typeof value === 'object' ? value.id : value] = 'fail';
       for (const value of Object.values(set.soloWarn ?? {}))
-        this.mistakeSoloMap[value] = 'warn';
+        this.mistakeSoloMap[typeof value === 'object' ? value.id : value] = 'warn';
       for (const value of Object.values(set.soloFail ?? {}))
-        this.mistakeSoloMap[value] = 'fail';
+        this.mistakeSoloMap[typeof value === 'object' ? value.id : value] = 'fail';
     }
   }
 


### PR DESCRIPTION
This PR adds some new helpers to oopsy, specifically:
* **missedWarn/missedFail**: Generate a mistake for players who did **not** get hit by a particular action.  The most obvious glaring need for this is missing a party/light-party stack.
* **multipleWarn/multipleFail**: Generate a mistake for players who got hit multiple times by the same action.  Common uses would be getting hit by two role cleaves or more than X hits of a persistent ground effect, etc.

(These helpers are all on the current [oopsy to-do list](https://github.com/OverlayPlugin/cactbot/blob/main/docs/OopsyraidsyGuide.md#future-oopsy-work)).

To implement these helpers, this PR also extends the current `MistakeMap` type in oopsy to now accept params instead of just an action/effect id -- among other things, to make it possible to limit mistakes to particular roles, control the amount of time a missed/multiple mistake will collect for, override the default mistake text, etc.

Marking this as a draft for now because it still needs more in-game testing and some docs updates.  Would greatly appreciate any early feedback though.

