### PR TITLE
raidboss: use ActorControlExtra for sidewise spark cleaves

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r4n.ts
+++ b/ui/raidboss/data/07-dt/raid/r4n.ts
@@ -201,27 +201,20 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'R4N Clone Cleave Collector',
-      type: 'CombatantMemory',
-      // Filter to only enemy actors for performance
-      // TODO: Change this to an ActorControlExtra line if OverlayPlugin adds SetModelState as a valid category
-      netRegex: {
-        id: '4[0-9A-Fa-f]{7}',
-        pair: [{ key: 'WeaponId', value: ['33', '121'] }],
-        capture: true,
-      },
+      type: 'ActorControlExtra',
+      // category: 0197 - PlayActionTimeline
+      // param1: 11D6 - right cleave
+      // param1: 11D8 - left cleave
+      netRegex: { category: '0197', param1: ['11D6', '11D8'] },
       condition: (data, matches) => {
         const actorID = parseInt(matches.id, 16);
         const initActorData = data.actors.find((actor) => actor.ID === actorID);
         if (!initActorData)
           return false;
 
-        const weaponId = matches.pairWeaponId;
-        if (weaponId === undefined)
-          return false;
+        const cleaveDir = matches.param1 === '11D8' ? 'left' : 'right';
 
-        const cleaveDir = weaponId === '121' ? 'left' : 'right';
-
-        // Sometimes we get extra lines with weaponId changed. Update an existing actor if it's already in the array.
+        // Check for an existing entry in case we get extra lines
         const existingCleave = data.storedCleaves.find((cleave) => cleave.id === actorID);
         if (existingCleave !== undefined) {
           existingCleave.dir = cleaveDir;


### PR DESCRIPTION
Valarnin recently did some work to improve the Twilight Sabbath triggers
in m4s. He discovered that we can detect the Wicked Replica cleave
directions using the ActorControlExtra log lines with the 0197
'PlayActionTimeline' category.

Do the same in m4n, replacing the check for CombatantMemory trigger.
This should be more precise and less overhead. It is also slightly less
code.

As far as I can tell, all the clones use the same 11D6 and1 11D8 values
for their left or right cleave.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
