### PR TITLE
resources: Update caresAboutAOE

### DIFF
--- a/resources/conditions.ts
+++ b/resources/conditions.ts
@@ -13,7 +13,8 @@ export default {
   },
   caresAboutAOE(): (data: Data) => boolean {
     return (data: Data) =>
-      data.role === 'tank' || data.role === 'healer' || data.CanAddle() || data.job === 'BLU';
+      data.role === 'tank' || data.role === 'healer' || data.CanAddle() || data.CanFeint() ||
+      data.job === 'BLU';
   },
   caresAboutMagical(): (data: Data) => boolean {
     return (data: Data) =>


### PR DESCRIPTION
Feint also applies to magical damage at reduced efficacy since Endwalker.  I don't think we're using this anywhere anymore, but update it anyways for consistency.