### PR TITLE
raidboss: fix bug with delays + countdowns

### DIFF
--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -446,14 +446,14 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Test Trigger Countdown',
       type: 'GameLog',
       netRegex: {
-        line: 'cactbot test trigger countdown',
+        line: 'cactbot test trigger countdown.*?',
         code: Util.gameLogCodes.echo,
         capture: false,
       },
       delaySeconds: 2,
       durationSeconds: 7, // should cause countdown to be displayed at 0.0 for 2 seconds.
       countdownSeconds: 5,
-      infoText: (data, _matches, output) => {
+      infoText: (_data, _matches, output) => {
         return output.text!();
       },
       outputStrings: {
@@ -466,6 +466,7 @@ const triggerSet: TriggerSet<Data> = {
   timelineReplace: [
     {
       locale: 'de',
+      missingTranslations: true,
       replaceSync: {
         'You bid farewell to the striking dummy': 'Du winkst der Trainingspuppe zum Abschied zu',
         'You bow courteously to the striking dummy':
@@ -506,6 +507,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       locale: 'fr',
+      missingTranslations: true,
       replaceSync: {
         'cactbot lang': 'cactbot langue',
         'cactbot test response': 'cactbot test de réponse',
@@ -590,6 +592,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       locale: 'cn',
+      missingTranslations: true,
       replaceSync: {
         'You bid farewell to the striking dummy': '.*向木人告别',
         'You bow courteously to the striking dummy': '.*恭敬地对木人行礼',
@@ -629,6 +632,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       locale: 'ko',
+      missingTranslations: true,
       replaceSync: {
         'You bid farewell to the striking dummy': '.*나무인형에게 작별 인사를 합니다',
         'You bow courteously to the striking dummy': '.*나무인형에게 공손하게 인사합니다',

--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -442,6 +442,26 @@ const triggerSet: TriggerSet<Data> = {
         },
       },
     },
+    {
+      id: 'Test Trigger Countdown',
+      type: 'GameLog',
+      netRegex: {
+        line: 'cactbot test trigger countdown',
+        code: Util.gameLogCodes.echo,
+        capture: false,
+      },
+      delaySeconds: 2,
+      durationSeconds: 7, // should cause countdown to be displayed at 0.0 for 2 seconds.
+      countdownSeconds: 5,
+      infoText: (data, _matches, output) => {
+        return output.text!();
+      },
+      outputStrings: {
+        text: {
+          en: 'Trigger countdown test',
+        },
+      },
+    },
   ],
   timelineReplace: [
     {

--- a/ui/raidboss/data/07-dt/dungeon/vanguard.ts
+++ b/ui/raidboss/data/07-dt/dungeon/vanguard.ts
@@ -109,10 +109,9 @@ const triggerSet: TriggerSet<Data> = {
       type: 'GainsEffect',
       netRegex: { effectId: 'EDA' },
       condition: Conditions.targetIsYou(),
-      // 15s duration - countdown ends at 14s for safety (game lag)
-      delaySeconds: 10,
-      durationSeconds: 5,
-      countdownSeconds: 14, // with 10s delay, countdown will not appear until 4s remaining
+      // 15s duration
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 5,
+      countdownSeconds: 5,
       response: Responses.stopMoving(),
     },
     {

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -529,6 +529,7 @@ export interface TriggerHelper {
     alertText: number;
     infoText: number;
   };
+  adjustedDelay?: number;
   countdown?: number;
   ttsText?: string;
   rumbleDurationMs?: number;
@@ -1340,6 +1341,7 @@ export class PopupText {
 
     if (adjustedDelay <= 0)
       return;
+    triggerHelper.adjustedDelay = adjustedDelay;
 
     const triggerID = this.currentTriggerID++;
     return new Promise((res, rej) => {
@@ -1592,7 +1594,9 @@ export class PopupText {
       triggerHelper.countdown !== undefined &&
       triggerHelper.countdown > 0 // allow users to override with 0 to disable countdown
     ) {
-      const endTime = triggerHelper.now + (triggerHelper.countdown * 1000);
+      const endTime = triggerHelper.now +
+        ((triggerHelper.adjustedDelay ?? 0) * 1000) +
+        (triggerHelper.countdown * 1000);
       const span = document.createElement('span');
 
       // if the localized output string contains the {{CD}} substitution marker,


### PR DESCRIPTION
This fixes a bug (so far only occurring in Vanguard triggers) where `countdownSeconds` is used in conjunction with `delaySeconds`.  Previously, the countdown end time was set to the trigger execution time + the countdown; however, if a delay is also present, the countdown would then be truncated by the amount of the delay (and would display past 0.0), since the alert duration is the greater of the original countdown value or duration.

Fix tested and confirmed working in Vanguard and with some test triggers.  Behavior now matches repo documentation.

cc: @xiashtra who I think (?) mentioned this issue originally