### PR TITLE
raidboss: Fix minor bug with `TimelineParser.Translate`

### DIFF
--- a/ui/raidboss/timeline_parser.ts
+++ b/ui/raidboss/timeline_parser.ts
@@ -767,7 +767,7 @@ export class TimelineParser {
             timeline.options.ParserLanguage,
             timeline.replacements,
           ).params;
-          line = line.replace(/{[^}]*}/, `{ ${JSON.stringify(translatedParams)} }`);
+          line = line.replace(/{[^}]*}/, JSON.stringify(translatedParams));
         }
       }
 


### PR DESCRIPTION
Noticed a minor bug with `TimelineParser.Translate`. The opening/closing curly braces were being duplicated. This is visible in the output from `translate_timeline` and in the cactbot config UI's timeline editor:

Original timeline entry:
```
14.6 "Cyclonic Break 1 (targeted)" Ability { id: "9CD1", source: "Fatebreaker" }
```

"translated" line before bugfix:
```
14.6 "Cyclonic Break 1 (targeted)" Ability { {"id":"9CD1","source":"Fatebreaker"} }
```

"translated" line after bugfix:
```
14.6 "Cyclonic Break 1 (targeted)" Ability {"id":"9CD1","source":"Fatebreaker"}
```

It wasn't really causing any problems since these translated timelines weren't being re-parsed by anything, but it was bothering me.