### PR TITLE
raidboss: update M5N/M6N tankbusters

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r5n.ts
+++ b/ui/raidboss/data/07-dt/raid/r5n.ts
@@ -345,9 +345,10 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
+      // cast is self-targeted on boss
       id: 'R5N Deep Cut',
-      type: 'StartsUsing',
-      netRegex: { id: 'A6C6', source: 'Dancing Green', capture: true },
+      type: 'HeadMarker',
+      netRegex: { id: headMarkerData.tankLaser, capture: true },
       response: Responses.tankCleave(),
     },
     {

--- a/ui/raidboss/data/07-dt/raid/r5n.ts
+++ b/ui/raidboss/data/07-dt/raid/r5n.ts
@@ -348,7 +348,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'R5N Deep Cut',
       type: 'StartsUsing',
       netRegex: { id: 'A6C6', source: 'Dancing Green', capture: true },
-      response: Responses.tankBuster(),
+      response: Responses.tankCleave(),
     },
     {
       id: 'R5N Full Beat',

--- a/ui/raidboss/data/07-dt/raid/r6n.ts
+++ b/ui/raidboss/data/07-dt/raid/r6n.ts
@@ -297,15 +297,17 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.aoe(),
     },
     {
+      // cast is self-targeted on boss
       id: 'R6N Pudding Party',
       type: 'HeadMarker',
       netRegex: { id: headMarkerData.stack, capture: true },
       response: Responses.stackMarkerOn(),
     },
     {
+      // cast is self-targeted on boss
       id: 'R6N Color Riot',
-      type: 'StartsUsing',
-      netRegex: { id: 'A670', source: 'Sugar Riot', capture: true },
+      type: 'HeadMarker',
+      netRegex: { id: headMarkerData.tankbuster, capture: true },
       response: Responses.tankCleave(),
     },
     {


### PR DESCRIPTION
These split busters are self-targeted casts from the boss; update the triggers to use headmarkers instead.