### PR TITLE
raidboss: r5s: add missing X-snap Twist IDs

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r5s.ts
+++ b/ui/raidboss/data/07-dt/raid/r5s.ts
@@ -21,23 +21,29 @@ const snapTwistIdMap: { [id: string]: [SnapCount, EastWest] } = {
   'A728': ['two', 'west'],
   'A729': ['two', 'west'],
   'A72A': ['two', 'west'],
+  'A4DB': ['two', 'west'],
   'A72B': ['two', 'east'],
   'A72C': ['two', 'east'],
   'A72D': ['two', 'east'],
+  'A4DC': ['two', 'east'],
   // 3-snap Twist & Drop the Needle
   'A730': ['three', 'west'],
   'A731': ['three', 'west'],
   'A732': ['three', 'west'],
+  'A4DD': ['three', 'west'],
   'A733': ['three', 'east'],
   'A734': ['three', 'east'],
   'A735': ['three', 'east'],
+  'A4DE': ['three', 'east'],
   // 4-snap Twist & Drop the Needle
   'A739': ['four', 'west'],
   'A73A': ['four', 'west'],
   'A73B': ['four', 'west'],
+  'A4DF': ['four', 'west'],
   'A73C': ['four', 'east'],
   'A73D': ['four', 'east'],
   'A73E': ['four', 'east'],
+  'A4E0': ['four', 'east'],
 };
 
 // map of Frogtourage cast ids to safe dirs


### PR DESCRIPTION
Near the middle of the fight, a bit before the second arcady fever, the
boss does one more X-snap Twist & Drop the Needle. This does not
currently have a callout.

Based on my log files, this is due to missing IDs in the snapTwistIdMap,
ranging from A4DB to A4E0. I initially analyzed the log files I have to
determine that these are ordered from 2 to 4 in pairs. I also noticed
that "west" IDs typically come first before "east" IDs. I verified the
snap counts by lining them up in the log file with the "Dancing Green
readies" log lines. I also tested in game and confirmed that the
east/west values match in practice.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
