### PR TITLE
raidboss: r8s reign direction

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r8s.ts
+++ b/ui/raidboss/data/07-dt/raid/r8s.ts
@@ -1,4 +1,3 @@
-import { UnreachableCode } from '../../../../../resources/not_reached';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
 import { Responses } from '../../../../../resources/responses';
 import { Directions } from '../../../../../resources/util';

--- a/ui/raidboss/data/07-dt/raid/r8s.ts
+++ b/ui/raidboss/data/07-dt/raid/r8s.ts
@@ -99,14 +99,16 @@ const triggerSet: TriggerSet<Data> = {
         })).combatants;
         const actor = actors[0];
         if (actors.length !== 1 || actor === undefined) {
-          console.error(`R8S Eminent/Revolutionary Reign Direction: Wrong actor count ${actors.length}`);
+          console.error(
+            `R8S Eminent/Revolutionary Reign Direction: Wrong actor count ${actors.length}`
+          );
           return;
         }
 
         switch (matches.id) {
           case eminentReign1:
           case eminentReign2:
-            data.reignDir = (Directions.hdgTo8DirNum(actor.Heading) + 4) % 8
+            data.reignDir = (Directions.hdgTo8DirNum(actor.Heading) + 4) % 8;
             break;
           case revolutionaryReign1:
           case revolutionaryReign2:
@@ -116,8 +118,7 @@ const triggerSet: TriggerSet<Data> = {
       },
       infoText: (data, matches, output) => {
         const dir = output[Directions.outputFrom8DirNum(data.reignDir ?? -1)]!();
-        console.error(`Received ${dir} dir`);
-        switch(matches.id) {
+        switch (matches.id) {
           case eminentReign1:
           case eminentReign2:
             return output.inDir!({ dir: dir });

--- a/ui/raidboss/data/07-dt/raid/r8s.ts
+++ b/ui/raidboss/data/07-dt/raid/r8s.ts
@@ -110,6 +110,12 @@ const triggerSet: TriggerSet<Data> = {
         },
       },
     },
+    {
+      id: 'R8S Titanic Pursuit',
+      type: 'StartsUsing',
+      netRegex: { id: 'A3C7', source: 'Howling Blade', capture: false },
+      response: Responses.aoe(),
+    },
   ],
 };
 

--- a/ui/raidboss/data/07-dt/raid/r8s.ts
+++ b/ui/raidboss/data/07-dt/raid/r8s.ts
@@ -64,7 +64,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'StartsUsing',
       netRegex: { id: ['A911', 'A912', 'A913', 'A914'], source: 'Howling Blade', capture: true },
       infoText: (_data, matches, output) => {
-        switch(matches.id) {
+        switch (matches.id) {
           case eminentReign1:
           case eminentReign2:
             return output.inLater!();

--- a/ui/raidboss/data/07-dt/raid/r8s.ts
+++ b/ui/raidboss/data/07-dt/raid/r8s.ts
@@ -1,14 +1,118 @@
+import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
+export interface Data extends RaidbossData {
+}
+
+const eminentReign1 = 'A911'; // N=>S, SW=>NE, SE=>NW
+const eminentReign2 = 'A912'; // S=>N, NW=>SE, NE=>SW
+const revolutionaryReign1 = 'A913'; // N=>S, SW=>NE, SE=>NW
+const revolutionaryReign2 = 'A914'; // S=>N, NW=>SE, NE=>SW
+
 
 const triggerSet: TriggerSet<Data> = {
   id: 'AacCruiserweightM4Savage',
   zoneId: ZoneId.AacCruiserweightM4Savage,
   timelineFile: 'r8s.txt',
-  triggers: [],
+  triggers: [
+    {
+      id: 'R8S Extraplanar Pursuit',
+      type: 'StartsUsing',
+      netRegex: { id: 'A3DA', source: 'Howling Blade', capture: false },
+      response: Responses.bigAoe(),
+    },
+    {
+      id: 'R8S Windfang/Stonefang',
+      type: 'StartsUsing',
+      netRegex: { id: ['A39E', 'A39D', 'A3A1', 'A3A2'], source: 'Howling Blade', capture: true },
+      infoText: (_data, matches, output) => {
+        const windfangCards = 'A39D';
+        const windfangInter = 'A39E';
+        const stonefangCards = 'A3A1';
+        const stonefangInter = 'A3A2';
+        // A39F is cast for both A39D (card windfang) and A39E (intercard windfang)
+        // A3B0 is cast for both A3A1 (card stonefang) and A3A2 (intercard stonefang)
+        switch (matches.id) {
+          case windfangCards:
+            return output.inInterCardsPartners!();
+          case windfangInter:
+            return output.inCardsPartners!();
+          case stonefangCards:
+            return output.outInterCardsProtean!();
+          case stonefangInter:
+            return output.outCardsProtean!();
+        }
+      },
+      outputStrings: {
+        inCardsPartners: {
+          en: 'In + Cards + Partners',
+        },
+        inInterCardsPartners: {
+          en: 'In + Intercards + Partners',
+        },
+        outCardsProtean: {
+          en: 'Out + Cards + Protean',
+        },
+        outInterCardsProtean: {
+          en: 'Out + InterCards + Protean',
+        },
+      },
+    },
+    {
+      id: 'R8S Eminent/Revolutionary Reign',
+      type: 'StartsUsing',
+      netRegex: { id: ['A911', 'A912', 'A913', 'A914'], source: 'Howling Blade', capture: true },
+      infoText: (_data, matches, output) => {
+        switch(matches.id) {
+          case eminentReign1:
+          case eminentReign2:
+            return output.inLater!();
+          case revolutionaryReign1:
+          case revolutionaryReign2:
+            return output.outLater!();
+        }
+      },
+      outputStrings: {
+        inLater: {
+          en: '(In Later)',
+        },
+        outLater: {
+          en: '(Out Later)',
+        },
+      },
+    },
+    {
+      id: 'R8S Millenial Decay',
+      type: 'StartsUsing',
+      netRegex: { id: 'A3B2', source: 'Howling Blade', capture: false },
+      response: Responses.bigAoe(),
+    },
+    {
+      id: 'R8S Aero III',
+      type: 'StartsUsing',
+      netRegex: { id: 'A3B7', source: 'Howling Blade', capture: false },
+      response: Responses.knockback(),
+    },
+    {
+      id: 'R8S Tracking Tremors',
+      type: 'StartsUsing',
+      netRegex: { id: 'A3B9', source: 'Howling Blade', capture: false },
+      durationSeconds: 9,
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Stack x8',
+          de: 'Sammeln x8',
+          fr: 'Package x8',
+          ja: '頭割り x8',
+          cn: '8次分摊',
+          ko: '쉐어 8번',
+        },
+      },
+    },
+  ],
 };
 
 export default triggerSet;

--- a/ui/raidboss/data/07-dt/raid/r8s.ts
+++ b/ui/raidboss/data/07-dt/raid/r8s.ts
@@ -87,7 +87,7 @@ const triggerSet: TriggerSet<Data> = {
         },
       },
     },
-{
+    {
       id: 'R8S Eminent/Revolutionary Reign Direction',
       type: 'StartsUsing',
       netRegex: { id: ['A911', 'A912', 'A913', 'A914'], source: 'Howling Blade', capture: true },
@@ -100,7 +100,7 @@ const triggerSet: TriggerSet<Data> = {
         const actor = actors[0];
         if (actors.length !== 1 || actor === undefined) {
           console.error(
-            `R8S Eminent/Revolutionary Reign Direction: Wrong actor count ${actors.length}`
+            `R8S Eminent/Revolutionary Reign Direction: Wrong actor count ${actors.length}`,
           );
           return;
         }

--- a/ui/raidboss/data/07-dt/raid/r8s.ts
+++ b/ui/raidboss/data/07-dt/raid/r8s.ts
@@ -3,7 +3,7 @@ import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData;
+export type Data = RaidbossData;
 
 const eminentReign1 = 'A911'; // N=>S, SW=>NE, SE=>NW
 const eminentReign2 = 'A912'; // S=>N, NW=>SE, NE=>SW

--- a/ui/raidboss/data/07-dt/raid/r8s.ts
+++ b/ui/raidboss/data/07-dt/raid/r8s.ts
@@ -3,8 +3,7 @@ import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
-}
+export interface Data extends RaidbossData;
 
 const eminentReign1 = 'A911'; // N=>S, SW=>NE, SE=>NW
 const eminentReign2 = 'A912'; // S=>N, NW=>SE, NE=>SW

--- a/ui/raidboss/data/07-dt/raid/r8s.ts
+++ b/ui/raidboss/data/07-dt/raid/r8s.ts
@@ -10,7 +10,6 @@ const eminentReign2 = 'A912'; // S=>N, NW=>SE, NE=>SW
 const revolutionaryReign1 = 'A913'; // N=>S, SW=>NE, SE=>NW
 const revolutionaryReign2 = 'A914'; // S=>N, NW=>SE, NE=>SW
 
-
 const triggerSet: TriggerSet<Data> = {
   id: 'AacCruiserweightM4Savage',
   zoneId: ZoneId.AacCruiserweightM4Savage,


### PR DESCRIPTION
This is still being tested. I think it works as low as 1.1 second, at 1s I was seeing that the boss turning from N to SE would still round to E. I have set to 1.2. Possibly as late as 1.3 on much slower systems?

Should have the r8s triggers pr.


EDIT: Unsure how useful this will be given how fast the reaction and delay from overlayHandler that is needed and that the boss dives through the middle during this. Possibly a faster way to get the data somehow.

EDIT2: Some thoughts, so there doesn't appear to be E/W in use and only two spells per in/out. The boss seems to also only starts as facing N or S on the cast end. I would guess it's possible, given the starting heading, that we just need to know if it's turning east or west and as soon as we have that data we could know what it's going to be, thus reducing delay. I haven't looked into a link between starting facing and jump spots, but in theory the facing is only going 3 possible ways and there are only two location patterns for the Wolves Rein (circle aoes). Might not work if N/S facing do not go straight though seeing as how, as an example, a N to S turn could include NE and SW, or NE and SE.