### PR TITLE
raidboss: Improvements to FRU P2 timeline

### DIFF
--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
@@ -493,6 +493,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       'locale': 'en',
       'replaceText': {
+        'Axe Kick/Scythe Kick': 'Axe/Scythe Kick',
         'Shining Armor + Frost Armor': 'Shining + Frost Armor',
         'Sinbound Fire III/Sinbound Thunder III': 'Sinbound Fire/Thunder',
       },

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
@@ -493,6 +493,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       'locale': 'en',
       'replaceText': {
+        'Shining Armor + Frost Armor': 'Shining + Frost Armor',
         'Sinbound Fire III/Sinbound Thunder III': 'Sinbound Fire/Thunder',
       },
     },

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
@@ -1,7 +1,7 @@
 ### FUTURES REWRITTEN (ULTIMATE)
 # ZoneId: 1238
 
-# -ii 9CB4 9CD8 9CD9 9CC9 9CCA 9CCC 9CCD 9CCF 9CE5 9CE6 9CE9
+# -ii 9CB4 9CD8 9CD9 9CC9 9CCA 9CCC 9CCD 9CCF 9CE5 9CE6 9CE9 9CF0 9D0C 9D0E 9D13
 # -p 9CFF:215.3 9D22:500.0 9D72:940.7
 
 hideall "--Reset--"
@@ -65,74 +65,74 @@ hideall "--sync--"
 200.0 "--sync--" MapEffect { flags: "00020001", location: "17" } window 200.0,0
 204.1 "--targetable--"
 210.3 "--sync--" StartsUsing { id: "9CFF", source: "Usurper of Frost" } window 210.3,0
-215.3 "Quadruple Slap" Ability { id: "9CFF", source: "Usurper of Frost" }
-219.4 "Quadruple Slap" Ability { id: "9D00", source: "Usurper of Frost" }
-224.5 "--sync--" Ability { id: "9CEF", source: "Usurper of Frost" }
+215.3 "Quadruple Slap 1" Ability { id: "9CFF", source: "Usurper of Frost" }
+219.4 "Quadruple Slap 2" Ability { id: "9D00", source: "Usurper of Frost" }
+224.5 "--jump south--" Ability { id: "9CEF", source: "Usurper of Frost" }
 228.8 "Mirror Image" Ability { id: "9CF4", source: "Usurper of Frost" }
 235.9 "Diamond Dust" Ability { id: "9D05", source: "Usurper of Frost" }
 239.0 "--untargetable--"
-244.9 "Axe Kick/Scythe Kick" Ability { id: ["9D0A", "9D0B"], source: "Oracle's Reflection" }
-245.8 "The House of Light" Ability { id: "9D0E", source: "Fatebreaker's Image" }
+244.6 "Axe Kick/Scythe Kick" Ability { id: ["9D0A", "9D0B"], source: "Oracle's Reflection" }
+245.5 "The House of Light" Ability { id: "9D0E", source: ["Fatebreaker's Image", "Oracle's Reflection", "Usurper Of Frost"] }
 247.2 "Frigid Stone" Ability { id: "9D07", source: "Usurper of Frost" }
 247.6 "Icicle Impact" Ability { id: "9D06", source: "Usurper of Frost" }
-248.4 "--sync--" Ability { id: "9CEF", source: "Oracle's Reflection" }
+248.4 "--center--" Ability { id: "9CEF", source: "Oracle's Reflection" }
 251.5 "Heavenly Strike" Ability { id: "9D0F", source: "Usurper of Frost" }
 251.6 "Icicle Impact" Ability { id: "9D06", source: "Usurper of Frost" }
 254.2 "Frigid Needle" Ability { id: "9D08", source: "Usurper of Frost" }
 254.6 "Sinbound Holy (cast)" Ability { id: "9D10", source: "Oracle's Reflection" }
 255.5 "Icicle Impact" Ability { id: "9D06", source: "Usurper of Frost" }
-255.5 "Sinbound Holy" #Ability { id: "9D11", source: "Usurper of Frost" }
+255.5 "Sinbound Holy 1 (puddles)" #Ability { id: "9D11", source: "Usurper of Frost" }
+256.9 "Sinbound Holy 2 (puddles)" #Ability { id: "9D11", source: "Oracle's Reflection" }
+258.5 "Sinbound Holy 3 (puddles)" #Ability { id: "9D11", source: "Oracle's Reflection" }
+260.1 "Sinbound Holy 4 (puddles)" #Ability { id: "9D11", source: "Oracle's Reflection" }
+263.9 "Shining Armor + Frost Armor" Ability { id: ["9FC8", "9CF9"], source: ["Oracle's Reflection", "Usurper Of Frost"] }
+270.5 "Twin Stillness/Twin Silence" Ability { id: ["9D01", "9D02"], source: "Oracle's Reflection" }
+272.6 "Twin Silence/Twin Stillness" Ability { id: ["9D03", "9D04"], source: "Oracle's Reflection" }
+276.2 "--targetable--"
+283.3 "Hallowed Ray" Ability { id: "9D12", source: "Usurper of Frost" }
+293.0 "Mirror, Mirror" Ability { id: "9CF3", source: "Usurper of Frost" }
+307.1 "Scythe Kick" Ability { id: "9D0B", source: "Usurper of Frost" }
+317.2 "Reflected Scythe Kick" Ability { id: "9D0D", source: "Frozen Mirror" }
+323.3 "Banish III" Ability { id: ["9D1C", "9D1D"], source: "Usurper of Frost" }
+326.4 "--center--" Ability { id: "9CEF", source: "Usurper of Frost" }
+332.7 "Light Rampant" Ability { id: "9D14", source: "Usurper of Frost" }
+335.7 "--untargetable--"
+340.7 "Luminous Hammer 1" #Ability { id: "9D1A", source: "Usurper of Frost" }
+342.3 "Luminous Hammer 2" #Ability { id: "9D1A", source: "Usurper of Frost" }
+343.9 "Luminous Hammer 3" #Ability { id: "9D1A", source: "Usurper of Frost" }
+344.0 "Bright Hunger" Ability { id: "9D15", source: "Usurper of Frost" }
+345.4 "Luminous Hammer 4" #Ability { id: "9D1A", source: "Usurper of Frost" }
+347.0 "Luminous Hammer 5" #Ability { id: "9D1A", source: "Usurper of Frost" }
+349.8 "Powerful Light" Ability { id: "9D19", source: "Usurper of Frost" }
+358.8 "Bright Hunger" Ability { id: "9D15", source: "Usurper of Frost" }
+361.9 "Banish III" Ability { id: ["9D1C", "9D1D"], source: "Usurper of Frost" }
+364.9 "--targetable--"
+370.8 "The House of Light" Ability { id: "9CFC", source: "Usurper of Frost" }
+376.2 "--center--" Ability { id: "9CEF", source: "Usurper of Frost" }
+379.5 "--sync--" StartsUsing { id: "9D20", source: "Usurper of Frost" }
+390.1 "Absolute Zero (enrage)" Ability { id: "9D8E", source: "Usurper of Frost" }
 
 # Timeline entries below here are from FFLogs reports and should be re-generated with valid
 # network log files when they're available. Notably, mechanics with variations
 # (Twin Stillness/Twin Silence, for example) do not have both IDs included.
 # Additionally, like all FFLogs-generated timelines, the actual entries can vary significantly over time.
 
-256.9 "Sinbound Holy" #Ability { id: "9D11", source: "Oracle's Reflection" }
-258.5 "Sinbound Holy" #Ability { id: "9D11", source: "Oracle's Reflection" }
-260.1 "Sinbound Holy" #Ability { id: "9D11", source: "Oracle's Reflection" }
-263.9 "Shining Armor" Ability { id: "9CF9", source: "Usurper of Frost" }
-263.9 "Frost Armor" Ability { id: "9CF8", source: "Oracle's Reflection" }
-270.5 "Twin Stillness/Twin Silence" Ability { id: "9D01", source: "Oracle's Reflection" }
-272.6 "Twin Stillness/Twin Silence" Ability { id: "9D04", source: "Oracle's Reflection" }
-283.3 "Hallowed Ray" Ability { id: "9D12", source: "Usurper of Frost" }
-283.7 "Hallowed Ray" Ability { id: "9D13", source: "Usurper of Frost" }
-292.8 "Mirror, Mirror" Ability { id: "9CF3", source: "Usurper of Frost" }
-306.9 "Scythe Kick" Ability { id: "9D0B", source: "Usurper of Frost" }
-317.7 "The House of Light" Ability { id: "9D0E", source: "Usurper of Frost" }
-323.1 "Banish III" Ability { id: ["9D1C", "9D1D"], source: "Usurper of Frost" }
-326.2 "--sync--" Ability { id: "9CEF", source: "Usurper of Frost" }
-332.3 "Light Rampant" Ability { id: "9D14", source: "Usurper of Frost" }
-340.3 "Luminous Hammer" #Ability { id: "9D1A", source: "Usurper of Frost" }
-341.9 "Luminous Hammer" #Ability { id: "9D1A", source: "Usurper of Frost" }
-343.5 "Luminous Hammer" #Ability { id: "9D1A", source: "Usurper of Frost" }
-343.6 "Bright Hunger" Ability { id: "9D15", source: "Usurper of Frost" }
-345.0 "Luminous Hammer" #Ability { id: "9D1A", source: "Usurper of Frost" }
-346.6 "Luminous Hammer" #Ability { id: "9D1A", source: "Usurper of Frost" }
-349.4 "Powerful Light" Ability { id: "9D19", source: "Usurper of Frost" }
-358.4 "Bright Hunger" Ability { id: "9D15", source: "Usurper of Frost" }
-361.5 "Banish III" Ability { id: ["9D1C", "9D1D"], source: "Usurper of Frost" }
-370.4 "The House of Light" Ability { id: "9CFC", source: "Usurper of Frost" }
-375.8 "--sync--" Ability { id: "9CEF", source: "Usurper of Frost" }
-379.1 "--sync--" StartsUsing { id: "9D20", source: "Usurper of Frost" }
-389.7 "Absolute Zero (enrage)" Ability { id: "9D8E", source: "Usurper of Frost" }
-
 # Adds Phase
-392.0 "Swelling Frost" Ability { id: "9D21", source: "Usurper of Frost" }
-424.0 "Sinbound Blizzard III" Ability { id: "9D42", source: "Crystal of Darkness" }
-425.0 "Hiemal Storm" Ability { id: "9D40", source: "Crystal of Light" }
-428.2 "Hiemal Storm" Ability { id: "9D40", source: "Crystal of Light" }
-429.2 "Sinbound Blizzard III" Ability { id: "9D42", source: "Crystal of Darkness" }
-431.4 "Hiemal Storm" Ability { id: "9D40", source: "Crystal of Light" }
-434.3 "Sinbound Blizzard III" Ability { id: "9D42", source: "Crystal of Darkness" }
-434.5 "Hiemal Storm" Ability { id: "9D40", source: "Crystal of Light" }
-437.7 "Hiemal Storm" Ability { id: "9D40", source: "Crystal of Light" }
-439.5 "Sinbound Blizzard III" Ability { id: "9D42", source: "Crystal of Darkness" }
-440.9 "Hiemal Storm" Ability { id: "9D40", source: "Crystal of Light" }
-444.1 "Hiemal Storm" Ability { id: "9D40", source: "Crystal of Light" }
-444.8 "Sinbound Blizzard III" Ability { id: "9D42", source: "Crystal of Darkness" }
-447.3 "Hiemal Storm" Ability { id: "9D40", source: "Crystal of Light" }
-450.1 "Sinbound Blizzard III" Ability { id: "9D42", source: "Crystal of Darkness" }
+392.4 "Swelling Frost" Ability { id: "9D21", source: "Usurper of Frost" }
+424.4 "Sinbound Blizzard III" Ability { id: "9D42", source: "Crystal of Darkness" }
+425.4 "Hiemal Storm" Ability { id: "9D40", source: "Crystal of Light" }
+428.6 "Hiemal Storm" Ability { id: "9D40", source: "Crystal of Light" }
+429.6 "Sinbound Blizzard III" Ability { id: "9D42", source: "Crystal of Darkness" }
+431.8 "Hiemal Storm" Ability { id: "9D40", source: "Crystal of Light" }
+434.7 "Sinbound Blizzard III" Ability { id: "9D42", source: "Crystal of Darkness" }
+434.9 "Hiemal Storm" Ability { id: "9D40", source: "Crystal of Light" }
+438.1 "Hiemal Storm" Ability { id: "9D40", source: "Crystal of Light" }
+439.9 "Sinbound Blizzard III" Ability { id: "9D42", source: "Crystal of Darkness" }
+441.3 "Hiemal Storm" Ability { id: "9D40", source: "Crystal of Light" }
+444.5 "Hiemal Storm" Ability { id: "9D40", source: "Crystal of Light" }
+445.2 "Sinbound Blizzard III" Ability { id: "9D42", source: "Crystal of Darkness" }
+447.7 "Hiemal Storm" Ability { id: "9D40", source: "Crystal of Light" }
+450.5 "Sinbound Blizzard III" Ability { id: "9D42", source: "Crystal of Darkness" }
 
 # Phase Three
 500.0 "Junction" Ability { id: "9D22", source: "Usurper of Frost" } window 500.0,0
@@ -299,6 +299,12 @@ hideall "--sync--"
 # 9CE6 Solemn Charge: Rush to tether target, clones, Turn Of The Heavens
 # 9CE9 Burn Mark: Tower failure
 
+# Usurper Of Frost
+# 9CF0 --sync--: Auto-attack
+# 9D0C Reflected Scythe Kick: Blue mirror copy of Scythe Kick
+# 9D0E The House Of Light: Mirror Proteans
+# 9D13 Hallowed Ray: Stack laser resolves
+
 # ALL ENCOUNTER ABILITIES
 # 9CB2 attack
 # 9CB3 --sync--: Auto-attack
@@ -365,52 +371,52 @@ hideall "--sync--"
 # 9CF0 --sync--: Auto-attack
 # 9CF1 --sync--: Auto-attack
 # 9CF2 --sync--: Auto-attack
-# 9CF3 Mirror, Mirror
-# 9CF4 Mirror Image
+# 9CF3 Mirror, Mirror: Summon mirrors
+# 9CF4 Mirror Image: Summon Shiva clone
 # 9CF5 Darkest Dance
 # 9CF6 Darkest Dance
 # 9CF7 Darkest Dance
-# 9CF8 Frost Armor
-# 9CF9 Shining Armor
+# 9CF8 Frost Armor: Slippery floor cast
+# 9CF9 Shining Armor: Gaze attack from Shiva and clone
 # 9CFA Drachen Armor
 # 9CFB the Path of Light
-# 9CFC the House of Light
-# 9CFD the House of Light
+# 9CFC the House of Light: Final P2 Protean castbar
+# 9CFD the House of Light: Final P2 Protean castbar
 # 9CFE the Path of Light
-# 9CFF Quadruple Slap
-# 9D00 Quadruple Slap
-# 9D01 Twin Stillness
-# 9D02 Twin Silence
-# 9D03 Twin Silence
-# 9D04 Twin Stillness
-# 9D05 Diamond Dust
-# 9D06 Icicle Impact
-# 9D07 Frigid Stone
-# 9D08 Frigid Needle
-# 9D09 Frigid Needle
-# 9D0A Axe Kick
-# 9D0B Scythe Kick
-# 9D0C Reflected Scythe Kick
-# 9D0D Reflected Scythe Kick
-# 9D0E the House of Light
-# 9D0F Heavenly Strike
-# 9D10 Sinbound Holy
-# 9D11 Sinbound Holy
-# 9D12 Hallowed Ray
-# 9D13 Hallowed Ray
-# 9D14 Light Rampant
-# 9D15 Bright Hunger
-# 9D16 Inescapable Illumination
-# 9D17 Refulgent Fate
-# 9D18 Lightsteep
-# 9D19 Powerful Light
-# 9D1A Luminous Hammer
-# 9D1B Burst
-# 9D1C Banish III
-# 9D1D Banish III
-# 9D1E Banish III
-# 9D1F Banish III Divided
-# 9D20 Absolute Zero
+# 9CFF Quadruple Slap: Shiva tankbuster hit 1
+# 9D00 Quadruple Slap: Shiva tankbuster hit 2
+# 9D01 Twin Stillness: Front -> back cleave combo, front hit
+# 9D02 Twin Silence: Back -> front cleave combo, back hit
+# 9D03 Twin Silence: Back -> front cleave combo, front hit
+# 9D04 Twin Stillness: Front -> back cleave combo, back hit
+# 9D05 Diamond Dust: Raidwide
+# 9D06 Icicle Impact: Shiva circles
+# 9D07 Frigid Stone: Shiva stars land
+# 9D08 Frigid Needle: Shiva star explosions cast (no visible castbar)
+# 9D09 Frigid Needle: Shiva star explosions
+# 9D0A Axe Kick: Chariot AoE
+# 9D0B Scythe Kick: Dynamo AoE
+# 9D0C Reflected Scythe Kick: Blue mirror copy of Scythe Kick
+# 9D0D Reflected Scythe Kick: Red mirror copy of Scythe Kick
+# 9D0E The House Of Light: Mirror Proteans
+# 9D0F Heavenly Strike: Knockback
+# 9D10 Sinbound Holy: Healer stack puddles castbar
+# 9D11 Sinbound Holy: Healer stack puddles
+# 9D12 Hallowed Ray: Stack laser castbar
+# 9D13 Hallowed Ray: Stack laser resolves
+# 9D14 Light Rampant: Raidwide
+# 9D15 Bright Hunger: Light Rampant tower resolution
+# 9D16 Inescapable Illumination: Lightsteep stacks x5?
+# 9D17 Refulgent Fate: Light Rampant chain break
+# 9D18 Lightsteep: Light Rampant stack addition
+# 9D19 Powerful Light: Light Rampant 4/4 stack orbs
+# 9D1A Luminous Hammer: Light Rampant puddles
+# 9D1B Burst: Light Rampant large puddle AoEs
+# 9D1C Banish III: P2 partner stacks cast (no visible castbar)
+# 9D1D Banish III: P2 spreads cast (no visible castbar)
+# 9D1E Banish III: P2 partner stacks
+# 9D1F Banish III Divided: P2 spreads
+# 9D20 Absolute Zero: P2 phase end castbar, raidwide
 # 9D21 Swelling Frost
 # 9D22 Junction
 # 9D23 Hallowed Wings

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
@@ -61,6 +61,8 @@ hideall "--sync--"
 160.2 "Burnished Glory (enrage)" Ability { id: "9CC0", source: "Fatebreaker" }
 
 # Phase Two
+# Source actors are elided on some lines where stale data can make P1 actors fill it in.
+# Ability IDs should be sufficient in those cases.
 # Sync on the map change
 200.0 "--sync--" MapEffect { flags: "00020001", location: "17" } window 200.0,0
 204.1 "--targetable--"
@@ -72,10 +74,10 @@ hideall "--sync--"
 235.9 "Diamond Dust" Ability { id: "9D05", source: "Usurper of Frost" }
 239.0 "--untargetable--"
 244.6 "Axe Kick/Scythe Kick" Ability { id: ["9D0A", "9D0B"], source: "Oracle's Reflection" }
-245.5 "The House of Light" Ability { id: "9D0E", source: ["Fatebreaker's Image", "Oracle's Reflection", "Usurper Of Frost"] }
+245.5 "The House of Light" Ability { id: "9D0E" }
 247.2 "Frigid Stone" Ability { id: "9D07", source: "Usurper of Frost" }
 247.6 "Icicle Impact" Ability { id: "9D06", source: "Usurper of Frost" }
-248.4 "--center--" Ability { id: "9CEF", source: "Oracle's Reflection" }
+248.4 "--center--" Ability { id: "9CEF" }
 251.5 "Heavenly Strike" Ability { id: "9D0F", source: "Usurper of Frost" }
 251.6 "Icicle Impact" Ability { id: "9D06", source: "Usurper of Frost" }
 254.2 "Frigid Needle" Ability { id: "9D08", source: "Usurper of Frost" }
@@ -100,11 +102,13 @@ hideall "--sync--"
 340.7 "Luminous Hammer 1" #Ability { id: "9D1A", source: "Usurper of Frost" }
 342.3 "Luminous Hammer 2" #Ability { id: "9D1A", source: "Usurper of Frost" }
 343.9 "Luminous Hammer 3" #Ability { id: "9D1A", source: "Usurper of Frost" }
-344.0 "Bright Hunger" Ability { id: "9D15", source: "Usurper of Frost" }
+344.0 "Bright Hunger (solo towers)" Ability { id: "9D15", source: "Usurper of Frost" }
 345.4 "Luminous Hammer 4" #Ability { id: "9D1A", source: "Usurper of Frost" }
 347.0 "Luminous Hammer 5" #Ability { id: "9D1A", source: "Usurper of Frost" }
 349.8 "Powerful Light" Ability { id: "9D19", source: "Usurper of Frost" }
-358.8 "Bright Hunger" Ability { id: "9D15", source: "Usurper of Frost" }
+352.2 "Burst 1" #Ability { id: "9D1B", source: "Holy Light" }
+355.2 "Burst 2" #Ability { id: "9D1B", source: "Holy Light" }
+358.8 "Bright Hunger (group tower)" Ability { id: "9D15", source: "Usurper of Frost" }
 361.9 "Banish III" Ability { id: ["9D1C", "9D1D"], source: "Usurper of Frost" }
 364.9 "--targetable--"
 370.8 "The House of Light" Ability { id: "9CFC", source: "Usurper of Frost" }
@@ -135,7 +139,9 @@ hideall "--sync--"
 450.5 "Sinbound Blizzard III" Ability { id: "9D42", source: "Crystal of Darkness" }
 
 # Phase Three
+488.8 "--sync--" WasDefeated { source: 'Ice Veil' } window 488.8,10
 500.0 "Junction" Ability { id: "9D22", source: "Usurper of Frost" } window 500.0,0
+514.3 "--targetable--"
 518.3 "Hell's Judgment" Ability { id: "9D49", source: "Oracle of Darkness" }
 521.4 "--sync--" Ability { id: "9CB5", source: "Oracle of Darkness" }
 532.4 "Ultimate Relativity" Ability { id: "9D4A", source: "Oracle of Darkness" }


### PR DESCRIPTION
This has been tested in-game. I adjusted some timings to better match what I saw across my logs to match `test_timeline` and added the remaining `targetable` entries. I also combined the Shining and Frost armor entries since those always go off simultaneously but the order in the log is random. Finally, I filled out some more data on the P2 abilities in the ability list.

Timings for intermission and beyond have not been modified.