### PR TITLE
raidboss: more coverage comments

### DIFF
--- a/resources/content_list.ts
+++ b/resources/content_list.ts
@@ -131,10 +131,8 @@ const contentList: (ZoneIdType)[] = [
   ZoneId.TheBowlOfEmbers,
   ZoneId.TheNavel,
   ZoneId.TheHowlingEye,
-  ZoneId.CapeWestwind, // changed to solo duty in 6.1
   ZoneId.ThePortaDecumana,
   ZoneId.TheChrysalis,
-  ZoneId.TheStepsOfFaith, // changed to solo duty in 6.2
   ZoneId.ARelicRebornTheChimera,
   ZoneId.ARelicRebornTheHydra,
   ZoneId.BattleOnTheBigBridge,

--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -32,7 +32,7 @@ const triggerSet: TriggerSet<Data> = {
   },
   comments: {
     en:
-      'Testing/troubleshooting triggers (See <a href="https://github.com/OverlayPlugin/cactbot/blob/main/docs/FAQ-Troubleshooting.md#summerford-farms-raidboss-test">Summerford Farms Raidboss Test</a>)',
+      'Testing/troubleshooting triggers (See: <a href="https://github.com/OverlayPlugin/cactbot/blob/main/docs/FAQ-Troubleshooting.md#summerford-farms-raidboss-test">Summerford Farms Raidboss Test</a>)',
   },
   config: [
     {

--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -28,10 +28,11 @@ const triggerSet: TriggerSet<Data> = {
   id: 'CactbotTest',
   zoneId: ZoneId.MiddleLaNoscea,
   zoneLabel: {
-    en: 'Cactbot test triggers (Summerford Farms)',
+    en: 'Cactbot Test Triggers',
   },
   comments: {
-    en: 'Cactbot test triggers (Summerford Farms)',
+    en:
+      'Testing/troubleshooting triggers (See <a href="https://github.com/OverlayPlugin/cactbot/blob/main/docs/FAQ-Troubleshooting.md#summerford-farms-raidboss-test">Summerford Farms Raidboss Test</a>)',
   },
   config: [
     {

--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -27,8 +27,11 @@ export interface Data extends RaidbossData {
 const triggerSet: TriggerSet<Data> = {
   id: 'CactbotTest',
   zoneId: ZoneId.MiddleLaNoscea,
+  zoneLabel: {
+    en: 'Cactbot test triggers (Summerford Farms)',
+  },
   comments: {
-    en: 'Cactbot test triggers',
+    en: 'Cactbot test triggers (Summerford Farms)',
   },
   config: [
     {

--- a/ui/raidboss/data/04-sb/hunts/yanxia.ts
+++ b/ui/raidboss/data/04-sb/hunts/yanxia.ts
@@ -9,7 +9,7 @@ const triggerSet: TriggerSet<Data> = {
   id: 'Yanxia',
   zoneId: ZoneId.Yanxia,
   comments: {
-    en: 'Hunts: Angada only',
+    en: 'A Rank Hunts: Angada only',
   },
   triggers: [
     {

--- a/ui/raidboss/data/05-shb/hunts/amh_araeng.ts
+++ b/ui/raidboss/data/05-shb/hunts/amh_araeng.ts
@@ -11,7 +11,7 @@ const triggerSet: TriggerSet<Data> = {
   id: 'AmhAraeng',
   zoneId: ZoneId.AmhAraeng,
   comments: {
-    en: 'Hunts',
+    en: 'A Rank Hunts',
   },
   triggers: [
     {

--- a/ui/raidboss/data/05-shb/hunts/il_mheg.ts
+++ b/ui/raidboss/data/05-shb/hunts/il_mheg.ts
@@ -9,7 +9,7 @@ const triggerSet: TriggerSet<Data> = {
   id: 'IlMheg',
   zoneId: ZoneId.IlMheg,
   comments: {
-    en: 'Hunts',
+    en: 'A Rank Hunts',
   },
   triggers: [
     {

--- a/ui/raidboss/data/05-shb/hunts/kholusia.ts
+++ b/ui/raidboss/data/05-shb/hunts/kholusia.ts
@@ -12,7 +12,7 @@ const triggerSet: TriggerSet<Data> = {
   id: 'Kholusia',
   zoneId: ZoneId.Kholusia,
   comments: {
-    en: 'Hunts, missing Formidable boss FATE',
+    en: 'A Rank Hunts, missing Formidable boss FATE',
   },
   triggers: [
     {

--- a/ui/raidboss/data/05-shb/hunts/lakeland.ts
+++ b/ui/raidboss/data/05-shb/hunts/lakeland.ts
@@ -12,7 +12,7 @@ const triggerSet: TriggerSet<Data> = {
   id: 'Lakeland',
   zoneId: ZoneId.Lakeland,
   comments: {
-    en: 'Hunts',
+    en: 'A Rank Hunts',
   },
   triggers: [
     {

--- a/ui/raidboss/data/05-shb/hunts/ss_rank.ts
+++ b/ui/raidboss/data/05-shb/hunts/ss_rank.ts
@@ -22,6 +22,9 @@ const triggerSet: TriggerSet<Data> = {
     cn: 'SS 级狩猎怪',
     ko: 'SS급 마물',
   },
+  comments: {
+    en: 'SS Rank Hunts',
+  },
   triggers: [
     {
       id: 'Hunt Rebellion Royal Decree',

--- a/ui/raidboss/data/05-shb/hunts/the_raktika_greatwood.ts
+++ b/ui/raidboss/data/05-shb/hunts/the_raktika_greatwood.ts
@@ -12,7 +12,7 @@ const triggerSet: TriggerSet<Data> = {
   id: 'TheRaktikaGreatwood',
   zoneId: ZoneId.TheRaktikaGreatwood,
   comments: {
-    en: 'Hunts',
+    en: 'A Rank Hunts',
   },
   triggers: [
     {

--- a/ui/raidboss/data/05-shb/hunts/the_tempest.ts
+++ b/ui/raidboss/data/05-shb/hunts/the_tempest.ts
@@ -14,7 +14,7 @@ const triggerSet: TriggerSet<Data> = {
   id: 'TheTempest',
   zoneId: ZoneId.TheTempest,
   comments: {
-    en: 'Hunts, missing Archaeotania boss FATE',
+    en: 'A Rank Hunts, missing Archaeotania boss FATE',
   },
   triggers: [
     {

--- a/ui/raidboss/data/06-ew/hunts/elpis.ts
+++ b/ui/raidboss/data/06-ew/hunts/elpis.ts
@@ -12,7 +12,7 @@ const triggerSet: TriggerSet<Data> = {
   id: 'Elpis',
   zoneId: ZoneId.Elpis,
   comments: {
-    en: 'Hunts',
+    en: 'A Rank Hunts',
   },
   triggers: [
     {

--- a/ui/raidboss/data/06-ew/hunts/garlemald.ts
+++ b/ui/raidboss/data/06-ew/hunts/garlemald.ts
@@ -11,7 +11,7 @@ const triggerSet: TriggerSet<Data> = {
   id: 'Garlemald',
   zoneId: ZoneId.Garlemald,
   comments: {
-    en: 'Hunts',
+    en: 'A Rank Hunts',
   },
   triggers: [
     {

--- a/ui/raidboss/data/06-ew/hunts/labyrinthos.ts
+++ b/ui/raidboss/data/06-ew/hunts/labyrinthos.ts
@@ -9,7 +9,7 @@ const triggerSet: TriggerSet<Data> = {
   id: 'Labyrinthos',
   zoneId: ZoneId.Labyrinthos,
   comments: {
-    en: 'Hunts',
+    en: 'A Rank Hunts',
   },
   triggers: [
     {

--- a/ui/raidboss/data/06-ew/hunts/mare_lamentorum.ts
+++ b/ui/raidboss/data/06-ew/hunts/mare_lamentorum.ts
@@ -14,7 +14,7 @@ const triggerSet: TriggerSet<Data> = {
   id: 'MareLamentorum',
   zoneId: ZoneId.MareLamentorum,
   comments: {
-    en: 'Hunts',
+    en: 'A Rank Hunts',
   },
   resetWhenOutOfCombat: false,
   initData: () => {

--- a/ui/raidboss/data/06-ew/hunts/ss_rank.ts
+++ b/ui/raidboss/data/06-ew/hunts/ss_rank.ts
@@ -28,6 +28,9 @@ const triggerSet: TriggerSet<Data> = {
     cn: 'SS 级狩猎怪',
     ko: 'SS급 마물',
   },
+  comments: {
+    en: 'SS Rank Hunts',
+  },
   triggers: [
     {
       id: 'Hunt Ker Heliovoid',

--- a/ui/raidboss/data/06-ew/hunts/thavnair.ts
+++ b/ui/raidboss/data/06-ew/hunts/thavnair.ts
@@ -27,7 +27,7 @@ const triggerSet: TriggerSet<Data> = {
   id: 'Thavnair',
   zoneId: ZoneId.Thavnair,
   comments: {
-    en: 'Hunts and Daivadipa boss FATE',
+    en: 'A Rank Hunts and Daivadipa boss FATE',
   },
   resetWhenOutOfCombat: false,
   initData: () => {

--- a/ui/raidboss/data/06-ew/hunts/ultima_thule.ts
+++ b/ui/raidboss/data/06-ew/hunts/ultima_thule.ts
@@ -18,7 +18,7 @@ const triggerSet: TriggerSet<Data> = {
   id: 'UltimaThule',
   zoneId: ZoneId.UltimaThule,
   comments: {
-    en: 'Hunts and Chi boss FATE',
+    en: 'A Rank Hunts and Chi boss FATE',
   },
   triggers: [
     {

--- a/ui/raidboss/data/07-dt/hunts/heritage_found.ts
+++ b/ui/raidboss/data/07-dt/hunts/heritage_found.ts
@@ -52,7 +52,7 @@ const triggerSet: TriggerSet<Data> = {
   id: 'HeritageFound',
   zoneId: ZoneId.HeritageFound,
   comments: {
-    en: 'Hunts',
+    en: 'A Rank Hunts',
   },
   initData: () => ({
     atticusCleaves: [],

--- a/ui/raidboss/data/07-dt/hunts/kozamauka.ts
+++ b/ui/raidboss/data/07-dt/hunts/kozamauka.ts
@@ -36,7 +36,7 @@ const triggerSet: TriggerSet<Data> = {
   id: 'Kozamauka',
   zoneId: ZoneId.Kozamauka,
   comments: {
-    en: 'Hunts',
+    en: 'A Rank Hunts',
   },
   initData: () => ({
     nextDoReMisery: [],

--- a/ui/raidboss/data/07-dt/hunts/living_memory.ts
+++ b/ui/raidboss/data/07-dt/hunts/living_memory.ts
@@ -135,7 +135,7 @@ const triggerSet: TriggerSet<Data> = {
   id: 'LivingMemory',
   zoneId: ZoneId.LivingMemory,
   comments: {
-    en: 'Hunts and Mica the Magical Mu boss FATE',
+    en: 'A Rank Hunts and Mica the Magical Mu boss FATE',
   },
   initData: () => ({
     executionSafe: [],

--- a/ui/raidboss/data/07-dt/hunts/shaaloani.ts
+++ b/ui/raidboss/data/07-dt/hunts/shaaloani.ts
@@ -198,7 +198,7 @@ const triggerSet: TriggerSet<Data> = {
   id: 'Shaaloani',
   zoneId: ZoneId.Shaaloani,
   comments: {
-    en: 'Hunts and Ttokrrone boss FATE',
+    en: 'A Rank Hunts and Ttokrrone boss FATE',
   },
   initData: () => ({
     yeheheTurnBuffs: [],

--- a/ui/raidboss/data/07-dt/hunts/ss_rank.ts
+++ b/ui/raidboss/data/07-dt/hunts/ss_rank.ts
@@ -27,6 +27,9 @@ const triggerSet: TriggerSet<Data> = {
     cn: 'SS 级狩猎怪',
     ko: 'SS급 마물',
   },
+  comments: {
+    en: 'SS Rank Hunts',
+  },
   triggers: [
     {
       id: 'Hunt Arch Aethereater Aetherodynamics',

--- a/ui/raidboss/data/07-dt/hunts/urqopacha.ts
+++ b/ui/raidboss/data/07-dt/hunts/urqopacha.ts
@@ -21,7 +21,7 @@ const triggerSet: TriggerSet<Data> = {
   id: 'Urqopacha',
   zoneId: ZoneId.Urqopacha,
   comments: {
-    en: 'Hunts',
+    en: 'A Rank Hunts',
   },
   triggers: [
     // ****** A-RANK: Nechuciho ****** //

--- a/ui/raidboss/data/07-dt/hunts/yaktel.ts
+++ b/ui/raidboss/data/07-dt/hunts/yaktel.ts
@@ -16,7 +16,7 @@ const triggerSet: TriggerSet<Data> = {
   id: 'YakTel',
   zoneId: ZoneId.YakTel,
   comments: {
-    en: 'Hunts',
+    en: 'A Rank Hunts',
   },
   initData: () => ({
     rraxTriplicateSafe: [],


### PR DESCRIPTION
- added coverage report comments for SS-rank hunt triggers
- added descriptive name for the Cactbot test triggers (will show in the config UI instead of "Middle La Noscea")
- removed Cape Westwind and The Steps of Faith from `content_list.ts` so they no longer show on the coverage report (both instances were re-worked from Trials into solo instances during Endwalker)