### PR TITLE
raidboss: FRU - p2 + p3

### DIFF
--- a/resources/responses.ts
+++ b/resources/responses.ts
@@ -328,6 +328,7 @@ export const Responses = {
   bigAoe: (sev?: Severity) => staticResponse(defaultInfoText(sev), Outputs.bigAoe),
   bleedAoe: (sev?: Severity) => staticResponse(defaultInfoText(sev), Outputs.bleedAoe),
   spread: (sev?: Severity) => staticResponse(defaultInfoText(sev), Outputs.spread),
+  protean: (sev?: Severity) => staticResponse(defaultInfoText(sev), Outputs.protean),
   // for stack marker situations.
   stackMarker: (sev?: Severity) => staticResponse(defaultAlertText(sev), Outputs.stackMarker),
   // for getting together without stack marker

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
@@ -659,9 +659,9 @@ const triggerSet: TriggerSet<Data> = {
             case 'opposite':
               return output.aaccCursed!();
             case 'clockwise':
-              return output.aaccClockwise!();
+              return output.aaccRotateCCW!();
             case 'counterclockwise':
-              return output.aaccCounterclockwise!();
+              return output.aaccRotateCW!();
             default:
               break;
           }
@@ -671,10 +671,10 @@ const triggerSet: TriggerSet<Data> = {
         aaccCursed: {
           en: 'Cursed Add - Fast Clockwise',
         },
-        aaccClockwise: {
+        aaccRotateCCW: {
           en: 'Rotate Counterclockwise (away from add)',
         },
-        aaccCounterclockwise: {
+        aaccRotateCW: {
           en: 'Rotate Clockwise (away from add)',
         },
         same: {

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
@@ -1384,7 +1384,25 @@ const triggerSet: TriggerSet<Data> = {
       id: 'FRU P3 Black Halo',
       type: 'StartsUsing',
       netRegex: { id: '9D62', source: 'Oracle of Darkness' },
-      response: Responses.sharedTankBuster(),
+      response: (data, matches, output) => {
+        // cactbot-builtin-response
+        output.responseOutputStrings = {
+          onYou: {
+            en: 'Shared tank cleave on YOU',
+          },
+          share: {
+            en: 'Shared tank cleave on ${target}',
+          },
+          avoid: {
+            en: 'Avoid tank cleave',
+          },
+        };
+        if (data.me === matches.target)
+          return { alertText: output.onYou!() };
+        else if (data.role === 'tank')
+          return { alertText: output.share!({ target: data.party.member(matches.target).nick }) };
+        return { infoText: output.avoid!() };
+      }
     },
     // ***** Apocalypse *****
     {

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
@@ -196,7 +196,9 @@ const triggerSet: TriggerSet<Data> = {
       id: 'ultimateRel',
       comment: {
         en:
-          `Y North, DPS E-SW, Supp W-NE: <a href="https://pastebin.com/ue7w9jJH" target="_blank">LesBin<a>`,
+          `Y North, DPS E-SW, Supp W-NE: <a href="https://pastebin.com/ue7w9jJH" target="_blank">LesBin<a>.  
+          Directional output is true north (i.e., "east" means actual east,
+          not wherever is east of the "Y" north spot).`,
       },
       name: {
         en: 'P3 Ultimate Relativity',

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
@@ -12,7 +12,7 @@ import { NetMatches } from '../../../../../types/net_matches';
 import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO:
-//  - P4: Somber Dance (tb bait x2)
+//  - P4 + P5
 
 type Phase = 'p1' | 'p2-dd' | 'p2-mm' | 'p2-lr' | 'p3-ur' | 'p3-apoc' | 'p4-dld' | 'p4-ct' | 'p5';
 const phases: { [id: string]: Phase } = {
@@ -165,9 +165,6 @@ export interface Data extends RaidbossData {
   p3ApocFirstDirNum?: number;
   p3ApocRotationDir?: 1 | -1; // 1 = clockwise, -1 = counterclockwise
   p3CalledApoc: boolean;
-  // P4 -- Duo
-  p4RefulgentChains: string[];
-  p4DarklitStacks: string[];
 }
 
 const triggerSet: TriggerSet<Data> = {
@@ -257,8 +254,6 @@ const triggerSet: TriggerSet<Data> = {
         none: [],
       },
       p3CalledApoc: false,
-      p4RefulgentChains: [],
-      p4DarklitStacks: [],
     };
   },
   timelineTriggers: [],
@@ -1617,105 +1612,7 @@ const triggerSet: TriggerSet<Data> = {
     // ************************
     // P4 -- Duo
     // ************************
-    {
-      id: 'FRU P4 Akh Rhai',
-      type: 'GainsEffect',
-      // no castbar, vfx-based cue
-      // invisible actors spawn 4.6s after this effect is applied and use Akh Rhai
-      netRegex: { effectId: '8E1', capture: false },
-      condition: (data) => data.phase === 'p4-dld',
-      delaySeconds: 4.7,
-      suppressSeconds: 1,
-      response: Responses.moveAway('alert'),
-    },
-    // ***** Darklit Dragonsong *****
-    {
-      id: 'FRU P4 Darklit Dragonsong',
-      type: 'StartsUsing',
-      netRegex: { id: '9D6D', source: 'Oracle of Darkness', capture: false },
-      response: Responses.bigAoe(),
-    },
-    {
-      id: 'FRU PP4 Refulgent Chain Collect',
-      type: 'GainsEffect',
-      netRegex: { effectId: '8CD' }, // Refulgent Chain
-      condition: (data) => data.phase === 'p4-dld',
-      run: (data, matches) => data.p4RefulgentChains.push(matches.target),
-    },
-    {
-      id: 'FRU P4 Darklit Stacks',
-      type: 'GainsEffect',
-      netRegex: { effectId: '99D' }, // Spell-in-Waiting: Dark Water III
-      condition: (data) => data.phase === 'p4-dld',
-      delaySeconds: 2.5, // delay until after Refulgent Chains go out
-      durationSeconds: 5,
-      infoText: (data, matches, output) => {
-        data.p4DarklitStacks.push(matches.target);
-        if (data.p4DarklitStacks.length !== 2)
-          return;
 
-        const and = output.and!();
-        const targets = data.p4DarklitStacks.map((p) => data.party.member(p).nick).join(and);
-        return output.stacks!({ players: targets });
-      },
-      outputStrings: {
-        stacks: {
-          en: '(stacks after on ${players})',
-        },
-        and: Outputs.and,
-      },
-    },
-    {
-      id: 'FRU P4 Path of Light',
-      type: 'StartsUsing',
-      netRegex: { id: '9CFB', source: 'Usurper of Frost', capture: false },
-      delaySeconds: 3, // 7.7s cast time, give time for tether/stack adjusts
-      alertText: (data, _matches, output) =>
-        data.p4RefulgentChains.includes(data.me) ? output.tether!() : output.bait!(),
-      outputStrings: {
-        tether: {
-          en: 'Soak Tower',
-        },
-        bait: {
-          en: 'Bait Cleave',
-        },
-      },
-    },
-    {
-      id: 'FRU P4 Spirit Taker',
-      type: 'StartsUsing',
-      netRegex: { id: '9D60', source: 'Oracle of Darkness', capture: false },
-      condition: (data) => data.phase === 'p4-dld',
-      delaySeconds: 0.5, // delay until after Path of Light snapshots
-      durationSeconds: 2,
-      response: Responses.spread('alert'),
-    },
-    {
-      id: 'FRU P4 Hallowed Wings',
-      type: 'StartsUsing',
-      netRegex: { id: ['9D23', '9D24'], source: 'Usurper of Frost' },
-      condition: (data) => data.phase === 'p4-dld',
-      delaySeconds: 1, // avoid collision with Spirit Taker
-      infoText: (_data, matches, output) => {
-        const dir = matches.id === '9D23' ? 'east' : 'west';
-        return output.combo!({ dir: output[dir]!(), stacks: output.stacks!() });
-      },
-      outputStrings: {
-        combo: {
-          en: '${dir} => ${stacks}',
-        },
-        east: Outputs.east,
-        west: Outputs.west,
-        stacks: Outputs.stacks,
-      },
-    },
-    // ***** Crystallize Time *****
-    {
-      id: 'FRU P4 Crystallize Time',
-      type: 'StartsUsing',
-      netRegex: { id: '9D6A', source: 'Oracle of Darkness', capture: false },
-      response: Responses.bigAoe(),
-    },
     // ************************
     // P5 -- Pandora
     // ************************

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
@@ -153,8 +153,6 @@ export interface Data extends RaidbossData {
   p2LightsteepedCount: number;
   p2LightRampantPuddles: string[];
   p2SeenFirstHolyLight: boolean;
-  // Intermission
-  intermissionCrystalDeadCount: number;
   // P3 -- Oracle of Darkness
   p3RelativityRoleCount: number;
   p3RelativityDebuff?: RelativityDebuff;
@@ -243,7 +241,6 @@ const triggerSet: TriggerSet<Data> = {
       p2LightsteepedCount: 0,
       p2LightRampantPuddles: [],
       p2SeenFirstHolyLight: false,
-      intermissionCrystalDeadCount: 0,
       p3RelativityRoleCount: 0,
       p3RelativityRoleMap: newRoleMap(),
       p3RelativityStoplights: {},
@@ -955,14 +952,11 @@ const triggerSet: TriggerSet<Data> = {
     // Intermission / Crystals
     // ************************
     {
-      id: 'FRU Intermission Crystals Dead',
-      type: 'WasDefeated',
-      netRegex: { target: 'Crystal of Light', capture: false },
-      infoText: (data, _matches, output) => {
-        data.intermissionCrystalDeadCount++;
-        if (data.intermissionCrystalDeadCount === 4)
-          return output.targetVeil!();
-      },
+      id: 'FRU Intermission Target Veil',
+      type: 'LosesEffect',
+      // 307 - Invincibility
+      netRegex: { effectId: '307', target: 'Ice Veil', capture: false },
+      infoText: (_data, _matches, output) => output.targetVeil!(),
       outputStrings: {
         targetVeil: {
           en: 'Target Ice Veil',

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
@@ -1580,7 +1580,7 @@ const triggerSet: TriggerSet<Data> = {
         'Sinbound Fire III/Sinbound Thunder III': 'Sinbound Fire/Thunder',
         'Dark Fire III/Unholy Darkness': '(spreads/stack)',
         'Dark Fire III/Dark Blizzard III/Unholy Darkness': '(spreads/donut/stack)',
-        'Shadoweye/Dark Water III/Dark Eruption': '(gazes/stack/spreads)'
+        'Shadoweye/Dark Water III/Dark Eruption': '(gazes/stack/spreads)',
       },
     },
     {

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
@@ -151,6 +151,8 @@ export interface Data extends RaidbossData {
   p2LightsteepedCount: number;
   p2LightRampantPuddles: string[];
   p2SeenFirstHolyLight: boolean;
+  // Intermission
+  intermissionCrystalDeadCount: number;
   // P3 -- Oracle of Darkness
   p3RelativityRoleCount: number;
   p3RelativityDebuff?: RelativityDebuff;
@@ -221,6 +223,7 @@ const triggerSet: TriggerSet<Data> = {
       p2LightsteepedCount: 0,
       p2LightRampantPuddles: [],
       p2SeenFirstHolyLight: false,
+      intermissionCrystalDeadCount: 0,
       p3RelativityRoleCount: 0,
       p3RelativityRoleMap: newRoleMap(),
       p3RelativityStoplights: {},
@@ -932,7 +935,21 @@ const triggerSet: TriggerSet<Data> = {
     // ************************
     // Intermission / Crystals
     // ************************
-    // There's not really too much to do here.
+    {
+      id: 'FRU Intermission Crystals Dead',
+      type: 'WasDefeated',
+      netRegex: { target: 'Crystal of Light', capture: false },
+      infoText: (data, _matches, output) => {
+        data.intermissionCrystalDeadCount++;
+        if (data.intermissionCrystalDeadCount === 4)
+          return output.targetVeil!();
+      },
+      outputStrings: {
+        targetVeil: {
+          en: 'Target Ice Veil',
+        },
+      },
+    },
     {
       id: 'FRU Intermission Junction',
       type: 'WasDefeated',

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
@@ -1402,7 +1402,7 @@ const triggerSet: TriggerSet<Data> = {
         else if (data.role === 'tank')
           return { alertText: output.share!({ target: data.party.member(matches.target).nick }) };
         return { infoText: output.avoid!() };
-      }
+      },
     },
     // ***** Apocalypse *****
     {
@@ -1500,12 +1500,12 @@ const triggerSet: TriggerSet<Data> = {
         // Melees can spread one additional dir away from the rotation direction
         const safe = [
           (startNum - rotationDir + 8) % 8,
-          (startNum + 4 - rotationDir + 8) % 8
+          (startNum + 4 - rotationDir + 8) % 8,
         ];
 
         const toward = [
           (safe[0]! - rotationDir + 8) % 8,
-          (safe[1]! - rotationDir + 8) % 8
+          (safe[1]! - rotationDir + 8) % 8,
         ];
 
         // We shouldn't just sort safe[], and toward[], since the elements are paired

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
@@ -1560,6 +1560,9 @@ const triggerSet: TriggerSet<Data> = {
         'Axe Kick/Scythe Kick': 'Axe/Scythe Kick',
         'Shining Armor + Frost Armor': 'Shining + Frost Armor',
         'Sinbound Fire III/Sinbound Thunder III': 'Sinbound Fire/Thunder',
+        'Dark Fire III/Unholy Darkness': '(spreads/stack)',
+        'Dark Fire III/Dark Blizzard III/Unholy Darkness': '(spreads/donut/stack)',
+        'Shadoweye/Dark Water III/Dark Eruption': '(gazes/stack/spreads)'
       },
     },
     {

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
@@ -1358,7 +1358,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { effectId: '994' }, // 994 - Return
       condition: (data, matches) => data.phase === 'p3-ur' && data.me === matches.target,
       delaySeconds: (_data, matches) => parseFloat(matches.duration) - 4,
-      countdownSeconds: (_data, matches) => parseFloat(matches.duration),
+      countdownSeconds: 4,
       response: Responses.lookAway('alarm'),
     },
     {

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
@@ -84,7 +84,10 @@ const newRoleMap = () => ({
   ice: '',
 });
 
-const findNorthDirNum = (dirs: number[]): number => {
+// Helper for Ultimate Relativity that finds relative North based on the yellow-tethered lights
+// It takes an array of dir nums (e.g. 0-8), finds the two dir nums that have a single gap
+// between them (e.g. 1 and 3) -- the apex of the "Y" -- and returns the dir num of the gap.
+const findURNorthDirNum = (dirs: number[]): number => {
   for (let i = 0; i < dirs.length; i++) {
     for (let j = i + 1; j < dirs.length; j++) {
       const [dir1, dir2] = [dirs[i], dirs[j]];
@@ -1107,7 +1110,7 @@ const triggerSet: TriggerSet<Data> = {
         if (data.p3RelativityYellowDirNums.length !== 3)
           return;
 
-        const northDirNum = findNorthDirNum(data.p3RelativityYellowDirNums);
+        const northDirNum = findURNorthDirNum(data.p3RelativityYellowDirNums);
         if (northDirNum === -1 || data.p3RelativityDebuff === undefined) {
           data.p3RelativityMyDirStr = output.unknown!();
           return;

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
@@ -1090,7 +1090,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'Tether',
       // boss tethers to 5 stoplights - 0085 are purple tethers, 0086 are yellow
       netRegex: { id: '0086' },
-      // condition: (data) => data.triggerSetConfig.ultimateRel === 'yNorthDPSEast',
+      condition: (data) => data.phase === 'p3-ur',
       run: (data, matches, output) => {
         const id = matches.sourceId;
         const stoplight = data.p3RelativityStoplights[id];

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
@@ -171,6 +171,9 @@ export interface Data extends RaidbossData {
 const triggerSet: TriggerSet<Data> = {
   id: 'FuturesRewrittenUltimate',
   zoneId: ZoneId.FuturesRewrittenUltimate,
+  comments: {
+    en: 'Triggers: P1-3 / Timeline: P1-5',
+  },
   config: [
     {
       id: 'sinboundRotate',

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
@@ -24,7 +24,7 @@ const phases: { [id: string]: Phase } = {
   '9D49': 'p3-ur', // Hell's Judgment (pre-Ultimate Relativity)
   '9D4D': 'p3-apoc', // Spell-in-Waiting: Refrain (pre-Apocalypse)
   '9D36': 'p4-dld', // Materialization (pre-Darklit Dragonsong)
-  '9D30': 'p4-ct', // Crystallize Time
+  '9D6A': 'p4-ct', // Crystallize Time
   // tbd: 'p5',
 };
 
@@ -1341,7 +1341,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { effectId: '994' }, // 994 - Return
       condition: (data, matches) => data.phase === 'p3-ur' && data.me === matches.target,
       delaySeconds: (_data, matches) => parseFloat(matches.duration) - 4,
-      countdownSeconds: 4,
+      countdownSeconds: (_data, matches) => parseFloat(matches.duration),
       response: Responses.lookAway('alarm'),
     },
     {
@@ -1481,7 +1481,8 @@ const triggerSet: TriggerSet<Data> = {
       type: 'GainsEffect',
       netRegex: { effectId: '99D' }, // Spell-in-Waiting: Dark Water III
       condition: (data) => data.phase === 'p4-dld',
-      delaySeconds: 2, // delay until after Refulgent Chains go out
+      delaySeconds: 2.5, // delay until after Refulgent Chains go out
+      durationSeconds: 5,
       infoText: (data, matches, output) => {
         data.p4DarklitStacks.push(matches.target);
         if (data.p4DarklitStacks.length !== 2)
@@ -1493,7 +1494,7 @@ const triggerSet: TriggerSet<Data> = {
       },
       outputStrings: {
         stacks: {
-          en: 'Stacks Later (${players})',
+          en: '(stacks after on ${players})',
         },
         and: Outputs.and,
       },
@@ -1517,7 +1518,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'FRU P4 Spirit Taker',
       type: 'StartsUsing',
-      netRegex: { id: '96D0', source: 'Oracle of Darkness', capture: false },
+      netRegex: { id: '9D60', source: 'Oracle of Darkness', capture: false },
       condition: (data) => data.phase === 'p4-dld',
       delaySeconds: 0.5, // delay until after Path of Light snapshots
       durationSeconds: 2,
@@ -1546,7 +1547,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'FRU P4 Crystallize Time',
       type: 'StartsUsing',
-      netRegex: { id: '9D6D', source: 'Oracle of Darkness', capture: false },
+      netRegex: { id: '9D6A', source: 'Oracle of Darkness', capture: false },
       response: Responses.bigAoe(),
     },
     // ************************

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
@@ -124,6 +124,7 @@ hideall "--sync--"
 # Adds Phase
 # The Heimal Storm casts from the Crystals of Light will stop once they all are killed.
 392.4 "Swelling Frost" Ability { id: "9D21", source: "Usurper of Frost" }
+411.4 "--adds targetable--"
 424.4 "Sinbound Blizzard III" Ability { id: "9D42", source: "Crystal of Darkness" }
 425.4 "Hiemal Storm" Ability { id: "9D40", source: "Crystal of Light" }
 428.6 "Hiemal Storm" Ability { id: "9D40", source: "Crystal of Light" }

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
@@ -142,7 +142,7 @@ hideall "--sync--"
 
 # Phase Three
 488.8 "--sync--" WasDefeated { target: 'Ice Veil' } window 488.8,10
-500.0 "Junction" Ability { id: "9D22", source: "Usurper of Frost" } window 500.0,0
+500.0 "Junction" Ability { id: "9D22", source: "Usurper of Frost" } window 500.0,5
 514.3 "--targetable--"
 518.3 "Hell's Judgment" Ability { id: "9D49", source: "Oracle of Darkness" }
 521.4 "--sync--" Ability { id: "9CB5", source: "Oracle of Darkness" }

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
@@ -113,7 +113,6 @@ hideall "--sync--"
 364.9 "--targetable--"
 370.8 "The House of Light" Ability { id: "9CFC", source: "Usurper of Frost" }
 376.2 "--center--" Ability { id: "9CEF", source: "Usurper of Frost" }
-379.5 "--sync--" StartsUsing { id: "9D20", source: "Usurper of Frost" }
 390.1 "Absolute Zero (enrage)" Ability { id: "9D8D", source: "Usurper of Frost" }
 
 # Timeline entries below here are from FFLogs reports and should be re-generated with valid
@@ -156,7 +155,7 @@ hideall "--sync--"
 569.3 "Sinbound Meltdown 3 (x10)" Ability { id: "9D2B", source: "Delight's Hourglass" } duration 10.2
 572.5 "Stun + Rewind"
 575.0 "Shadoweye/Dark Water III/Dark Eruption" Ability { id: "9D56", source: "Oracle of Darkness" }
-578.6 "Shell Crusher (x2)" Ability { id: "9D5E", source: "Oracle of Darkness" }
+578.6 "Shell Crusher" Ability { id: "9D5E", source: "Oracle of Darkness" }
 587.1 "Shockwave Pulsar" Ability { id: "9D5A", source: "Oracle of Darkness" }
 595.5 "Black Halo" Ability { id: "9D62", source: "Oracle of Darkness" }
 604.6 "Spell-in-Waiting Refrain" Ability { id: "9D4D", source: "Oracle of Darkness" }
@@ -171,7 +170,7 @@ hideall "--sync--"
 647.3 "Darkest Dance (knockback)" Ability { id: "9CF7", source: "Oracle of Darkness" }
 651.2 "Dark Water III" Ability { id: "9D4F", source: "Oracle of Darkness" }
 656.6 "Shockwave Pulsar" Ability { id: "9D5A", source: "Oracle of Darkness" }
-670.3 "Memory's End" Ability { id: "9D6C", source: "Oracle of Darkness" }
+670.3 "Memory's End (enrage)" Ability { id: "9D6C", source: "Oracle of Darkness" }
 
 # Phase Four
 684.7 "--sync--" StartsUsing { id: "9D36", source: "Usurper of Frost" } window 10,10

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
@@ -148,11 +148,11 @@ hideall "--sync--"
 521.4 "--sync--" Ability { id: "9CB5", source: "Oracle of Darkness" }
 532.4 "Ultimate Relativity" Ability { id: "9D4A", source: "Oracle of Darkness" }
 544.2 "Dark Fire III/Unholy Darkness" Ability { id: "9D54", source: "Oracle of Darkness" }
-549.3 "Sinbound Meltdown 1 (x10)" Ability { id: "9D2B", source: "Delight's Hourglass" } duration 10.2
+549.3 "Sinbound Meltdown 1 (x10)" Ability { id: "9D2B" } duration 10.2
 554.0 "Dark Fire III/Dark Blizzard III/Unholy Darkness" Ability { id: "9D54", source: "Oracle of Darkness" }
-558.8 "Sinbound Meltdown 2 (x10)" Ability { id: "9D2B", source: "Delight's Hourglass" } duration 10.2
+558.8 "Sinbound Meltdown 2 (x10)" Ability { id: "9D2B" } duration 10.2
 563.6 "Dark Fire III/Unholy Darkness" Ability { id: "9D54", source: "Oracle of Darkness" }
-569.3 "Sinbound Meltdown 3 (x10)" Ability { id: "9D2B", source: "Delight's Hourglass" } duration 10.2
+569.3 "Sinbound Meltdown 3 (x10)" Ability { id: "9D2B" } duration 10.2
 572.5 "Stun + Rewind"
 575.0 "Shadoweye/Dark Water III/Dark Eruption" Ability { id: "9D56", source: "Oracle of Darkness" }
 578.6 "Shell Crusher" Ability { id: "9D5E", source: "Oracle of Darkness" }

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
@@ -147,43 +147,30 @@ hideall "--sync--"
 518.3 "Hell's Judgment" Ability { id: "9D49", source: "Oracle of Darkness" }
 521.4 "--sync--" Ability { id: "9CB5", source: "Oracle of Darkness" }
 532.4 "Ultimate Relativity" Ability { id: "9D4A", source: "Oracle of Darkness" }
-542.1 "Speed/Quicken/Slow" #Ability { id: "9D65", source: "Oracle of Darkness" }
-544.2 "Dark Fire III" Ability { id: "9D54", source: "Oracle of Darkness" }
-544.2 "Unholy Darkness" #Ability { id: "9D55", source: "Oracle of Darkness" }
-549.3 "Sinbound Meltdown" Ability { id: "9D2B", source: "Delight's Hourglass" }
-551.3 "Sinbound Meltdown (x9)" duration 8.2
-554.0 "Dark Blizzard III" Ability { id: "9D57", source: "Crystal of Darkness" }
-554.0 "Unholy Darkness" Ability { id: "9D55", source: "Crystal of Darkness" }
-558.8 "Sinbound Meltdown (x9)" duration 8.2
-563.6 "Dark Fire III" Ability { id: "9D54", source: "Oracle of Darkness" }
-563.6 "Unholy Darkness" Ability { id: "9D55", source: "Oracle of Darkness" }
-569.3 "Sinbound Meltdown" Ability { id: "9D2B", source: "Delight's Hourglass" }
-571.3 "Sinbound Meltdown (x9)" duration 8.2
-574.9 "Shadoweye" Ability { id: "9D56", source: "Oracle of Darkness" }
-574.9 "Dark Eruption" #Ability { id: "9D52", source: "Oracle of Darkness" }
-574.9 "Dark Water III" Ability { id: "9D4F", source: "Oracle of Darkness" }
-574.9 "Shadoweye" Ability { id: "9D56", source: "Oracle of Darkness" }
-578.6 "Shell Crusher" Ability { id: "9D5E", source: "Oracle of Darkness" }
-579.0 "Shell Crusher" Ability { id: "9D5F", source: "Oracle of Darkness" }
+544.2 "Dark Fire III/Unholy Darkness" Ability { id: "9D54", source: "Oracle of Darkness" }
+549.3 "Sinbound Meltdown 1 (x10)" Ability { id: "9D2B", source: "Delight's Hourglass" } duration 10.2
+554.0 "Dark Fire III/Dark Blizzard III/Unholy Darkness" Ability { id: "9D54", source: "Oracle of Darkness" }
+558.8 "Sinbound Meltdown 2 (x10)" Ability { id: "9D2B", source: "Delight's Hourglass" } duration 10.2
+563.6 "Dark Fire III/Unholy Darkness" Ability { id: "9D54", source: "Oracle of Darkness" }
+569.3 "Sinbound Meltdown 3 (x10)" Ability { id: "9D2B", source: "Delight's Hourglass" } duration 10.2
+571.9 "Stun + Rewind"
+574.9 "Shadoweye/Dark Water III/Dark Eruption" Ability { id: "9D56", source: "Oracle of Darkness" }
+578.6 "Shell Crusher (x2)" Ability { id: "9D5E", source: "Oracle of Darkness" }
 587.1 "Shockwave Pulsar" Ability { id: "9D5A", source: "Oracle of Darkness" }
 595.5 "Black Halo" Ability { id: "9D62", source: "Oracle of Darkness" }
 604.6 "Spell-in-Waiting Refrain" Ability { id: "9D4D", source: "Oracle of Darkness" }
 619.7 "Apocalypse" Ability { id: "9D68", source: "Oracle of Darkness" }
 623.1 "Dark Water III" Ability { id: "9D4F", source: "Oracle of Darkness" }
 624.8 "Spirit Taker" Ability { id: "9D60", source: "Oracle of Darkness" }
-625.1 "Spirit Taker" Ability { id: "9D61", source: "Oracle of Darkness" }
 628.0 "--sync--" Ability { id: "9CB5", source: "Oracle of Darkness" }
 633.7 "Apocalypse (x6)" duration 10.0
-635.4 "Dark Eruption" Ability { id: "9D51", source: "Oracle of Darkness" }
 636.5 "Dark Eruption" Ability { id: "9D52", source: "Oracle of Darkness" }
 642.1 "Dark Water III" Ability { id: "9D4F", source: "Oracle of Darkness" }
-644.0 "Darkest Dance" Ability { id: "9CF5", source: "Oracle of Darkness" }
-644.4 "Darkest Dance" Ability { id: "9CF6", source: "Oracle of Darkness" }
-647.3 "Darkest Dance" Ability { id: "9CF7", source: "Oracle of Darkness" }
+644.4 "Darkest Dance (jump)" Ability { id: "9CF6", source: "Oracle of Darkness" }
+647.3 "Darkest Dance (knockback)" Ability { id: "9CF7", source: "Oracle of Darkness" }
 651.2 "Dark Water III" Ability { id: "9D4F", source: "Oracle of Darkness" }
 656.6 "Shockwave Pulsar" Ability { id: "9D5A", source: "Oracle of Darkness" }
 670.3 "Memory's End" Ability { id: "9D6C", source: "Oracle of Darkness" }
-670.3 "Memory's End" Ability { id: "9D8F", source: "Oracle of Darkness" }
 
 # Phase Four
 684.7 "--sync--" StartsUsing { id: "9D36", source: "Usurper of Frost" } window 10,10

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
@@ -87,7 +87,7 @@ hideall "--sync--"
 256.9 "Sinbound Holy 2 (puddles)" #Ability { id: "9D11", source: "Oracle's Reflection" }
 258.5 "Sinbound Holy 3 (puddles)" #Ability { id: "9D11", source: "Oracle's Reflection" }
 260.1 "Sinbound Holy 4 (puddles)" #Ability { id: "9D11", source: "Oracle's Reflection" }
-263.9 "Shining Armor + Frost Armor" Ability { id: ["9FC8", "9CF9"], source: ["Oracle's Reflection", "Usurper Of Frost"] }
+263.9 "Shining Armor + Frost Armor" Ability { id: ["9CF8", "9CF9"], source: ["Oracle's Reflection", "Usurper Of Frost"] }
 270.5 "Twin Stillness/Twin Silence" Ability { id: ["9D01", "9D02"], source: "Oracle's Reflection" }
 272.6 "Twin Silence/Twin Stillness" Ability { id: ["9D03", "9D04"], source: "Oracle's Reflection" }
 276.2 "--targetable--"

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
@@ -153,8 +153,8 @@ hideall "--sync--"
 558.8 "Sinbound Meltdown 2 (x10)" Ability { id: "9D2B", source: "Delight's Hourglass" } duration 10.2
 563.6 "Dark Fire III/Unholy Darkness" Ability { id: "9D54", source: "Oracle of Darkness" }
 569.3 "Sinbound Meltdown 3 (x10)" Ability { id: "9D2B", source: "Delight's Hourglass" } duration 10.2
-571.9 "Stun + Rewind"
-574.9 "Shadoweye/Dark Water III/Dark Eruption" Ability { id: "9D56", source: "Oracle of Darkness" }
+572.5 "Stun + Rewind"
+575.0 "Shadoweye/Dark Water III/Dark Eruption" Ability { id: "9D56", source: "Oracle of Darkness" }
 578.6 "Shell Crusher (x2)" Ability { id: "9D5E", source: "Oracle of Darkness" }
 587.1 "Shockwave Pulsar" Ability { id: "9D5A", source: "Oracle of Darkness" }
 595.5 "Black Halo" Ability { id: "9D62", source: "Oracle of Darkness" }


### PR DESCRIPTION
~~This has the rest of p2 and initial p3 through Ultimate Relativity.  I'm marking this as draft/WIP for now because, even though it looks fine in RE, it needs some solid testing in-game (especially on the UR timings).  And there's probably comment typos thanks to my crappy keyboard, and who knows, probably other mistakes too.~~  

(1/11/25 edit: This now has the rest of P2 and P3.  I'll PR the P4 stuff separately.)

I started adding strat options for some stuff as well.  So far:
* Sinbound Holy - the LesBin/current pf strat seems to be to always rotate away from Shiva unless she spawns on a knockback spot, in which case everyone races CW and the group approaching her then slides to rejoin the other before Silence/Stillness.  I haven't seen any other strats getting attention, but defer to others if they have.  This is added as a strat option, but because the alternative is just calling the relative add spot (which feels, i dunno, kinda unhelpful?), I made this the default option.  If folks object, I will change it back.
* Ultimate Relativity - the LesBin/current pf strat seems to be Y north with DPS E-SW.  Using this strat option lets cactbot actually calculate your absolute clock spot for this mech.  For the `none` option, it will still call each step, since it's fairly deterministic regardless of strat.  But again, happy to defer to others here if they have better ideas.