### PR TITLE
raidemulator: Minor tweaks and >8 player support

### DIFF
--- a/ui/raidboss/emulator/translations.ts
+++ b/ui/raidboss/emulator/translations.ts
@@ -349,6 +349,9 @@ const emulatorLabels: Translation = {
     ja: '無出力トリガーを隠す',
     cn: '隐藏收集器',
   },
+  ' label[for=hideGeneral]': {
+    en: 'Hide General',
+  },
 } as const;
 
 const emulatorTooltips: Translation = {
@@ -365,6 +368,9 @@ const emulatorTooltips: Translation = {
     fr: 'Masquer les triggers sans sortie',
     ja: '出力がないトリガーを隠す',
     cn: '隐藏没有输出的触发器',
+  },
+  '.triggerHideGeneral': {
+    en: 'Hide triggers that are not for a specific zone',
   },
   '.connectedIndicator': {
     en: 'Connected to websocket',

--- a/ui/raidboss/raidemulator.html
+++ b/ui/raidboss/raidemulator.html
@@ -154,13 +154,15 @@
               <input type="checkbox" name="hideCollector" class="triggerHideCollector translate" checked="checked" id="hideCollector">
               <label for="hideCollector"></label>
             </div>
+            <div class="trigger-hide-collector-container translate" data-toggle="tooltip" title="">
+              <input type="checkbox" name="hideGeneral" class="triggerHideGeneral translate" checked="checked" id="hideGeneral">
+              <label for="hideGeneral"></label>
+            </div>
             <div style="clear: both"></div>
           </div>
         </div>
         <div class="col-2 party-info-column">
           <div class="d-flex flex-column flex-fill">
-            <div style="height: calc(16.666667vw - 30px)" class="p-1 map">
-            </div>
             <div class="flex-fill party"></div>
           </div>
         </div>


### PR DESCRIPTION
Working on chaotic finally reminded me that the 8-player restriction still existed in raidemulator. Also I got tired of looking at the general `Provoke`/`Shirk` triggers while testing/debugging, so added an option to hide general triggers.

- Remove unused `map` element to make space for more players
- Add `Hide General` triggers checkbox
- Remove 8-player restriction

The timeline bar at the top will still only show the first 8 players' triggers for now. I left an `@TODO` comment in `EmulatedPartyInfo.ts` for this.