### PR TITLE
util: fix weather rate schema in gen_zone_info

### DIFF
--- a/util/gen_zone_id_and_info.ts
+++ b/util/gen_zone_id_and_info.ts
@@ -130,7 +130,7 @@ type ResultTerritoryType = {
       };
     };
     TerritoryIntendedUse?: RowIdOnly;
-    WeatherRate?: number;
+    WeatherRate?: RowIdOnly;
   };
 };
 
@@ -564,7 +564,7 @@ const generateZoneInfoMap = async (
       continue;
     }
 
-    const weatherRate = ttZoneData.fields.WeatherRate;
+    const weatherRate = ttZoneData.fields.WeatherRate?.row_id;
     if (weatherRate === undefined) {
       log.alert(`No weather rate data found for territory ID ${ttId}. Resolve before merge.`);
       continue;


### PR DESCRIPTION
Updating the `gen_zone_id_and_info` script to reflect underlying xivapi schema changes for the `TerritoryType` sheet.

(No actual resource file changes with 7.2hf1 though.)