### PR TITLE
plugin: Fix offsets for global 7.1

### DIFF
--- a/plugin/CactbotEventSource/FFXIVProcessIntl.cs
+++ b/plugin/CactbotEventSource/FFXIVProcessIntl.cs
@@ -8,7 +8,7 @@ using RainbowMage.OverlayPlugin;
 
 namespace Cactbot {
   public class FFXIVProcessIntl : FFXIVProcess {
-    // Last updated for FFXIV 7.0
+    // Last updated for FFXIV 7.1
 
     [StructLayout(LayoutKind.Explicit)]
     public unsafe struct EntityMemory {
@@ -41,10 +41,10 @@ namespace Cactbot {
       [FieldOffset(0xC0)]
       public Single rotation;
 
-      [FieldOffset(0x1BC)]
+      [FieldOffset(0x1AC)]
       public CharacterDetails charDetails;
 
-      [FieldOffset(0x1E6)]
+      [FieldOffset(0x1D6)]
       public byte shieldPercentage;
     }
 


### PR DESCRIPTION
(probably, `shieldPercentage` should be merged into `CharacterDetails` as it's in the same internal struct in the game, but that's beyond the scope of this PR)

Fix offsets for EntityMemory for patch 7.1

Job sigs and offsets seem fine. Not sure if any jobs had actual job gauge data layout changes this patch, if so they can be fixed with a separate PR.