### PR TITLE
resources: tweak GainsEffect/LosesEffect analysis filters

### DIFF
--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -701,8 +701,8 @@ const latestLogDefinitions = {
           sourceId: '[E4].{7}',
           targetId: '1.{7}',
         },
-        { // effects applied by NPCs to other NPCs (including themselves)
-          sourceId: '4.{7}',
+        { // effect from environment/NPC applied to NPC (including itself)
+          sourceId: '[E4].{7}',
           targetId: '4.{7}',
         },
         { // known effectIds of interest
@@ -809,8 +809,8 @@ const latestLogDefinitions = {
           sourceId: '[E4].{7}',
           targetId: '1.{7}',
         },
-        { // effects applied by NPCs to other NPCs (including themselves)
-          sourceId: '4.{7}',
+        { // effect from environment/NPC applied to NPC (including itself)
+          sourceId: '[E4].{7}',
           targetId: '4.{7}',
         },
         { // known effectIds of interest


### PR DESCRIPTION
The analysis filter for `GainsEffect`/`LosesEffect` currently excludes effects applied by `E0000000` to an NPC (`4.{7}`).  This fixes the filter criteria.

NB.  See https://github.com/OverlayPlugin/cactbot/pull/538#discussion_r1912366585 - this was causing the analysis filter to exclude certain relevant lines in FRU, for example, like:
```
30|2025-01-08T22:11:33.4700000-05:00|307|Invincibility|0.00|E0000000||4000684F|Ice Veil|00|2513805||
```