### PR TITLE
raidboss: ex3 timeline fix

### DIFF
--- a/ui/raidboss/data/07-dt/trial/queen-eternal-ex.txt
+++ b/ui/raidboss/data/07-dt/trial/queen-eternal-ex.txt
@@ -4,6 +4,9 @@
 # Phase two pulled from -r GBaArv7yzHnXck8D -rf 17
 # A lot of manual cleanup applied
 
+hideall "--Reset--"
+hideall "--sync--"
+
 # Phase one
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 13.1 "--sync--" StartsUsing { id: "A00C", source: "Queen Eternal" }


### PR DESCRIPTION
Small thing I caught when testing this a sec ago, just need to suppress the `--sync--`s