### PR TITLE
raidboss: add wakeUP trigger to DRS

### DIFF
--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.ts
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.ts
@@ -2626,6 +2626,8 @@ const triggerSet: TriggerSet<Data> = {
       'locale': 'de',
       'replaceSync': {
         '(?<!Crowned )Marchosias': 'Marchosias',
+        '7 minutes have elapsed since your last activity.':
+          'Seit deiner letzten Aktivität sind 7 Minuten vergangen.',
         'Aetherial Bolt': 'Magiegeschoss',
         'Aetherial Burst': 'Magiebombe',
         'Aetherial Orb': 'Magiekugel',
@@ -2847,6 +2849,8 @@ const triggerSet: TriggerSet<Data> = {
       'locale': 'fr',
       'replaceSync': {
         '(?<!Crowned )Marchosias': 'marchosias',
+        '7 minutes have elapsed since your last activity..*?':
+          'Votre personnage est inactif depuis 7 minutes',
         'Aetherial Bolt': 'petite bombe',
         'Aetherial Burst': 'énorme bombe',
         'Aetherial Orb': 'amas d\'éther élémentaire',
@@ -3070,6 +3074,7 @@ const triggerSet: TriggerSet<Data> = {
       'missingTranslations': true,
       'replaceSync': {
         '(?<!Crowned )Marchosias': 'マルコシアス',
+        '7 minutes have elapsed since your last activity..*?': '操作がない状態になってから7分が経過しました。',
         'Aetherial Bolt': '魔弾',
         'Aetherial Burst': '大魔弾',
         'Aetherial Orb': '魔力塊',
@@ -3283,6 +3288,7 @@ const triggerSet: TriggerSet<Data> = {
       'locale': 'cn',
       'replaceSync': {
         '(?<!Crowned )Marchosias': '马可西亚斯',
+        '7 minutes have elapsed since your last activity.': '已经7分钟没有进行任何操作',
         'Aetherial Bolt': '魔弹',
         'Aetherial Burst': '大魔弹',
         'Aetherial Orb': '魔力块',
@@ -3503,6 +3509,7 @@ const triggerSet: TriggerSet<Data> = {
       'locale': 'ko',
       'replaceSync': {
         '(?<!Crowned )Marchosias': '마르코시아스',
+        '7 minutes have elapsed since your last activity.': '7분 동안 아무 조작을 하지 않았습니다.',
         'Aetherial Bolt': '마탄',
         'Aetherial Burst': '대마탄',
         'Aetherial Orb': '마력 덩어리',

--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.ts
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.ts
@@ -180,6 +180,15 @@ const triggerSet: TriggerSet<Data> = {
       // Note: this headmarker *could* be skipped, so we will change this later.
       run: (data) => data.firstUnknownHeadmarker = headmarker.mercifulArc,
     },
+    // https://xivapi.com/LogMessage/916
+    // en: 7 minutes have elapsed since your last activity. [...]
+    // There is no network packet for these log lines; so have to use GameLog.
+    {
+      id: 'DelubrumSav Falling Asleep',
+      type: 'GameLog',
+      netRegex: { line: '7 minutes have elapsed since your last activity..*?', capture: false },
+      response: Responses.wakeUp(),
+    },
     {
       id: 'DelubrumSav Seeker Verdant Tempest',
       type: 'StartsUsing',


### PR DESCRIPTION
Closes #609

This could be added to the non-savage as well, but less likely to trigger there as the risk of dying is less and explanations for mechanics not as needed.