### PR TITLE
util: New zone coverage report format

### DIFF
--- a/ui/config/config.ts
+++ b/ui/config/config.ts
@@ -138,7 +138,7 @@ export const kPrefixToCategory = {
 };
 
 // Translating data subfolders to encounter type.
-const kDirectoryToCategory = {
+export const kDirectoryToCategory = {
   alliance: {
     en: 'Alliance Raid',
     de: 'Allianz-Raid',

--- a/util/coverage/coverage.css
+++ b/util/coverage/coverage.css
@@ -22,16 +22,6 @@ body > div {
   margin-bottom: 10px;
 }
 
-#description-emoji {
-  float: left;
-  margin-right: 5px;
-}
-
-#description-text {
-  display: inline-block;
-  white-space: normal;
-}
-
 #warning {
   font-size: 30px;
   color: red;
@@ -39,25 +29,6 @@ body > div {
 
 .emoji {
   text-align: center;
-}
-
-#expansion-grid {
-  display: grid;
-  grid-template-columns: max-content repeat(6, minmax(60px, max-content));
-  column-gap: 20px;
-  row-gap: 10px;
-}
-
-#translation-grid {
-  display: grid;
-  grid-template-columns: max-content repeat(4, minmax(60px, max-content));
-  column-gap: 20px;
-  row-gap: 10px;
-}
-
-#expansion-grid > div,
-#translation-grid > div {
-  width: 100%;
 }
 
 .table > thead {

--- a/util/coverage/coverage.css
+++ b/util/coverage/coverage.css
@@ -1,5 +1,9 @@
+html {
+  background-color: initial;
+}
+
 body {
-  margin: 20px;
+  padding: 20px;
   padding-top: 2em;
 }
 
@@ -18,17 +22,6 @@ body > div {
   margin-bottom: 10px;
 }
 
-#language-select {
-  display: grid;
-  grid-auto-flow: column;
-  width: 400px;
-  align-items: end;
-}
-
-#description {
-  white-space: nowrap;
-}
-
 #description-emoji {
   float: left;
   margin-right: 5px;
@@ -37,33 +30,11 @@ body > div {
 #description-text {
   display: inline-block;
   white-space: normal;
-  max-width: 800px;
 }
 
 #warning {
   font-size: 30px;
   color: red;
-}
-
-.label {
-  font-weight: bold;
-  font-size: 20px;
-  background-color: white;
-  position: sticky;
-  top: 0;
-  padding: 3px 0;
-}
-
-#expansion-grid > .label {
-  justify-self: right;
-}
-
-.header {
-  font-size: 18px;
-}
-
-.data {
-  justify-self: right;
 }
 
 .emoji {
@@ -84,25 +55,12 @@ body > div {
   row-gap: 10px;
 }
 
-#zone-grid {
-  display: grid;
-  grid-template-columns: max-content repeat(8, minmax(60px, max-content));
-  column-gap: 20px;
-  row-gap: 10px;
-  justify-items: left;
-}
-
 #expansion-grid > div,
-#translation-grid > div,
-#zone-grid > div {
+#translation-grid > div {
   width: 100%;
 }
 
-#zone-table .text {
-  color: white;
-}
-
-#zone-table > thead {
+.table > thead {
   position: sticky;
   top: 0;
 }
@@ -112,28 +70,49 @@ body > div {
   top: calc(1em + 1rem);
 }
 
-#zone-table .collapsed > td:not(:first-child) {
+.table .collapsed > td:not(:first-child) {
   display: table-cell;
 }
 
-#zone-table tbody > tr:nth-child(odd of .zone-table-content-row:not(.d-none)),
+/* I can't find a way for stlyelint to allow wrapping these selectors across multiple lines */
+/* stylelint-disable max-line-length */
+
+/* For base striped row, color pulled straight from base bootstrap */
 #zone-table tbody > tr:nth-child(odd of .zone-table-content-row:not(.d-none)) > *,
-#zone-table tbody > tr:nth-child(odd of .zone-table-content-row:not(.d-none)) + .collapse,
 #zone-table tbody > tr:nth-child(odd of .zone-table-content-row:not(.d-none)) + .collapse > * {
   background-color: rgb(0 0 0 / 5%);
 }
 
+/* For the rest, convert base RGB for cells to HSL, reduce luminance by 15% */
 #zone-table tbody > tr:nth-child(odd of .zone-table-content-row:not(.d-none)) > td.table-success {
-  /* Convert base RGB for cells to HSL, reduce luminance by 15% */
   background-color: rgb(159 203 183);
 }
 
 #zone-table tbody > tr:nth-child(odd of .zone-table-content-row:not(.d-none)) > td.table-warning {
-  /* Convert base RGB for cells to HSL, reduce luminance by 15% */
   background-color: rgb(255 225 128);
 }
 
 #zone-table tbody > tr:nth-child(odd of .zone-table-content-row:not(.d-none)) > td.table-danger {
-  /* Convert base RGB for cells to HSL, reduce luminance by 15% */
   background-color: rgb(237 151 158);
 }
+
+/* Alternates for dark theme */
+html[data-bs-theme="dark"] #zone-table tbody > tr:nth-child(odd of .zone-table-content-row:not(.d-none)) > *,
+html[data-bs-theme="dark"] #zone-table tbody > tr:nth-child(odd of .zone-table-content-row:not(.d-none)) + .collapse > * {
+  background-color: rgb(255 255 255 / 5%);
+}
+
+/* For the rest, convert base RGB for cells to HSL, reduce luminance by 15% */
+html[data-bs-theme="dark"] #zone-table tbody > tr:nth-child(odd of .zone-table-content-row:not(.d-none)) > td.table-success {
+  background-color: rgb(159 203 183);
+}
+
+html[data-bs-theme="dark"] #zone-table tbody > tr:nth-child(odd of .zone-table-content-row:not(.d-none)) > td.table-warning {
+  background-color: rgb(255 225 128);
+}
+
+html[data-bs-theme="dark"] #zone-table tbody > tr:nth-child(odd of .zone-table-content-row:not(.d-none)) > td.table-danger {
+  background-color: rgb(237 151 158);
+}
+
+/* stylelint-enable max-line-length */

--- a/util/coverage/coverage.css
+++ b/util/coverage/coverage.css
@@ -45,6 +45,30 @@ body > div {
   display: table-cell;
 }
 
+#zone-table .comment {
+  margin: calc(-0.5rem - 1px) 0 calc(-0.5rem - 4px);
+  padding: calc(0.5rem + 1px) 0 calc(0.5rem + 3px);
+  font-size: inherit;
+  max-width: initial;
+  word-wrap: initial;
+  hyphens: initial;
+  display: inline-block;
+  padding-right: 0.5rem;
+}
+
+#zone-table .comment + .comment {
+  padding-left: 0.5rem;
+  border-left: var(--bs-border-width) solid var(--bs-table-border-color);
+}
+
+#zone-table .zone-table-content-row {
+  cursor: pointer;
+}
+
+:target {
+  scroll-margin-top: calc(2em + 2rem);
+}
+
 /* I can't find a way for stlyelint to allow wrapping these selectors across multiple lines */
 /* stylelint-disable max-line-length */
 

--- a/util/coverage/coverage.css
+++ b/util/coverage/coverage.css
@@ -97,3 +97,43 @@ body > div {
 #zone-grid > div {
   width: 100%;
 }
+
+#zone-table .text {
+  color: white;
+}
+
+#zone-table > thead {
+  position: sticky;
+  top: 0;
+}
+
+#zone-table > tbody > .expansion-row {
+  position: sticky;
+  top: calc(1em + 1rem);
+}
+
+#zone-table .collapsed > td:not(:first-child) {
+  display: table-cell;
+}
+
+#zone-table tbody > tr:nth-child(odd of .zone-table-content-row:not(.d-none)),
+#zone-table tbody > tr:nth-child(odd of .zone-table-content-row:not(.d-none)) > *,
+#zone-table tbody > tr:nth-child(odd of .zone-table-content-row:not(.d-none)) + .collapse,
+#zone-table tbody > tr:nth-child(odd of .zone-table-content-row:not(.d-none)) + .collapse > * {
+  background-color: rgb(0 0 0 / 5%);
+}
+
+#zone-table tbody > tr:nth-child(odd of .zone-table-content-row:not(.d-none)) > td.table-success {
+  /* Convert base RGB for cells to HSL, reduce luminance by 15% */
+  background-color: rgb(159 203 183);
+}
+
+#zone-table tbody > tr:nth-child(odd of .zone-table-content-row:not(.d-none)) > td.table-warning {
+  /* Convert base RGB for cells to HSL, reduce luminance by 15% */
+  background-color: rgb(255 225 128);
+}
+
+#zone-table tbody > tr:nth-child(odd of .zone-table-content-row:not(.d-none)) > td.table-danger {
+  /* Convert base RGB for cells to HSL, reduce luminance by 15% */
+  background-color: rgb(237 151 158);
+}

--- a/util/coverage/coverage.d.ts
+++ b/util/coverage/coverage.d.ts
@@ -11,23 +11,30 @@ export type CoverageEntry = {
     hasFile?: boolean;
     timelineNeedsFixing?: boolean;
     hasNoTimeline?: boolean;
+    duration?: number;
+    entries?: number;
   };
   oopsy?: {
     num: number;
+  };
+  translationCount?: {
+    [type in MissingTranslationErrorType]?: number;
   };
   translations?: {
     [lang in Lang]?: {
       [type in MissingTranslationErrorType]?: number;
     };
   };
-  comments?: LocaleText;
-  files: {
+  comments: LocaleText[];
+  files?: {
     name: string;
     commit?: string;
     tag?: string;
     tagHash?: string;
   }[];
   lastModified: number;
+  openPRs: number[];
+  allTags: string[];
 };
 
 export type Coverage = { [zoneId: string]: CoverageEntry };
@@ -58,21 +65,27 @@ export type TranslationTotals = {
   };
 };
 
-export type Tags = {
-  [tagName: string]: {
-    tagDate: number;
-    tagHash: string;
-    files: {
-      name: string;
-      hash: string;
-    }[];
-  };
+export type Tag = {
+  tagName: string;
+  tagDate: number;
+  tagHash: string;
+  tagTitle?: string;
+  files?: {
+    name: string;
+    hash: string;
+  }[];
 };
 
-export type Pulls = {
+export type Tags = {
+  [tagName: string]: Tag;
+};
+
+export type Pull = {
   url: string;
   number: number;
   title: string;
-  files: string[];
+  files?: string[];
   zones: number[];
-}[];
+};
+
+export type Pulls = Pull[];

--- a/util/coverage/coverage.html
+++ b/util/coverage/coverage.html
@@ -30,9 +30,9 @@
 <body>
   <div id="title"></div>
   <div id="language-select"></div>
-  <div id="description">
-    <span id="description-emoji">📢</span>
-    <span id="description-text"></span>
+  <div id="description" class="d-flex">
+    <div class="align-self-center me-2">📢</div>
+    <div id="description-text"></div>
   </div>
   <div id="warning"></div>
   <div><table id="expansion-table" class="table table-striped table-bordered"></table></div>

--- a/util/coverage/coverage.html
+++ b/util/coverage/coverage.html
@@ -29,7 +29,16 @@
 </head>
 <body>
   <div id="title"></div>
-  <div id="language-select"></div>
+  <div class="container container-fluid mx-0 px-0">
+    <div class="row">
+      <div class="col">
+        <div id="language-select"></div>
+      </div>
+      <div class="col">
+        <div id="theme-select"></div>
+      </div>
+    </div>
+  </div>
   <div id="description" class="d-flex">
     <div class="align-self-center me-2">📢</div>
     <div id="description-text"></div>

--- a/util/coverage/coverage.html
+++ b/util/coverage/coverage.html
@@ -2,6 +2,8 @@
 <head>
   <meta charset="utf-8" />
   <title>Cactbot Content Coverage</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 </head>
 <body>
   <div id="title"></div>
@@ -13,5 +15,7 @@
   <div id="warning"></div>
   <div id="expansion-grid"></div>
   <div id="translation-grid"></div>
-  <div id="zone-grid"></div>
+  <div class="input-group"><input type="text" id="zone-table-filter" class="w-auto" placeholder="Search..." /><span class="input-group-text">⌕</span></div>
+  <table id="zone-table" class="table table-hover">
+  </table>
 </body>

--- a/util/coverage/coverage.html
+++ b/util/coverage/coverage.html
@@ -4,6 +4,28 @@
   <title>Cactbot Content Coverage</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+  <script type="text/javascript">
+    // This JS is deliberately inline to allow early evaluation and apply dark mode quickly
+
+    // First try from query params
+    const params = new URLSearchParams(window.location.search);
+    let theme = params.get('theme');
+
+    // Then from stored value
+    if (theme === null || theme === undefined || theme.length === 0)
+      theme = localStorage.getItem('theme');
+    else {
+      // If we did actually get a theme param, store it in local storage for future override
+      localStorage.setItem('theme', theme);
+    }
+
+    // Final check from media query
+    if (theme === null || theme === undefined || theme.length === 0)
+      theme = window.matchMedia("(prefers-color-scheme:dark)").matches ? 'dark' : undefined;
+
+    if (theme === 'dark')
+      document.documentElement.setAttribute('data-bs-theme', 'dark');
+  </script>
 </head>
 <body>
   <div id="title"></div>
@@ -13,9 +35,10 @@
     <span id="description-text"></span>
   </div>
   <div id="warning"></div>
-  <div id="expansion-grid"></div>
-  <div id="translation-grid"></div>
-  <div class="input-group"><input type="text" id="zone-table-filter" class="w-auto" placeholder="Search..." /><span class="input-group-text">⌕</span></div>
-  <table id="zone-table" class="table table-hover">
-  </table>
+  <div><table id="expansion-table" class="table table-striped table-bordered"></table></div>
+  <div><table id="translation-table" class="table table-striped table-bordered"></table></div>
+  <div>
+    <div class="input-group mb-2"><span class="input-group-text">Zone Filter</span><input type="text" id="zone-table-filter" class="w-auto" placeholder="Search..." /><span class="input-group-text">⌕</span></div>
+    <div><table id="zone-table" class="table table-hover table-bordered"></table></div>
+  </div>
 </body>


### PR DESCRIPTION
Plus dark theme, autodetected based on media query with an optional `?theme=dark|light` query parameter to override. If manually overridden, that setting is saved in local storage and used in the future.

Light theme:
![coverage light theme](https://github.com/user-attachments/assets/43c289a2-2d5f-4fce-a87d-d083b30dbc84)

Dark theme:
![coverage dark theme](https://github.com/user-attachments/assets/74efe53e-3dc2-44b3-876f-167d375d3734)

Dark theme with filtered zone table:
![coverage with filter](https://github.com/user-attachments/assets/da5528e0-98d7-418a-a3c6-95fe94c5e467)

Example of sticky headers on zone table, with row hover effect:
![image](https://github.com/user-attachments/assets/a0270cd7-5bf0-44bf-acc3-1fb876dae032)

I'm still working out a few minor bugs with table borders, as seen on the last screenshot with the sticky headers, and with the description megaphone icon not floating left properly, but this is code complete otherwise and ready for a general review.