### PR TITLE
raidemulator: Fix trigger popup text not showing up

### DIFF
--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimelineUI.ts
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimelineUI.ts
@@ -26,7 +26,7 @@ export default class RaidEmulatorTimelineUI extends TimelineUI {
   $barContainer: HTMLElement;
   $progressTemplate: HTMLElement;
 
-  private popupText?: PopupText;
+  popupText?: PopupText;
 
   constructor(protected options: RaidbossOptions) {
     super();
@@ -179,13 +179,55 @@ export default class RaidEmulatorTimelineUI extends TimelineUI {
   }
 
   // Override
-  override OnTrigger(
+  public override OnShowInfoText(text: string, currentTime: number): void {
+    this.popupText?.OnTrigger(
+      {
+        infoText: text,
+        tts: text,
+      },
+      null,
+      currentTime,
+    );
+  }
+
+  public override OnShowAlertText(text: string, currentTime: number): void {
+    this.popupText?.OnTrigger(
+      {
+        alertText: text,
+        tts: text,
+      },
+      null,
+      currentTime,
+    );
+  }
+
+  public override OnShowAlarmText(text: string, currentTime: number): void {
+    this.popupText?.OnTrigger(
+      {
+        alarmText: text,
+        tts: text,
+      },
+      null,
+      currentTime,
+    );
+  }
+
+  public override OnSpeakTTS(text: string, currentTime: number): void {
+    this.popupText?.OnTrigger(
+      {
+        infoText: text,
+        tts: text,
+      },
+      null,
+      currentTime,
+    );
+  }
+
+  public override OnTrigger(
     trigger: LooseTimelineTrigger,
     matches: RegExpExecArray | null,
     currentTime: number,
   ): void {
-    if (this.popupText) {
-      this.popupText.OnTrigger(trigger, matches, currentTime);
-    }
+    this.popupText?.OnTrigger(trigger, matches, currentTime);
   }
 }

--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimelineUI.ts
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimelineUI.ts
@@ -1,4 +1,6 @@
 import { UnreachableCode } from '../../../../resources/not_reached';
+import { LooseTimelineTrigger } from '../../../../types/trigger';
+import { PopupText } from '../../popup-text';
 import { RaidbossOptions } from '../../raidboss_options';
 import { TimelineUI } from '../../timeline';
 import { Event } from '../../timeline_parser';
@@ -23,6 +25,9 @@ export default class RaidEmulatorTimelineUI extends TimelineUI {
   emulatedStatus = 'pause';
   $barContainer: HTMLElement;
   $progressTemplate: HTMLElement;
+
+  private popupText?: PopupText;
+
   constructor(protected options: RaidbossOptions) {
     super();
     const container = document.querySelector('.timer-bar-container');
@@ -100,6 +105,10 @@ export default class RaidEmulatorTimelineUI extends TimelineUI {
     bar.$bar.style.width = `${barProg}%`;
   }
 
+  setPopupText(popupText: PopupText): void {
+    this.popupText = popupText;
+  }
+
   override Init(): void {
     // This space intentionally left blank
   }
@@ -167,5 +176,16 @@ export default class RaidEmulatorTimelineUI extends TimelineUI {
       if (expired && this.options.KeepExpiredTimerBarsForSeconds)
         bar.forceRemoveAt += this.options.KeepExpiredTimerBarsForSeconds * 1000;
     });
+  }
+
+  // Override
+  override OnTrigger(
+    trigger: LooseTimelineTrigger,
+    matches: RegExpExecArray | null,
+    currentTime: number,
+  ): void {
+    if (this.popupText) {
+      this.popupText.OnTrigger(trigger, matches, currentTime);
+    }
   }
 }

--- a/ui/raidboss/raidemulator.ts
+++ b/ui/raidboss/raidemulator.ts
@@ -191,6 +191,7 @@ const raidEmulatorOnLoad = async () => {
 
   timelineController.SetPopupTextInterface(new PopupTextGenerator(popupText));
 
+  timelineUI.setPopupText(popupText);
   emulator.setPopupText(popupText);
 
   const emulatorWatchCombatantsOverride = new RaidEmulatorWatchCombatantsOverride(


### PR DESCRIPTION
For timeline triggers, alert text / tts was not showing up in raidemulator.

Due to circular dependency in bindTo, a setter was added for popup text.  Suggestions welcome since I am not familiar with typescript / this project