### PR TITLE
lint: prevent prop use on data.party.member

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -300,6 +300,7 @@ const overrides = [
   {
     'files': ['**/raidboss/data/**/*'],
     'rules': {
+      'rulesdir/cactbot-party-member-property-access': 'error',
       'rulesdir/cactbot-trigger-property-order': ['warn', { 'module': 'raidboss' }],
       'rulesdir/cactbot-triggerset-property-order': ['warn', { 'module': 'raidboss' }],
     },

--- a/docs/RaidbossGuide.md
+++ b/docs/RaidbossGuide.md
@@ -513,7 +513,7 @@ Then it returns the replaced string for `alarmText` to use.
 
 Instead of passing a name into any trigger, always use `data.party.member` to pass a player object instead.
 This allows the "use job names instead of player names" option to work.
-Do not directly access the `.nick` or `.toString()` properties of `data.party.member()` in triggers;
+Do not directly access properties of `data.party.member()` in triggers;
 always use `data.party.member()` so output will reflect user config preferences.
 You can always pass any array (of strings or of player objects) as a parameter
 and the result will be a list with commas, e.g. `['a', 'b', 'c']` => `'a, b, c'`.

--- a/docs/RaidbossGuide.md
+++ b/docs/RaidbossGuide.md
@@ -513,6 +513,8 @@ Then it returns the replaced string for `alarmText` to use.
 
 Instead of passing a name into any trigger, always use `data.party.member` to pass a player object instead.
 This allows the "use job names instead of player names" option to work.
+Do not directly access the `.nick` or `.toString()` properties of `data.party.member()` in triggers;
+always use `data.party.member()` so output will reflect user config preferences.
 You can always pass any array (of strings or of player objects) as a parameter
 and the result will be a list with commas, e.g. `['a', 'b', 'c']` => `'a, b, c'`.
 

--- a/eslint/cactbot-party-member-property-access.js
+++ b/eslint/cactbot-party-member-property-access.js
@@ -1,0 +1,38 @@
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'no use of data.party.member().nick or .toString() in raidboss triggers',
+      category: 'Best Practices',
+      recommended: true,
+      url:
+        'https://github.com/OverlayPlugin/cactbot/blob/main/docs/RaidbossGuide.md#trigger-properties',
+    },
+    fixable: 'code',
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      'Property[key.name=/(timelineTriggers|triggers)/] > ArrayExpression > ObjectExpression': (
+        node,
+      ) => {
+        // Look for any use of data.party.member().nick or .toString within a trigger,
+        const matchRegex = /data\.party\.member\(([^)]+)\)\.(nick|toString\(\))/;
+
+        const trigger = context.getSourceCode().getText(node);
+        const lines = trigger.split('\n').map((l) => l.trim());
+        lines.forEach((line) => {
+          const match = matchRegex.exec(line);
+          if (match) {
+            context.report({
+              node,
+              message: `"${line}"
+              Use data.party.member(); do not add .nick or .toString().`,
+            });
+          }
+        });
+      },
+    };
+  },
+};

--- a/eslint/cactbot-party-member-property-access.js
+++ b/eslint/cactbot-party-member-property-access.js
@@ -2,7 +2,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'no use of data.party.member().nick or .toString() in raidboss triggers',
+      description: 'no use of data.party.member() properties',
       category: 'Best Practices',
       recommended: true,
       url:
@@ -17,8 +17,8 @@ module.exports = {
       'Property[key.name=/(timelineTriggers|triggers)/] > ArrayExpression > ObjectExpression': (
         node,
       ) => {
-        // Look for any use of data.party.member().nick or .toString within a trigger,
-        const matchRegex = /data\.party\.member\(([^)]+)\)\.(nick|toString\(\))/;
+        // Look for any use of data.party.member().[property],
+        const matchRegex = /data\.party\.member\(([^)]+)\)\.\w+/;
 
         const trigger = context.getSourceCode().getText(node);
         const lines = trigger.split('\n').map((l) => l.trim());
@@ -28,7 +28,7 @@ module.exports = {
             context.report({
               node,
               message: `"${line}"
-              Use data.party.member(); do not add .nick or .toString().`,
+              Use data.party.member(); do not directly access its properties in triggers.`,
             });
           }
         });

--- a/ui/raidboss/data/07-dt/raid/r2s.ts
+++ b/ui/raidboss/data/07-dt/raid/r2s.ts
@@ -623,18 +623,17 @@ const triggerSet: TriggerSet<Data> = {
       condition: Conditions.targetIsYou(),
       delaySeconds: (_data, matches) => parseFloat(matches.duration) - 10,
       alertText: (data, _matches, output) => {
-        let partner = output.unknown!();
+        const unknown = output.unknown!();
         const myType = data.beelovedType;
         if (myType === undefined)
-          return output.merge!({ player: partner });
+          return output.merge!({ player: unknown });
 
         const orderIdx = data.beelovedDebuffs[myType].indexOf(data.me);
         if (orderIdx === -1)
-          return output.merge!({ player: partner });
+          return output.merge!({ player: unknown });
 
         const partnerType = myType === 'alpha' ? 'beta' : 'alpha';
-        partner = data.party.member(data.beelovedDebuffs[partnerType][orderIdx]).nick ??
-          output.unknown!();
+        const partner = data.party.member(data.beelovedDebuffs[partnerType][orderIdx]) ?? unknown;
         return output.merge!({ player: partner });
       },
       outputStrings: {
@@ -668,8 +667,8 @@ const triggerSet: TriggerSet<Data> = {
         if (alpha === data.me || beta === data.me)
           return;
 
-        const alphaShort = data.party.member(alpha).nick ?? output.unknown!();
-        const betaShort = data.party.member(beta).nick ?? output.unknown!();
+        const alphaShort = data.party.member(alpha) ?? output.unknown!();
+        const betaShort = data.party.member(beta) ?? output.unknown!();
         return output.merge!({ alpha: alphaShort, beta: betaShort });
       },
       outputStrings: {

--- a/ui/raidboss/data/07-dt/raid/r4s.ts
+++ b/ui/raidboss/data/07-dt/raid/r4s.ts
@@ -1243,12 +1243,8 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { effectId: 'F9F', capture: true },
       condition: Conditions.targetIsNotYou(),
       run: (data, matches) => {
-        data.condenserTimer = parseFloat(matches.duration) > 30 ? 'long' : 'short';
-        const shortName = data.party.member(matches.target).nick;
-        if (data.condenserTimer === 'long')
-          data.condenserMap.long.push(shortName);
-        else
-          data.condenserMap.short.push(shortName);
+        const condenserTimer = parseFloat(matches.duration) > 30 ? 'long' : 'short';
+        data.condenserMap[condenserTimer].push(matches.target);
       },
     },
     {
@@ -1265,7 +1261,9 @@ const triggerSet: TriggerSet<Data> = {
           data.witchgleamSelfCount++;
 
         // Some strats use long/short debuff assignments to do position swaps for EE2.
-        const same = data.condenserMap[data.condenserTimer].join(', ');
+        const same = data.condenserMap[data.condenserTimer]
+          .map((p) => data.party.member(p))
+          .join(', ');
 
         // Note: Taking unexpected lightning damage from Four/Eight Star, Sparks, or Sidewise Spark
         // will cause the stack count to increase. We could try to try to track that, but it makes
@@ -1704,7 +1702,7 @@ const triggerSet: TriggerSet<Data> = {
             !data.kindlingCauldronTargets.includes(m) &&
             !data.mustardBombTargets.includes(m)
           );
-          const toStr = safePlayers.map((m) => data.party.member(m).nick).join(', ');
+          const toStr = safePlayers.map((m) => data.party.member(m)).join(', ');
 
           return output.passDebuff!({ to: toStr });
         } else if (!data.kindlingCauldronTargets.includes(data.me)) {

--- a/ui/raidboss/data/07-dt/trial/zoraal-ja.ts
+++ b/ui/raidboss/data/07-dt/trial/zoraal-ja.ts
@@ -316,7 +316,7 @@ const triggerSet: TriggerSet<Data> = {
       infoText: (data, _matches, output) => {
         if (data.bitterReapingTargets.includes(data.me))
           return output.busterOnYou!();
-        const players = data.bitterReapingTargets.map((x) => data.party.member(x).nick).join(
+        const players = data.bitterReapingTargets.map((x) => data.party.member(x)).join(
           output.and!(),
         );
         return output.busters!({ player: players });

--- a/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
+++ b/ui/raidboss/data/07-dt/ultimate/futures_rewritten.ts
@@ -2208,19 +2208,19 @@ const triggerSet: TriggerSet<Data> = {
             if (dpsWithTank === data.me)
               return {
                 alertText: output.towerYouSwap!({
-                  player: data.party.member(towerTank).toString(),
+                  player: data.party.member(towerTank),
                 }),
               };
             else if (towerTank === data.me)
               return {
                 alertText: output.towerYouSwap!({
-                  player: data.party.member(dpsWithTank).toString(),
+                  player: data.party.member(dpsWithTank),
                 }),
               };
             return {
               infoText: output.towerOtherSwap!({
-                p1: data.party.member(dpsWithTank).toString(),
-                p2: data.party.member(towerTank).toString(),
+                p1: data.party.member(dpsWithTank),
+                p2: data.party.member(towerTank),
               }),
             };
           }
@@ -2239,7 +2239,7 @@ const triggerSet: TriggerSet<Data> = {
             return defaultOutput;
           return {
             alertText: output.baitDPS!({
-              otherDps: data.party.member(otherDps).toString(),
+              otherDps: data.party.member(otherDps),
             }),
           };
         }
@@ -2307,7 +2307,7 @@ const triggerSet: TriggerSet<Data> = {
         const baitStackPlayer = data.p4DarklitStacks.find((p) => baitPlayers.includes(p));
         if (baitStackPlayer === undefined || !baitPlayers.includes(data.me))
           return {};
-        const stackName = data.party.member(baitStackPlayer).toString();
+        const stackName = data.party.member(baitStackPlayer);
 
         const isStackOnMe = data.me === baitStackPlayer;
         const defaultOutput = isStackOnMe ? { infoText: output.stackOnYou!() } : {};


### PR DESCRIPTION
Adds lint rule and doc update to prevent use of `data.party.member().nick` or `.toString()` in raidboss triggers.  Also lints some current uses of the same in recent trigger files.

Closes #625.