### PR TITLE
raidboss: Add --targetable-- for P4 start

### DIFF
--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.txt
@@ -173,6 +173,7 @@ hideall "--sync--"
 670.3 "Memory's End (enrage)" Ability { id: "9D6C", source: "Oracle of Darkness" }
 
 # Phase Four
+679.3 "--targetable--"
 684.7 "--sync--" StartsUsing { id: "9D36", source: "Usurper of Frost" } window 10,10
 687.4 "Materialization" Ability { id: "9D36", source: "Usurper of Frost" } window 10,0
 698.6 "Drachen Armor" Ability { id: "9CFA", source: "Usurper of Frost" }


### PR DESCRIPTION
Adds the `--targetable--` line for P4 start.

Example relevant lines:
```
# 670.3 "Memory's End (enrage)" Ability { id: "9D6C", source: "Oracle of Darkness" }
21|2025-01-21T20:50:24.1370000-08:00|400086E9|Oracle of Darkness|9D6C|Memory's End|400086E9|Oracle of Darkness|1B|9D6C8000|0|0|0|0|0|0|0|0|0|0|0|0|0|0|4802177|30909445|10000|10000|||93.06|106.98|0.00|-0.61|4802177|30909445|10000|10000|||93.06|106.98|0.00|-0.61|00008B2C|0|1|00||01|9D6C|9D6C|3.600|6731|4126f9d05d75eeac
# 679.3 "--targetable--"
34|2025-01-21T20:50:33.1120000-08:00|40008718|Usurper of Frost|40008718|Usurper of Frost|01|87bd5224e09c1df3
# 684.7 "--sync--" StartsUsing { id: "9D36", source: "Usurper of Frost" } window 10,10
20|2025-01-21T20:50:38.3430000-08:00|40008718|Usurper of Frost|9D36|Materialization|40008718|Usurper of Frost|2.700|100.00|90.00|0.00|0.00|f3040f9a0d12c79b
```