### PR TITLE
raidboss: FRU UR - fix ice bait/rewind output

### DIFF
--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
@@ -1198,8 +1198,11 @@ const triggerSet: TriggerSet<Data> = {
         if (debuff === undefined)
           return;
 
-        if (data.triggerSetConfig.ultimateRel !== 'yNorthDPSEast')
+        if (data.triggerSetConfig.ultimateRel !== 'yNorthDPSEast') {
+          if (debuff === 'ice')
+            return role === 'dps' ? output.iceDps!() : output.iceSupport!();
           return output[debuff]!();
+        }
 
         const dirStr = data.p3RelativityMyDirStr;
 
@@ -1276,8 +1279,11 @@ const triggerSet: TriggerSet<Data> = {
         if (debuff === undefined)
           return;
 
-        if (data.triggerSetConfig.ultimateRel !== 'yNorthDPSEast')
+        if (data.triggerSetConfig.ultimateRel !== 'yNorthDPSEast') {
+          if (debuff === 'ice')
+            return role === 'dps' ? output.iceDps!() : output.iceSupport!();
           return output[debuff]!();
+        }
 
         const dirStr = data.p3RelativityMyDirStr;
 


### PR DESCRIPTION
This fixes a bug in the ice bait/rewind callouts in Ultimate Relativity if the user has selected `none` as their config option.  Verified in emulator; no impact on timing, just now correctly outputs the intended string instead of `???`.