### PR TITLE
plugin: ko 7.0 signatures and memory

### DIFF
--- a/plugin/CactbotEventSource/FFXIVProcessKo.cs
+++ b/plugin/CactbotEventSource/FFXIVProcessKo.cs
@@ -8,7 +8,7 @@ using RainbowMage.OverlayPlugin;
 
 namespace Cactbot {
   public class FFXIVProcessKo : FFXIVProcess {
-    // Last updated for FFXIV 6.5
+    // Last updated for FFXIV 7.0
 
     [StructLayout(LayoutKind.Explicit)]
     public unsafe struct EntityMemory {
@@ -100,16 +100,16 @@ namespace Cactbot {
     // In combat boolean.
     // This address is written to by "mov [rax+rcx],bl" and has three readers.
     // This reader is "cmp byte ptr [ffxiv_dx11.exe+????????],00 { (0),0 }"
-    private static String kInCombatSignature = "803D????????000F95C04883C428";
-    private static int kInCombatSignatureOffset = -12;
+    private static String kInCombatSignature = "803D??????????74??488B03488BCBFF50";
+    private static int kInCombatSignatureOffset = -15;
     private static bool kInCombatSignatureRIP = true;
     // Because this line is a cmp byte line, the signature is not at the end of the line.
     private static int kInCombatRipOffset = 1;
 
     // A piece of code that reads the job data.
     // The pointer of interest is the first ???????? in the signature.
-    private static String kJobDataSignature = "488B0D????????4885C90F84????????488B05????????3C03";
-    private static int kJobDataSignatureOffset = -22;
+    private static String kJobDataSignature = "488B3D????????33ED";
+    private static int kJobDataSignatureOffset = -6;
     // The signature finds a pointer in the executable code which uses RIP addressing.
     private static bool kJobDataSignatureRIP = true;
 
@@ -277,6 +277,10 @@ namespace Cactbot {
                 return JObject.FromObject(*(SageJobMemory*)&p[0]);
             case EntityJob.RPR:
                 return JObject.FromObject(*(ReaperJobMemory*)&p[0]);
+            case EntityJob.VPR:
+                return JObject.FromObject(*(ViperJobMemory*)&p[0]);
+            case EntityJob.PCT:
+                return JObject.FromObject(*(PictomancerJobMemory*)&p[0]);
           }
           return null;
         }
@@ -357,7 +361,11 @@ namespace Cactbot {
       }
 
       [FieldOffset(0x00)]
-      public ushort songMilliseconds;
+      public ushort songMilliseconds; // 00~01
+
+      // 02~03 is related to song and songProcs, but not sure what it is.
+      // 02 changes upon songProcs/soulGauge/Coda changes.
+      // 03 set on 0b when song active, changes upon songProcs/soulGauge cost, but reset to 0b at next songProcs/soulGauge gain.
 
       [FieldOffset(0x04)]
       public byte songProcs;
@@ -365,8 +373,11 @@ namespace Cactbot {
       [FieldOffset(0x05)]
       public byte soulGauge;
 
-      [NonSerialized]
       [FieldOffset(0x06)]
+      public byte LastCodaCost;
+
+      [NonSerialized]
+      [FieldOffset(0x07)]
       private SongFlags songFlags;
 
       public String songName {
@@ -486,13 +497,10 @@ namespace Cactbot {
     [StructLayout(LayoutKind.Explicit)]
     public struct NinjaJobMemory {
       [FieldOffset(0x00)]
-      public ushort hutonMilliseconds;
-
-      [FieldOffset(0x02)]
       public byte ninkiAmount;
 
-      [FieldOffset(0x03)]
-      private byte hutonCount; // Why though?
+      [FieldOffset(0x02)]
+      public byte kazematoi;
     };
 
     [StructLayout(LayoutKind.Explicit)]
@@ -542,6 +550,12 @@ namespace Cactbot {
           return enochian_state.HasFlag(EnochianFlags.Paradox);
         }
       }
+
+      public int astralSoulStacks {
+        get {
+          return ((int)enochian_state >> 2) & 0x7; // = 0b111, to get the last 3 bits.
+        }
+      }
     };
 
     [StructLayout(LayoutKind.Explicit)]
@@ -564,58 +578,103 @@ namespace Cactbot {
 
     [StructLayout(LayoutKind.Explicit)]
     public struct SummonerJobMemory {
+      public enum ActiveArcanum : byte {
+        None = 0,
+        Ifrit = 1,
+        Titan = 2,
+        Garuda = 3,
+      }
+
+      [Flags]
+      public enum Stance : byte {
+        None = 0,
+        // 0-1 bits: AetherFlows
+        AetherFlow1 = 1 << 0,
+        AetherFlow2 = 1 << 1,
+        AetherFlow3 = AetherFlow1 | AetherFlow2,
+        // 2 bit: Phoenix Ready
+        Phoenix = 1 << 2,
+        // 3 bit: Solar Bahamut Ready
+        // FIXME: guessed, not tested
+        SolarBahamut = 1 << 3,
+        // 4 bit: Unknown
+        // 5-7 bits: Usable Arcanum
+        Ruby = 1 << 5, // Fire/Ifrit
+        Topaz = 1 << 6, // Earth/Titan
+        Emerald = 1 << 7, // Wind/Garuda
+      }
+
       [FieldOffset(0x00)]
       public ushort tranceMilliseconds;
 
       [FieldOffset(0x02)]
       public ushort attunementMilliseconds;
 
+      /// <summary>
+      /// 0x04: 0x17 = Summoned other than Carbuncle, 0x00 = Other Condition
+      /// </summary>
+      [NonSerialized]
+      [FieldOffset(0x04)]
+      private byte _summonStatus;
+
+      /// <summary>
+      /// (From right to left)
+      /// 1-2 bits: Active Primal
+      /// 3-5 bits: Counts of Attunement Stacks
+      [NonSerialized]
       [FieldOffset(0x06)]
-      public byte attunement;
+      private byte _attunement;
 
       [NonSerialized]
       [FieldOffset(0x07)]
-      private byte stance;
+      private Stance stance;
 
-      public string[] usableArcanum {
+      public bool summonStatus {
         get {
-          var arcanums = new List<string>();
-          if ((stance & 0x20) != 0)
-            arcanums.Add("Ruby"); // Fire/Ifrit
-          if ((stance & 0x40) != 0)
-            arcanums.Add("Topaz"); // Earth/Titan
-          if ((stance & 0x80) != 0)
-            arcanums.Add("Emerald"); // Wind/Garuda
+          return _summonStatus != 0;
+        }
+      }
 
-          return arcanums.ToArray();
+      public int attunement {
+        get {
+          return (_attunement >> 2) & 0x7; // = 0b111, to get the last 3 bits.
         }
       }
 
       public string activePrimal {
         get {
-          if ((stance & 0xC) == 0x4)
-            return "Ifrit";
-          else if ((stance & 0xC) == 0x8)
-            return "Titan";
-          else if ((stance & 0xC) == 0xC)
-            return "Garuda";
-          else
-            return null;
+          return ((ActiveArcanum)(_attunement & 0x3)).ToString();
         }
       }
 
-      public String nextSummoned {
+      public string[] usableArcanum {
         get {
-          if ((stance & 0x10) == 0)
-            return "Bahamut";
-          else
-            return "Phoenix";
+          var arcanums = new List<string>();
+          foreach (var flag in new List<Stance> { Stance.Ruby, Stance.Topaz, Stance.Emerald }) {
+            if (stance.HasFlag(flag))
+              arcanums.Add(flag.ToString());
+          }
+
+          return arcanums.ToArray();
+        }
+      }
+
+      public string nextSummoned {
+        get {
+          foreach (var flag in new List<Stance> { Stance.SolarBahamut, Stance.Phoenix }) {
+            if (stance.HasFlag(flag))
+              return flag.ToString();
+          }
+          return "Bahamut";
         }
       }
 
       public int aetherflowStacks {
         get {
-          return stance & 0x3;
+          return stance.HasFlag(Stance.AetherFlow3) ? 3 :
+                 stance.HasFlag(Stance.AetherFlow2) ? 2 :
+                 stance.HasFlag(Stance.AetherFlow1) ? 1 :
+                 0;
         }
       }
     };
@@ -640,9 +699,9 @@ namespace Cactbot {
     public struct MonkJobMemory {
       public enum Beast : byte {
         None = 0,
-        Coeurl = 1,
-        Opo = 2,
-        Raptor = 3,
+        Opo = 1,
+        Raptor = 2,
+        Coeurl = 3,
       }
 
       [FieldOffset(0x00)]
@@ -662,7 +721,14 @@ namespace Cactbot {
 
       [NonSerialized]
       [FieldOffset(0x04)]
+      private byte Fury;
+
+      [NonSerialized]
+      [FieldOffset(0x05)]
       private byte Nadi;
+
+      [FieldOffset(0x06)]
+      public ushort MasterfulReadyMilisecond;
 
       public string[] beastChakra {
         get {
@@ -673,7 +739,7 @@ namespace Cactbot {
 
       public bool solarNadi {
         get {
-          if ((Nadi & 0x4) == 0x4)
+          if ((Nadi & 0x2) == 0x2)
             return true;
           else
             return false;
@@ -682,10 +748,28 @@ namespace Cactbot {
 
       public bool lunarNadi {
         get {
-          if ((Nadi & 0x2) == 0x2)
+          if ((Nadi & 0x1) == 0x1)
             return true;
           else
             return false;
+        }
+      }
+
+      public int opoopoFury {
+        get {
+          return Fury & 0x3;
+        }
+      }
+
+      public int raptorFury {
+        get {
+          return (Fury >> 2) & 0x3;
+        }
+      }
+
+      public int coeurlFury {
+        get {
+          return (Fury >> 4) & 0x3;
         }
       }
     };
@@ -734,45 +818,52 @@ namespace Cactbot {
         Spear = 4,
         Ewer = 5,
         Spire = 6,
-        Lord = 0x70,
-        Lady = 0x80,
-      }
-
-      public enum Arcanum : byte {
-        None = 0,
-        Solar = 1,
-        Lunar = 2,
-        Celestial = 3,
+        Lord = 7,
+        Lady = 8,
       }
 
       [NonSerialized]
-      [FieldOffset(0x05)]
-      private byte _heldCard;
+      [FieldOffset(0x00)]
+      private ushort _card;
 
       [NonSerialized]
-      [FieldOffset(0x06)]
-      private byte _arcanumsmix;
+      [FieldOffset(0x02)]
+      private byte _nextdraw;
 
-      public string heldCard {
+      public string card1 {
         get {
-          return ((Card)(_heldCard & 0xF)).ToString();
+          return ((Card)(_card & 0xF)).ToString();
         }
       }
 
-      public string crownCard {
+      public string card2 {
         get {
-          return ((Card)(_heldCard & 0xF0)).ToString();
+          return ((Card)((_card >> 4) & 0xF)).ToString();
         }
       }
 
-      public string[] arcanums {
+        public string card3 {
         get {
-          var _arcanums = new List<Arcanum>();
-          for (var i = 0; i < 3; i++) {
-            int arcanum = (_arcanumsmix >> 2 * i) & 0x3;
-            _arcanums.Add((Arcanum)arcanum);
+          return ((Card)((_card >> 8) & 0xF)).ToString();
+        }
+      }
+
+      public string card4 {
+        get {
+          return ((Card)((_card >> 12) & 0xF)).ToString();
+        }
+      }
+
+      public string nextdraw {
+        get {
+          if (_nextdraw == 0)
+          {
+            return "Astral";
+          } else
+          {
+            return "Umbral";
           }
-          return _arcanums.Select(a => a.ToString()).Where(a => a != "None").ToArray();
+
         }
       }
     };
@@ -839,6 +930,115 @@ namespace Cactbot {
 
       [FieldOffset(0x05)]
       public byte voidShroud;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct ViperJobMemory {
+      public enum AdvancedCombo : byte {
+        Vicewinder = 1,
+        HuntersCoil = 2,
+        SwiftskinsCoil = 3,
+        Vicepit = 4,
+        HuntersDen = 5,
+        SwiftskinsDen = 6,
+        Reawaken = 7,
+        FirstGeneration = 8,
+        SecondGeneration = 9,
+        ThirdGeneration = 10,
+        FourthGeneration = 11,
+      }
+
+      [FieldOffset(0x00)]
+      public byte rattlingCoilStacks;
+
+      [FieldOffset(0x01)]
+      public byte anguineTribute;
+
+      [FieldOffset(0x02)]
+      public byte serpentOffering;
+
+      [NonSerialized]
+      [FieldOffset(0x03)]
+      private AdvancedCombo _advancedCombo;
+
+      public string advancedCombo {
+        get {
+          return _advancedCombo.ToString();
+        }
+      }
+
+      [FieldOffset(0x06)]
+      public ushort reawakenedTimer;
+    }
+
+
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct PictomancerJobMemory {
+      [Flags]
+      private enum CanvasFlags : byte {
+          Pom = 1,
+          Wing = 1 << 1,
+          Claw = 1 << 2,
+          Maw = 1 << 3,
+          Weapon = 1 << 4,
+          Landscape = 1 << 5,
+      }
+
+      [Flags]
+      private enum CreatureFlags : byte {
+          Pom = 1,
+          Wing = 1 << 1,
+          Claw = 1 << 2,
+          // Maw = 1 << 3, // Once you paint the Maw motif, it becomes a Madeen portrait.
+          MooglePortrait = 1 << 4,
+          MadeenPortrait = 1 << 5,
+      }
+
+      [FieldOffset(0x00)]
+      public byte paletteGauge;
+      [FieldOffset(0x02)]
+      public byte paint;
+
+      [NonSerialized]
+      [FieldOffset(0x03)]
+      private CanvasFlags canvasFlags;
+
+      public string creatureMotif {
+        get {
+          if (canvasFlags.HasFlag(CanvasFlags.Pom))
+            return "Pom";
+          if (canvasFlags.HasFlag(CanvasFlags.Wing))
+            return "Wing";
+          if (canvasFlags.HasFlag(CanvasFlags.Claw))
+            return "Claw";
+          if (canvasFlags.HasFlag(CanvasFlags.Maw))
+            return "Maw";
+          return "None";
+        }
+      }
+      public bool weaponMotif => canvasFlags.HasFlag(CanvasFlags.Weapon);
+      public bool landscapeMotif => canvasFlags.HasFlag(CanvasFlags.Landscape);
+
+      [NonSerialized]
+      [FieldOffset(0x04)]
+      private CreatureFlags creatureFlags;
+
+      public string[] depictions {
+        get {
+          var motifs = new List<string>();
+          if (creatureFlags.HasFlag(CreatureFlags.Pom))
+            motifs.Add("Pom");
+          if (creatureFlags.HasFlag(CreatureFlags.Wing))
+            motifs.Add("Wing");
+          if (creatureFlags.HasFlag(CreatureFlags.Claw))
+            motifs.Add("Claw");
+          return motifs.ToArray();
+        }
+      }
+
+      public bool mooglePortrait => creatureFlags.HasFlag(CreatureFlags.MooglePortrait);
+      public bool madeenPortrait => creatureFlags.HasFlag(CreatureFlags.MadeenPortrait);
     }
   }
 }


### PR DESCRIPTION
This is the 1st of PRs for the Korean client 7.0, which will be updated on December 3rd.

Maintenance: [2024-12-02 12:00](https://www.timeanddate.com/worldclock/converter.html?iso=20241202T030000&p1=235&p2=137&p3=64&p4=263&p5=195&p6=37&p7=33&p8=248) ~ [2024-12-03 18:00](https://www.timeanddate.com/worldclock/converter.html?iso=20241203T090000&p1=235&p2=137&p3=64&p4=263&p5=195&p6=37&p7=33&p8=248) (KST, 30 hours) 

- 1st (Here) https://github.com/OverlayPlugin/cactbot/pull/523
- 2nd https://github.com/OverlayPlugin/cactbot/pull/524
- 3rd https://github.com/OverlayPlugin/cactbot/pull/525

---

- Update plugin/CactbotEventSource/FFXIVProcessKo.cs
  - This is a copy of [PR #436](https://github.com/OverlayPlugin/cactbot/pull/436), cn 7.0.