### PR TITLE
util: make_timeline RSVData support

### DIFF
--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -619,6 +619,15 @@ export default class NetRegexes {
   }
 
   /**
+   * matches: https://github.com/OverlayPlugin/cactbot/blob/main/docs/LogGuide.md#line-262-0x106-rsvdata
+   */
+  static rsvData(
+    params?: NetParams['RSVData'],
+  ): CactbotBaseRegExp<'RSVData'> {
+    return buildRegex('RSVData', params);
+  }
+
+  /**
    * matches: https://github.com/OverlayPlugin/cactbot/blob/main/docs/LogGuide.md#line-263-0x107-startsusingextra
    */
   static startsUsingExtra(

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -445,11 +445,8 @@ class TLFuncs {
   }
   static timeFromDate(date?: Date): string {
     if (date) {
-      const wholeTime = date.toLocaleTimeString('en-US', { hourCycle: 'h23' });
-      const milliseconds = date.getMilliseconds();
-      // If milliseconds is under 100, the leading zeroes will be truncated.
-      // We don't want that, so we pad it inside the formatter.
-      return `${wholeTime}.${milliseconds.toString().padStart(3, '0')}`;
+      const fullString = date.toISOString();
+      return fullString.slice(0, -1);
     }
     return 'Unknown_Time';
   }

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -12,6 +12,8 @@ import { commonReplacement, syncKeys } from '../../ui/raidboss/common_replacemen
 // TODO: add some error checking that a zone has been found before a fight.
 // This can happen on partial logs.
 
+export type RsvData = { [rsv: string]: string };
+
 type ZoneEncInfo = {
   zoneName?: string;
   zoneId?: number;
@@ -92,6 +94,7 @@ export class EncounterFinder {
 
   haveWon = false;
   haveSeenSeals = false;
+  rsvData: RsvData = {};
 
   regex: {
     changeZone: CactbotBaseRegExp<'ChangeZone'>;
@@ -104,6 +107,7 @@ export class EncounterFinder {
     inCombat: CactbotBaseRegExp<'InCombat'>;
     playerAttackingMob: CactbotBaseRegExp<'Ability'>;
     mobAttackingPlayer: CactbotBaseRegExp<'Ability'>;
+    rsv: CactbotBaseRegExp<'RSVData'>;
   };
 
   sealRegexes: Array<CactbotBaseRegExp<'GameLog'>> = [];
@@ -130,6 +134,7 @@ export class EncounterFinder {
       inCombat: NetRegexes.inCombat({ inGameCombat: '1', isGameChanged: '1' }),
       playerAttackingMob: NetRegexes.ability({ sourceId: '1.{7}', targetId: '4.{7}' }),
       mobAttackingPlayer: NetRegexes.ability({ sourceId: '4.{7}', targetId: '1.{7}' }),
+      rsv: NetRegexes.rsvData({}),
     };
 
     const sealReplace = commonReplacement.replaceSync[syncKeys.seal];
@@ -188,6 +193,12 @@ export class EncounterFinder {
     // This allows us to save a pass when making timelines.
     if (store && this.currentFight.startTime !== undefined)
       (this.currentFight.logLines ??= []).push(line);
+
+    // Always track/store RSV line data
+    const mRsv = this.regex.rsv.exec(line);
+    if (mRsv?.groups) {
+      this.rsvData[mRsv.groups?.key] = mRsv.groups?.value;
+    }
 
     const cZ = this.regex.changeZone.exec(line)?.groups;
     if (cZ) {

--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -246,14 +246,12 @@ const extractRawLinesFromLog = async (
   end = typeof end === 'string' ? end : TLFuncs.timeFromDate(end);
   let started = false;
   for await (const line of file) {
-    // This will fail on lines with 3-digit identifiers,
-    // but that's okay because those will never be start lines.
-    const lineTimeStamp = line.slice(14, 26);
-    if (start === lineTimeStamp && !started)
-      started = start === lineTimeStamp;
+    const lineTimestampSegment = line.split('|', 3)[1] ?? '';
+    if (!started && lineTimestampSegment.includes(start))
+      started = true;
     if (started)
       lines.push(line);
-    if (lineTimeStamp === end) {
+    if (lineTimestampSegment.includes(end)) {
       file.close();
       return lines;
     }

--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -599,6 +599,7 @@ const assembleHeaderArgStrings = (
   if (padHeaderArgs)
     assembled.push('');
   assembled.push('hideall "--Reset--"\nhideall "--sync--"\n');
+  assembled.push('0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0\n');
   return assembled;
 };
 


### PR DESCRIPTION
Add support to make_timeline to automatically replace RSVData-obfuscated entries with their deobfuscated equivalents when that information is available in the log file.

Also some tweaks to the logic for matching start/end line timestamps, because I had an instance of "end timestamp matched before start timestamp was found" due to it only matching timestamps and me having more than a day's worth of log lines in the same file, with a timestamp overlap across both days.