### PR TITLE
build: Fix NPM package creation errors #535

### DIFF
--- a/.github/scripts/npm-package.cjs
+++ b/.github/scripts/npm-package.cjs
@@ -20,7 +20,7 @@ async function main() {
   fs.rmSync('dist', { recursive: true, force: true });
   fs.mkdirSync('npm-package');
 
-  await exec('npx tsc --declaration');
+  await exec('npx tsc -p tsconfig.npm.json --declaration');
   fs.renameSync('dist/ui', 'npm-package/ui');
   fsExtra.copySync('types', 'npm-package/types', {});
   fs.renameSync('dist/resources', 'npm-package/resources');

--- a/tsconfig.npm.json
+++ b/tsconfig.npm.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./ui",
+    "./types",
+    "./resources",
+    "./util",
+    "./test",
+    "./user"
+  ],
+  "exclude": [
+    "./dist"
+  ]
+}

--- a/tsconfig.npm.json
+++ b/tsconfig.npm.json
@@ -4,9 +4,7 @@
     "./ui",
     "./types",
     "./resources",
-    "./util",
-    "./test",
-    "./user"
+    "./util"
   ],
   "exclude": [
     "./dist"


### PR DESCRIPTION
#271 removed some paths from the default tsconfig, which causes issues when building the npm package.

This PR adds an npm package-specific tsconfig file to resolve the issue.