### PR TITLE
raidboss: More fifth floor

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r5s.ts
+++ b/ui/raidboss/data/07-dt/raid/r5s.ts
@@ -1,15 +1,19 @@
 import Conditions from '../../../../../resources/conditions';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
-import { DirectionOutputCardinal, Directions } from '../../../../../resources/util';
+import {
+  DirectionOutput16,
+  DirectionOutputCardinal,
+  Directions,
+} from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
+import { NetMatches } from '../../../../../types/net_matches';
 import { TriggerSet } from '../../../../../types/trigger';
 
 // TODOs:
 // - Arcady Night Fever/Get Down - dodge followup cleave call
 // - Frogtourage 1 - E+W or N+S safe
-// - Frogtourage 2 - safe wedges + boss e/w cleave
 // - Frogtourage 3 - inside/outside + baits
 
 type EastWest = 'east' | 'west';
@@ -54,6 +58,15 @@ const feverIdMap: { [id: string]: DirectionOutputCardinal } = {
   'A70D': 'dirE', // west cleave
 };
 
+const hustleMap: { [id: string]: 'left' | 'right' } = {
+  // Frogtourage clones:
+  'A775': 'right',
+  'A776': 'left',
+  // Boss:
+  'A724': 'right',
+  'A725': 'left',
+};
+
 export interface Data extends RaidbossData {
   deepCutTargets: string[];
   storedABSideMech?: 'lightParty' | 'roleGroup';
@@ -63,7 +76,31 @@ export interface Data extends RaidbossData {
     alpha: number;
     beta: number;
   };
+  storedHustleCleaves: NetMatches['StartsUsing'][];
+  hustleCleaveCount: number;
 }
+
+const getSafeDirsForCloneCleave = (
+  matches: NetMatches['StartsUsing'],
+): DirectionOutputCardinal[] => {
+  const isLeftCleave = hustleMap[matches.id] === 'left';
+
+  // Snap the frog to the nearest cardinal in the direction of their cleave
+  const headingAdjust = isLeftCleave ? -(Math.PI / 8) : (Math.PI / 8);
+  let snappedHeading = (parseFloat(matches.heading) + headingAdjust) % Math.PI;
+  if (snappedHeading < -Math.PI)
+    snappedHeading = Math.PI - snappedHeading;
+  snappedHeading = snappedHeading % Math.PI;
+
+  // Frog's snapped heading and the next one CW or CCW depending on cleave direction are safe
+  const snappedFrogDir = Directions.hdgTo4DirNum(snappedHeading);
+  const otherSafeDir = ((snappedFrogDir + 4) + (isLeftCleave ? 1 : -1)) % 4;
+
+  return [
+    Directions.outputCardinalDir[snappedFrogDir] ?? 'unknown',
+    Directions.outputCardinalDir[otherSafeDir] ?? 'unknown',
+  ];
+};
 
 const triggerSet: TriggerSet<Data> = {
   id: 'AacCruiserweightM1Savage',
@@ -77,6 +114,8 @@ const triggerSet: TriggerSet<Data> = {
       alpha: 0,
       beta: 0,
     },
+    storedHustleCleaves: [],
+    hustleCleaveCount: 0,
   }),
   triggers: [
     {
@@ -467,6 +506,95 @@ const triggerSet: TriggerSet<Data> = {
       type: 'StartsUsing',
       netRegex: { id: 'A770', source: 'Dancing Green', capture: false },
       response: Responses.bigAoe(),
+    },
+    {
+      id: 'R5S Do the Hustle',
+      type: 'StartsUsing',
+      netRegex: { id: Object.keys(hustleMap) },
+      preRun: (data, matches) => data.storedHustleCleaves.push(matches),
+      infoText: (data, _matches, outputs) => {
+        // Order is double cleave, double cleave, single cleave, triple cleave
+        const expectedCountMap = [
+          2,
+          2,
+          1,
+          3,
+        ];
+        if (
+          data.storedHustleCleaves.length <
+            (expectedCountMap[data.hustleCleaveCount] ?? 0)
+        )
+          return;
+
+        const cleaves = data.storedHustleCleaves;
+        const currentCleaveCount = data.hustleCleaveCount;
+        data.storedHustleCleaves = [];
+        ++data.hustleCleaveCount;
+
+        // Double cleaves from clones
+        if (currentCleaveCount === 0 || currentCleaveCount === 1) {
+          const [cleave1, cleave2] = cleaves;
+          if (cleave1 === undefined || cleave2 === undefined)
+            return;
+
+          const safeDirs1 = getSafeDirsForCloneCleave(cleave1);
+          const safeDirs2 = getSafeDirsForCloneCleave(cleave2);
+          for (const dir of safeDirs1) {
+            if (safeDirs2.includes(dir)) {
+              return outputs[dir]!();
+            }
+          }
+          return outputs['unknown']!();
+        }
+
+        // Single boss cleave
+        if (currentCleaveCount === 2) {
+          const [cleave1] = cleaves;
+          if (cleave1 === undefined)
+            return;
+
+          return hustleMap[cleave1.id] === 'left' ? outputs['dirE']!() : outputs['dirW']!();
+        }
+
+        // Double cleaves from clones plus boss cleave
+        if (currentCleaveCount === 3) {
+          const cleave3 = cleaves.find((cleave) => ['A724', 'A725'].includes(cleave.id));
+          const [cleave1, cleave2] = cleaves.filter((c) => c !== cleave3);
+          if (cleave1 === undefined || cleave2 === undefined || cleave3 === undefined)
+            return;
+
+          const safeDirs1 = getSafeDirsForCloneCleave(cleave1);
+          const safeDirs2 = getSafeDirsForCloneCleave(cleave2);
+
+          let safeDir: DirectionOutput16 = 'unknown';
+
+          for (const dir of safeDirs1) {
+            if (safeDirs2.includes(dir)) {
+              safeDir = dir;
+            }
+          }
+
+          const isBossLeftCleave = hustleMap[cleave3.id] === 'left';
+
+          // safeDir should be either 'dirN' or 'dirS' at this point, adjust with boss left/right
+          if (safeDir === 'dirN') {
+            if (isBossLeftCleave)
+              return outputs['dirNNE']!();
+            return outputs['dirNNW']!();
+          }
+          if (safeDir === 'dirS') {
+            if (isBossLeftCleave)
+              return outputs['dirSSE']!();
+            return outputs['dirSSW']!();
+          }
+
+          return outputs['unknown']!();
+        }
+        return outputs['unknown']!();
+      },
+      outputStrings: {
+        ...Directions.outputStrings16Dir,
+      },
     },
   ],
   timelineReplace: [

--- a/ui/raidboss/data/07-dt/raid/r5s.ts
+++ b/ui/raidboss/data/07-dt/raid/r5s.ts
@@ -471,6 +471,7 @@ const triggerSet: TriggerSet<Data> = {
   ],
   timelineReplace: [
     {
+      'missingTranslations': true,
       'locale': 'de',
       'replaceSync': {
         'Dancing Green': 'Springhis Khan',
@@ -479,6 +480,7 @@ const triggerSet: TriggerSet<Data> = {
       'replaceText': {},
     },
     {
+      'missingTranslations': true,
       'locale': 'fr',
       'replaceSync': {
         'Dancing Green': 'Dancing Green',
@@ -487,6 +489,7 @@ const triggerSet: TriggerSet<Data> = {
       'replaceText': {},
     },
     {
+      'missingTranslations': true,
       'locale': 'ja',
       'replaceSync': {
         'Dancing Green': 'ダンシング・グリーン',
@@ -509,13 +512,13 @@ const triggerSet: TriggerSet<Data> = {
         'Ensemble Assemble': 'ダンサーズ・アッセンブル',
         'Arcady Night Fever': 'アルカディア・ナイトフィーバー',
         'Get Down!': 'ゲットダウン！',
-        'Let\'s Dance': 'レッツダンス！',
+        'Let\'s Dance(?!!)': 'レッツダンス！',
         'Freak Out': '静音爆発',
         'Let\'s Pose': 'レッツポーズ！',
         'Ride the Waves': 'ウェーブ・オン・ウェーブ',
         'Quarter Beats': '4ビート',
         'Eighth Beats': '8ビート',
-        'Frogtourage': 'カモン！ フロッグダンサー',
+        'Frogtourage(?! )': 'カモン！ フロッグダンサー',
         'Moonburn': 'ムーンバーン',
         'Back-up Dance': 'ダンシングウェーブ',
         'Arcady Night Encore Starts': 'ナイトフィーバー・アンコール',

--- a/ui/raidboss/data/07-dt/raid/r5s.ts
+++ b/ui/raidboss/data/07-dt/raid/r5s.ts
@@ -603,7 +603,7 @@ const triggerSet: TriggerSet<Data> = {
       replaceText: {
         'Flip to A-side/Flip to B-side': 'Flip to A/B-side',
         'Play A-side/Play B-side': 'Play A/B-side',
-        '2-snap Twist Drop the Needle/3-snap Twist Drop the Needle/4-snap Twist & Drop the Needle':
+        '2-snap Twist & Drop the Needle/3-snap Twist & Drop the Needle/4-snap Twist & Drop the Needle':
           '2/3/4-snap Twist',
       },
     },

--- a/ui/raidboss/data/07-dt/raid/r5s.ts
+++ b/ui/raidboss/data/07-dt/raid/r5s.ts
@@ -599,6 +599,15 @@ const triggerSet: TriggerSet<Data> = {
   ],
   timelineReplace: [
     {
+      locale: 'en',
+      replaceText: {
+        'Flip to A-side/Flip to B-side': 'Flip to A/B-side',
+        'Play A-side/Play B-side': 'Play A/B-side',
+        '2-snap Twist Drop the Needle/3-snap Twist Drop the Needle/4-snap Twist & Drop the Needle':
+          '2/3/4-snap Twist',
+      },
+    },
+    {
       'missingTranslations': true,
       'locale': 'de',
       'replaceSync': {

--- a/ui/raidboss/data/07-dt/raid/r5s.txt
+++ b/ui/raidboss/data/07-dt/raid/r5s.txt
@@ -12,15 +12,16 @@ hideall "--sync--"
 
 # Intro
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
+9.6 "--sync--" StartsUsing { id: "A721", source: "Dancing Green" } window 9.6,2
 15.3 "Deep Cut" Ability { id: "A722", source: "Dancing Green" }
 20.9 "--middle--" Ability { id: "A6C5", source: "Dancing Green" }
 27.0 "Flip to A-side/Flip to B-side" Ability { id: ["A780", "A781"], source: "Dancing Green" }
-34.1 "Snaps" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
-37.8 "Twist" #Ability { id: "A738", source: "Dancing Green" }
+34.1 "2-snap Twist Drop the Needle/3-snap Twist Drop the Needle/4-snap Twist & Drop the Needle" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
+37.8 "Drop the Needle" #Ability { id: "A738", source: "Dancing Green" }
 39.6 "Play A-side/Play B-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
 46.5 "Flip to B-side/Flip to A-side" Ability { id: ["A780", "A781"], source: "Dancing Green" }
-53.6 "Snaps" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
-57.2 "Twist" #Ability { id: "A738", source: "Dancing Green" }
+53.6 "2-snap Twist Drop the Needle/3-snap Twist Drop the Needle/4-snap Twist & Drop the Needle" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
+57.2 "Drop the Needle" #Ability { id: "A738", source: "Dancing Green" }
 59.0 "Play B-side/Play A-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
 65.0 "Celebrate Good Times" Ability { id: "A723", source: "Dancing Green" }
 
@@ -39,9 +40,9 @@ hideall "--sync--"
 106.7 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
 110.7 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
 114.7 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
-116.8 "Snaps" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
+116.8 "2-snap Twist Drop the Needle/3-snap Twist Drop the Needle/4-snap Twist & Drop the Needle" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
 118.7 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
-120.4 "Twist" #Ability { id: "A738", source: "Dancing Green" }
+120.4 "Drop the Needle" #Ability { id: "A738", source: "Dancing Green" }
 122.2 "Play A-side/Play B-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
 128.2 "Celebrate Good Times" Ability { id: "A723", source: "Dancing Green" }
 136.0 "Deep Cut" Ability { id: "A722", source: "Dancing Green" }
@@ -86,17 +87,17 @@ hideall "--sync--"
 174.8 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
 
 # Debuff and Dodge Dance
-182.2 "Let's Dance! (Cleave)" Ability { id: ["A76D", "A76E"], source: "Dancing Green" }
-184.8 "Let's Dance! (Cleave)" #Ability { id: "A76D", source: "Dancing Green" }
+182.2 "Let's Dance! (Cleave) 1" Ability { id: ["A76D", "A76E"], source: "Dancing Green" }
+184.8 "Let's Dance! (Cleave) 2" #Ability { id: "A76D", source: "Dancing Green" }
 185.7 "Debuffs 1"
-187.4 "Let's Dance! (Cleave)" #Ability { id: "A76E", source: "Dancing Green" }
-189.9 "Let's Dance! (Cleave)" #Ability { id: "A76E", source: "Dancing Green" }
+187.4 "Let's Dance! (Cleave) 3" #Ability { id: "A76E", source: "Dancing Green" }
+189.9 "Let's Dance! (Cleave) 4" #Ability { id: "A76E", source: "Dancing Green" }
 190.8 "Debuffs 2"
-192.4 "Let's Dance! (Cleave)" #Ability { id: "A76D", source: "Dancing Green" }
-194.9 "Let's Dance! (Cleave)" #Ability { id: "A76E", source: "Dancing Green" }
+192.4 "Let's Dance! (Cleave) 5" #Ability { id: "A76D", source: "Dancing Green" }
+194.9 "Let's Dance! (Cleave) 6" #Ability { id: "A76E", source: "Dancing Green" }
 195.9 "Debuffs 3"
-197.2 "Let's Dance! (Cleave)" #Ability { id: "A76E", source: "Dancing Green" }
-199.7 "Let's Dance! (Cleave)" #Ability { id: "A76D", source: "Dancing Green" }
+197.2 "Let's Dance! (Cleave) 7" #Ability { id: "A76E", source: "Dancing Green" }
+199.7 "Let's Dance! (Cleave) 8" #Ability { id: "A76D", source: "Dancing Green" }
 200.8 "Debuffs 4"
 208.7 "Let's Pose!" Ability { id: "A76F", source: "Dancing Green" }
 
@@ -108,8 +109,8 @@ hideall "--sync--"
 253.6 "--middle--" Ability { id: "A6C5", source: "Dancing Green" }
 260.7 "Inside Out/Outside In" Ability { id: ["A77C", "A77E"], source: "Dancing Green" }
 263.3 "Inside Out/Outside In" Ability { id: ["A77D", "A77F"], source: "Dancing Green" }
-270.7 "Snaps" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
-274.1 "Twist" #Ability { id: "A738", source: "Dancing Green" }
+270.7 "2-snap Twist Drop the Needle/3-snap Twist Drop the Needle/4-snap Twist & Drop the Needle" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
+274.1 "Drop the Needle" #Ability { id: "A738", source: "Dancing Green" }
 275.9 "Play A-side/Play B-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
 283.6 "Deep Cut" Ability { id: "A722", source: "Dancing Green" }
 290.2 "Celebrate Good Times" Ability { id: "A723", source: "Dancing Green" }
@@ -123,8 +124,8 @@ hideall "--sync--"
 335.2 "Back-up Dance" Ability { id: "A778", source: "Dancing Green" }
 344.6 "Flip to A-side/Flip to B-side" Ability { id: ["A780", "A781"], source: "Dancing Green" }
 345.1 "Back-up Dance" Ability { id: "A778", source: "Dancing Green" }
-351.5 "Snaps" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
-355.1 "Twist" #Ability { id: "A738", source: "Dancing Green" }
+351.5 "2-snap Twist Drop the Needle/3-snap Twist Drop the Needle/4-snap Twist & Drop the Needle" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
+355.1 "Drop the Needle" #Ability { id: "A738", source: "Dancing Green" }
 356.9 "Play A-side/Play B-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
 362.9 "Celebrate Good Times" Ability { id: "A723", source: "Dancing Green" }
 
@@ -168,14 +169,14 @@ hideall "--sync--"
 402.2 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
 
 # Dodge Dance
-409.6 "Let's Dance! Remix" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
-411.2 "Let's Dance! Remix" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
-412.7 "Let's Dance! Remix" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
-414.2 "Let's Dance! Remix" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
-415.7 "Let's Dance! Remix" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
-417.2 "Let's Dance! Remix" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
-418.7 "Let's Dance! Remix" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
-420.2 "Let's Dance! Remix" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
+409.6 "Let's Dance! Remix 1" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
+411.2 "Let's Dance! Remix 2" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
+412.7 "Let's Dance! Remix 3" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
+414.2 "Let's Dance! Remix 4" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
+415.7 "Let's Dance! Remix 5" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
+417.2 "Let's Dance! Remix 6" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
+418.7 "Let's Dance! Remix 7" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
+420.2 "Let's Dance! Remix 8" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
 428.2 "Let's Pose!" Ability { id: "A770", source: "Dancing Green" }
 
 # Frogtourage 2

--- a/ui/raidboss/data/07-dt/raid/r5s.txt
+++ b/ui/raidboss/data/07-dt/raid/r5s.txt
@@ -152,14 +152,14 @@ hideall "--sync--"
 # Frogtourage 2
 442.4 "--middle--" Ability { id: "A6C5", source: "Dancing Green" }
 447.5 "Frogtourage" Ability { id: "A75F", source: "Dancing Green" }
-454.6 "Do the Hustle" Ability { id: ["A775", "A776"], source: "Frogtourage" }
-458.7 "Do the Hustle" Ability { id: ["A775", "A776"], source: "Frogtourage" }
-462.7 "Do the Hustle" Ability { id: ["A724", "A725"], source: "Dancing Green" }
+454.6 "Do the Hustle (dancers)" Ability { id: ["A775", "A776"], source: "Frogtourage" }
+458.7 "Do the Hustle (dancers)" Ability { id: ["A775", "A776"], source: "Frogtourage" }
+462.7 "Do the Hustle (boss)" Ability { id: ["A724", "A725"], source: "Dancing Green" }
 479.3 "Moonburn"
 479.4 "Back-up Dance" Ability { id: "A778", source: "Dancing Green" }
 495.1 "Moonburn"
 495.2 "Back-up Dance" Ability { id: "A778", source: "Dancing Green" }
-504.5 "Do the Hustle" Ability { id: ["A724", "A725"], source: "Dancing Green" }
+504.5 "Do the Hustle (all)" Ability { id: ["A724", "A725"], source: "Dancing Green" }
 512.3 "Deep Cut" Ability { id: "A722", source: "Dancing Green" }
 
 # Disco Floor 2

--- a/ui/raidboss/data/07-dt/raid/r5s.txt
+++ b/ui/raidboss/data/07-dt/raid/r5s.txt
@@ -1,9 +1,364 @@
-### Arcadion (R5S): AAC Cruiserweight M1 Savage
+### AAC CRUISERWEIGHT M1 (SAVAGE)
+# ZoneId: 1257
+
+# -ii 93C1 93C2 93C3 93C8 93C9 A327 A70A A70B A70C A70D A77A
+
+# The X-snap twist syncs are ugly, sorry
 
 hideall "--Reset--"
 hideall "--sync--"
 
 0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
+# Intro
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
+15.3 "Deep Cut" Ability { id: "A722", source: "Dancing Green" }
+20.9 "--middle--" Ability { id: "A6C5", source: "Dancing Green" }
+27.0 "Flip to A-side/Flip to B-side" Ability { id: ["A780", "A781"], source: "Dancing Green" }
+34.1 "Snaps" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
+37.8 "Twist" Ability { id: "A738", source: "Dancing Green" }
+39.6 "Play A-side/Play B-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
+46.5 "Flip to B-side/Flip to A-side" Ability { id: ["A780", "A781"], source: "Dancing Green" }
+53.6 "Snaps" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
+57.2 "Twist" Ability { id: "A738", source: "Dancing Green" }
+59.0 "Play B-side/Play A-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
+65.0 "Celebrate Good Times" Ability { id: "A723", source: "Dancing Green" }
 
+# Disco Floor 1
+71.1 "--middle--" Ability { id: "A6C5", source: "Dancing Green" }
+77.2 "Disco Infernal" Ability { id: "A756", source: "Dancing Green" }
+82.5 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
+86.5 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
+90.5 "Inside Out/Outside In" Ability { id: ["A77C", "A77E"], source: "Dancing Green" }
+90.5 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
+92.9 "Inside Out/Outside In" Ability { id: ["A77D", "A77F"], source: "Dancing Green" }
+94.6 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
+98.6 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
+99.5 "Flip to A-side/Flip to B-side" Ability { id: ["A780", "A781"], source: "Dancing Green" }
+102.7 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
+106.7 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
+110.7 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
+114.7 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
+116.8 "Snaps" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
+118.7 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
+120.4 "Twist" Ability { id: "A738", source: "Dancing Green" }
+122.2 "Play A-side/Play B-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
+128.2 "Celebrate Good Times" Ability { id: "A723", source: "Dancing Green" }
+136.0 "Deep Cut" Ability { id: "A722", source: "Dancing Green" }
+
+# Ensemble 1
+141.6 "--middle--" Ability { id: "A6C5", source: "Dancing Green" }
+146.9 "Ensemble Assemble" Ability { id: "9A32", source: "Dancing Green" }
+154.9 "Arcady Night Fever" Ability { id: "A760", source: "Dancing Green" }
+# Set 1
+155.2 "Get Down! (Out)" Ability { id: "9BE4", source: "Dancing Green" }
+155.5 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
+# Set 2
+157.9 "Get Down! (In)" Ability { id: "A763", source: "Dancing Green" }
+157.9 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
+158.0 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+# Set 3
+160.3 "Get Down! (Out)" Ability { id: "A762", source: "Dancing Green" }
+160.3 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
+160.3 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+# Set 4
+162.6 "Get Down! (In)" Ability { id: "A763", source: "Dancing Green" }
+162.6 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
+162.7 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+# Set 5
+165.0 "Get Down! (Out)" Ability { id: "A762", source: "Dancing Green" }
+165.0 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
+165.1 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+# Set 6
+167.4 "Get Down! (In)" Ability { id: "A763", source: "Dancing Green" }
+167.4 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
+167.5 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+# Set 7
+169.8 "Get Down! (Out)" Ability { id: "A762", source: "Dancing Green" }
+169.8 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
+169.9 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+# Set 8
+172.2 "Get Down! (In)" Ability { id: "A763", source: "Dancing Green" }
+172.2 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
+172.3 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+
+174.2 "Fire" Ability { id: "98B5", source: "Dancing Green" }
+174.8 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+
+# Debuff and Dodge Dance
+182.2 "Let's Dance! (Cleave)" Ability { id: ["A76D", "A76E"], source: "Dancing Green" }
+184.8 "Let's Dance! (Cleave)" #Ability { id: "A76D", source: "Dancing Green" }
+185.7 "Debuffs 1"
+187.4 "Let's Dance! (Cleave)" #Ability { id: "A76E", source: "Dancing Green" }
+189.9 "Let's Dance! (Cleave)" #Ability { id: "A76E", source: "Dancing Green" }
+190.8 "Debuffs 2"
+192.4 "Let's Dance! (Cleave)" #Ability { id: "A76D", source: "Dancing Green" }
+194.9 "Let's Dance! (Cleave)" #Ability { id: "A76E", source: "Dancing Green" }
+195.9 "Debuffs 3"
+197.2 "Let's Dance! (Cleave)" #Ability { id: "A76E", source: "Dancing Green" }
+199.7 "Let's Dance! (Cleave)" #Ability { id: "A76D", source: "Dancing Green" }
+200.8 "Debuffs 4"
+208.7 "Let's Pose!" Ability { id: "A76F", source: "Dancing Green" }
+
+# Exafloors
+226.9 "Flip to A-side/Flip to B-side" Ability { id: ["A780", "A781"], source: "Dancing Green" }
+232.6 "Ride the Waves" Ability { id: "A754", source: "Dancing Green" } duration 39.8
+242.6 "Quarter Beats/Eighth Beats" Ability { id: ["A75B", "A75D"], source: "Dancing Green" }
+250.6 "Eighth Beats/Quarter Beats" Ability { id: ["A75B", "A75D"], source: "Dancing Green" }
+253.6 "--middle--" Ability { id: "A6C5", source: "Dancing Green" }
+260.7 "Inside Out/Outside In" Ability { id: ["A77C", "A77E"], source: "Dancing Green" }
+263.3 "Inside Out/Outside In" Ability { id: ["A77D", "A77F"], source: "Dancing Green" }
+270.7 "Snaps" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
+274.1 "Twist" Ability { id: "A738", source: "Dancing Green" }
+275.9 "Play A-side/Play B-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
+283.6 "Deep Cut" Ability { id: "A722", source: "Dancing Green" }
+290.2 "Celebrate Good Times" Ability { id: "A723", source: "Dancing Green" }
+
+# Frogtourage 1
+296.3 "--middle--" Ability { id: "A6C5", source: "Dancing Green" }
+301.4 "Frogtourage" Ability { id: "A75F", source: "Dancing Green" }
+315.5 "Quarter Beats/Eighth Beats" Ability { id: ["A75B", "A75D"], source: "Dancing Green" }
+316.0 "Moonburn" # 4 casts simultaneously, A773 and A774 IDs
+323.6 "Disco Infernal" Ability { id: "A756", source: "Dancing Green" }
+335.2 "Back-up Dance" Ability { id: "A778", source: "Dancing Green" }
+344.6 "Flip to A-side/Flip to B-side" Ability { id: ["A780", "A781"], source: "Dancing Green" }
+345.1 "Back-up Dance" Ability { id: "A778", source: "Dancing Green" }
+351.5 "Snaps" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
+355.1 "Twist" Ability { id: "A738", source: "Dancing Green" }
+356.9 "Play A-side/Play B-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
+362.9 "Celebrate Good Times" Ability { id: "A723", source: "Dancing Green" }
+
+# Ensemble 2
+369.0 "--middle--" Ability { id: "A6C5", source: "Dancing Green" }
+374.3 "Ensemble Assemble" Ability { id: "9A32", source: "Dancing Green" }
+382.3 "Arcady Night Encore" Ability { id: "A370", source: "Dancing Green" }
+# Set 1
+382.6 "Get Down! (Out)" Ability { id: "9BE4", source: "Dancing Green" }
+382.9 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
+# Set 2
+385.3 "Get Down! (In)" Ability { id: "A763", source: "Dancing Green" }
+385.3 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
+385.3 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+# Set 3
+387.6 "Get Down! (Out)" Ability { id: "A762", source: "Dancing Green" }
+387.6 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
+387.7 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+# Set 4
+390.0 "Get Down! (In)" Ability { id: "A763", source: "Dancing Green" }
+390.0 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
+390.1 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+# Set 5
+392.4 "Get Down! (Out)" Ability { id: "A762", source: "Dancing Green" }
+392.4 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
+392.5 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+# Set 6
+394.8 "Get Down! (In)" Ability { id: "A763", source: "Dancing Green" }
+394.8 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
+394.9 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+# Set 7
+397.2 "Get Down! (Out)" Ability { id: "A762", source: "Dancing Green" }
+397.2 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
+397.3 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+# Set 8
+399.6 "Get Down! (In)" Ability { id: "A763", source: "Dancing Green" }
+399.6 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
+399.7 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+
+401.6 "Fire" Ability { id: "98B5", source: "Dancing Green" }
+402.2 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+
+# Dodge Dance
+409.6 "Let's Dance! Remix" Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" } window 1,1
+411.2 "Let's Dance! Remix" Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" } window 1,1
+412.7 "Let's Dance! Remix" Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" } window 1,1
+414.2 "Let's Dance! Remix" Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" } window 1,1
+415.7 "Let's Dance! Remix" Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" } window 1,1
+417.2 "Let's Dance! Remix" Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" } window 1,1
+418.7 "Let's Dance! Remix" Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" } window 1,1
+420.2 "Let's Dance! Remix" Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" } window 1,1
+428.2 "Let's Pose!" Ability { id: "A770", source: "Dancing Green" }
+
+# Frogtourage 2
+442.4 "--middle--" Ability { id: "A6C5", source: "Dancing Green" }
+447.5 "Frogtourage" Ability { id: "A75F", source: "Dancing Green" }
+454.6 "Do the Hustle" Ability { id: ["A775", "A776"], source: "Frogtourage" }
+458.7 "Do the Hustle" Ability { id: ["A775", "A776"], source: "Frogtourage" }
+462.7 "Do the Hustle" Ability { id: ["A724", "A725"], source: "Dancing Green" }
+479.3 "Moonburn"
+479.4 "Back-up Dance" Ability { id: "A778", source: "Dancing Green" }
+495.1 "Moonburn"
+495.2 "Back-up Dance" Ability { id: "A778", source: "Dancing Green" }
+504.5 "Do the Hustle" Ability { id: ["A724", "A725"], source: "Dancing Green" }
+512.3 "Deep Cut" Ability { id: "A722", source: "Dancing Green" }
+
+# Disco Floor 2
+517.9 "--middle--" Ability { id: "A6C5", source: "Dancing Green" }
+523.2 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
+527.2 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
+530.8 "Quarter Beats/Eighth Beats" Ability { id: ["A75B", "A75D"], source: "Dancing Green" }
+531.2 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
+535.2 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
+538.9 "Inside Out/Outside In" Ability { id: ["A77C", "A77E"], source: "Dancing Green" }
+539.2 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
+541.2 "Inside Out/Outside In" Ability { id: ["A77D", "A77F"], source: "Dancing Green" }
+543.2 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
+547.2 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
+550.6 "Eighth Beats/Quarter Beats" Ability { id: ["A75B", "A75D"], source: "Dancing Green" }
+551.3 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
+
+# Soft Enrage
+557.9 "Celebrate Good Times" Ability { id: "A723", source: "Dancing Green" }
+568.0 "Celebrate Good Times" Ability { id: "A723", source: "Dancing Green" }
+583.0 "--middle--" Ability { id: "A6C5", source: "Dancing Green" }
+588.3 "Frogtourage Finale" Ability { id: "A4E1", source: "Dancing Green" }
+603.4 "Hi-NRG Fever (enrage)" Ability { id: "A779", source: "Dancing Green" }
+603.4 "--sync--" Ability { id: "A77B", source: "Frogtourage" }
+
+
+# IGNORED ABILITIES
+# 93C1 --sync--
+# 93C2 Inside Out
+# 93C3 Inside Out
+# 93C4 Outside In
+# 93C5 Outside In
+# 93C6 --sync--
+# 93C8 Play A-side
+# 93C9 Play B-side
+# 9640 --sync--
+# 9641 --sync--
+# 98B3 --sync--
+# 93D3 --sync--
+# 93D4 --sync--
+# 9BDD Let's Dance!
+# 9BE0 --sync--
+# 9BE1 --sync--
+# 9BE2 --sync--
+# 9BE3 --sync--
+# A327 --sync--
+# A36C --sync--
+# A36D --sync--
+# A36E --sync--
+# A36F --sync--
+# A390 Let's Dance! Remix
+# A395 Let's Dance! Remix
+# A70A --sync--
+# A70B --sync--
+# A70C --sync--
+# A70D --sync--
+# A71D --sync--
+# A71E --sync--
+# A721 Deep Cut
+# A752 Funky Floor
+# A755 Ride the Waves
+# A758 Shame
+# A75C Quarter Beats
+# A75E Eighth Beats
+# A76A Let's Dance!
+# A777 Back-up Dance
+# A77A --sync--
+
+# ALL ENCOUNTER ABILITIES
+# 93C1 --sync--
+# 93C2 Inside Out
+# 93C3 Inside Out
+# 93C4 Outside In
+# 93C5 Outside In
+# 93C6 --sync--
+# 93C8 Play A-side
+# 93C9 Play B-side
+# 93D3 --sync--
+# 93D4 --sync--
+# 9640 --sync--
+# 9641 --sync--
+# 98B3 --sync--
+# 98B5 Fire
+# 9A32 Ensemble Assemble
+# 9A34 Minor Freak Out
+# 9A36 Minor Freak Out
+# 9BDD Let's Dance!
+# 9BE0 --sync--
+# 9BE1 --sync--
+# 9BE2 --sync--
+# 9BE3 --sync--
+# 9BE4 Get Down!
+# A327 --sync--
+# A36C --sync--
+# A36D --sync--
+# A36E --sync--
+# A36F --sync--
+# A370 Arcady Night Encore
+# A390 Let's Dance! Remix
+# A391 Let's Dance! Remix
+# A392 Let's Dance! Remix
+# A393 Let's Dance! Remix
+# A394 Let's Dance! Remix
+# A395 Let's Dance! Remix
+# A4DC 2-snap Twist & Drop the Needle
+# A4E1 Frogtourage Finale
+# A6C5 --sync--
+# A70A --sync--
+# A70B --sync--
+# A70C --sync--
+# A70D --sync--
+# A71D --sync--
+# A71E --sync--
+# A721 Deep Cut
+# A722 Deep Cut
+# A723 Celebrate Good Times
+# A724 Do the Hustle
+# A725 Do the Hustle
+# A728 2-snap Twist & Drop the Needle
+# A729 2-snap Twist & Drop the Needle
+# A72E 2-snap Twist & Drop the Needle
+# A72F 2-snap Twist & Drop the Needle
+# A732 3-snap Twist & Drop the Needle
+# A736 3-snap Twist & Drop the Needle
+# A737 3-snap Twist & Drop the Needle
+# A738 3-snap Twist & Drop the Needle
+# A73C 4-snap Twist & Drop the Needle
+# A73F 4-snap Twist & Drop the Needle
+# A740 4-snap Twist & Drop the Needle
+# A741 4-snap Twist & Drop the Needle
+# A742 4-snap Twist & Drop the Needle
+# A752 Funky Floor
+# A753 Funky Floor
+# A754 Ride the Waves
+# A755 Ride the Waves
+# A756 Disco Infernal
+# A758 Shame
+# A75B Quarter Beats
+# A75C Quarter Beats
+# A75D Eighth Beats
+# A75E Eighth Beats
+# A75F Frogtourage
+# A760 Arcady Night Fever
+# A761 --sync--
+# A762 Get Down!
+# A763 Get Down!
+# A764 Get Down!
+# A765 Get Down!
+# A766 Freak Out
+# A767 Freak Out
+# A768 Minor Freak Out
+# A76A Let's Dance!
+# A76D Let's Dance!
+# A76E Let's Dance!
+# A76F Let's Pose!
+# A770 Let's Pose!
+# A773 Moonburn
+# A774 Moonburn
+# A775 Do the Hustle
+# A776 Do the Hustle
+# A777 Back-up Dance
+# A778 Back-up Dance
+# A779 Hi-NRG Fever
+# A77A --sync--
+# A77B --sync--
+# A77C Inside Out
+# A77D Inside Out
+# A77E Outside In
+# A77F Outside In
+# A780 Flip to A-side
+# A781 Flip to B-side
+# A783 Play A-side
+# A784 Play B-side

--- a/ui/raidboss/data/07-dt/raid/r5s.txt
+++ b/ui/raidboss/data/07-dt/raid/r5s.txt
@@ -273,6 +273,7 @@ hideall "--sync--"
 # 98B3 --sync--
 # 98B5 Fire
 # 9A32 Ensemble Assemble
+# 9A33 Minor Freak Out
 # 9A34 Minor Freak Out
 # 9A36 Minor Freak Out
 # 9BDD Let's Dance!
@@ -293,7 +294,12 @@ hideall "--sync--"
 # A393 Let's Dance! Remix
 # A394 Let's Dance! Remix
 # A395 Let's Dance! Remix
+# A4DB 2-snap Twist & Drop the Needle
 # A4DC 2-snap Twist & Drop the Needle
+# A4DD 3-snap Twist & Drop the Needle
+# A4DE 3-snap Twist & Drop the Needle
+# A4DF 4-snap Twist & Drop the Needle
+# A4E0 4-snap Twist & Drop the Needle
 # A4E1 Frogtourage Finale
 # A6C5 --sync--
 # A70A --sync--
@@ -309,13 +315,27 @@ hideall "--sync--"
 # A725 Do the Hustle
 # A728 2-snap Twist & Drop the Needle
 # A729 2-snap Twist & Drop the Needle
+# A72A 2-snap Twist & Drop the Needle
+# A72B 2-snap Twist & Drop the Needle
+# A72C 2-snap Twist & Drop the Needle
+# A72D 2-snap Twist & Drop the Needle
 # A72E 2-snap Twist & Drop the Needle
 # A72F 2-snap Twist & Drop the Needle
+# A730 3-snap Twist & Drop the Needle
+# A731 3-snap Twist & Drop the Needle
 # A732 3-snap Twist & Drop the Needle
+# A733 3-snap Twist & Drop the Needle
+# A734 3-snap Twist & Drop the Needle
+# A735 3-snap Twist & Drop the Needle
 # A736 3-snap Twist & Drop the Needle
 # A737 3-snap Twist & Drop the Needle
 # A738 3-snap Twist & Drop the Needle
+# A739 4-snap Twist & Drop the Needle
+# A73A 4-snap Twist & Drop the Needle
+# A73B 4-snap Twist & Drop the Needle
 # A73C 4-snap Twist & Drop the Needle
+# A73D 4-snap Twist & Drop the Needle
+# A73E 4-snap Twist & Drop the Needle
 # A73F 4-snap Twist & Drop the Needle
 # A740 4-snap Twist & Drop the Needle
 # A741 4-snap Twist & Drop the Needle
@@ -340,6 +360,7 @@ hideall "--sync--"
 # A766 Freak Out
 # A767 Freak Out
 # A768 Minor Freak Out
+# A769 Major Freak Out
 # A76A Let's Dance!
 # A76D Let's Dance!
 # A76E Let's Dance!

--- a/ui/raidboss/data/07-dt/raid/r5s.txt
+++ b/ui/raidboss/data/07-dt/raid/r5s.txt
@@ -16,11 +16,11 @@ hideall "--sync--"
 20.9 "--middle--" Ability { id: "A6C5", source: "Dancing Green" }
 27.0 "Flip to A-side/Flip to B-side" Ability { id: ["A780", "A781"], source: "Dancing Green" }
 34.1 "Snaps" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
-37.8 "Twist" Ability { id: "A738", source: "Dancing Green" }
+37.8 "Twist" #Ability { id: "A738", source: "Dancing Green" }
 39.6 "Play A-side/Play B-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
 46.5 "Flip to B-side/Flip to A-side" Ability { id: ["A780", "A781"], source: "Dancing Green" }
 53.6 "Snaps" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
-57.2 "Twist" Ability { id: "A738", source: "Dancing Green" }
+57.2 "Twist" #Ability { id: "A738", source: "Dancing Green" }
 59.0 "Play B-side/Play A-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
 65.0 "Celebrate Good Times" Ability { id: "A723", source: "Dancing Green" }
 
@@ -30,7 +30,7 @@ hideall "--sync--"
 82.5 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
 86.5 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
 90.5 "Inside Out/Outside In" Ability { id: ["A77C", "A77E"], source: "Dancing Green" }
-90.5 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
+90.5 "Funky Floor" #Ability { id: "A753", source: "Dancing Green" }
 92.9 "Inside Out/Outside In" Ability { id: ["A77D", "A77F"], source: "Dancing Green" }
 94.6 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
 98.6 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
@@ -41,7 +41,7 @@ hideall "--sync--"
 114.7 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
 116.8 "Snaps" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
 118.7 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
-120.4 "Twist" Ability { id: "A738", source: "Dancing Green" }
+120.4 "Twist" #Ability { id: "A738", source: "Dancing Green" }
 122.2 "Play A-side/Play B-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
 128.2 "Celebrate Good Times" Ability { id: "A723", source: "Dancing Green" }
 136.0 "Deep Cut" Ability { id: "A722", source: "Dancing Green" }
@@ -109,7 +109,7 @@ hideall "--sync--"
 260.7 "Inside Out/Outside In" Ability { id: ["A77C", "A77E"], source: "Dancing Green" }
 263.3 "Inside Out/Outside In" Ability { id: ["A77D", "A77F"], source: "Dancing Green" }
 270.7 "Snaps" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
-274.1 "Twist" Ability { id: "A738", source: "Dancing Green" }
+274.1 "Twist" #Ability { id: "A738", source: "Dancing Green" }
 275.9 "Play A-side/Play B-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
 283.6 "Deep Cut" Ability { id: "A722", source: "Dancing Green" }
 290.2 "Celebrate Good Times" Ability { id: "A723", source: "Dancing Green" }
@@ -124,7 +124,7 @@ hideall "--sync--"
 344.6 "Flip to A-side/Flip to B-side" Ability { id: ["A780", "A781"], source: "Dancing Green" }
 345.1 "Back-up Dance" Ability { id: "A778", source: "Dancing Green" }
 351.5 "Snaps" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
-355.1 "Twist" Ability { id: "A738", source: "Dancing Green" }
+355.1 "Twist" #Ability { id: "A738", source: "Dancing Green" }
 356.9 "Play A-side/Play B-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
 362.9 "Celebrate Good Times" Ability { id: "A723", source: "Dancing Green" }
 
@@ -168,14 +168,14 @@ hideall "--sync--"
 402.2 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
 
 # Dodge Dance
-409.6 "Let's Dance! Remix" Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" } window 1,1
-411.2 "Let's Dance! Remix" Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" } window 1,1
-412.7 "Let's Dance! Remix" Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" } window 1,1
-414.2 "Let's Dance! Remix" Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" } window 1,1
-415.7 "Let's Dance! Remix" Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" } window 1,1
-417.2 "Let's Dance! Remix" Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" } window 1,1
-418.7 "Let's Dance! Remix" Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" } window 1,1
-420.2 "Let's Dance! Remix" Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" } window 1,1
+409.6 "Let's Dance! Remix" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
+411.2 "Let's Dance! Remix" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
+412.7 "Let's Dance! Remix" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
+414.2 "Let's Dance! Remix" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
+415.7 "Let's Dance! Remix" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
+417.2 "Let's Dance! Remix" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
+418.7 "Let's Dance! Remix" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
+420.2 "Let's Dance! Remix" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }
 428.2 "Let's Pose!" Ability { id: "A770", source: "Dancing Green" }
 
 # Frogtourage 2

--- a/ui/raidboss/data/07-dt/raid/r5s.txt
+++ b/ui/raidboss/data/07-dt/raid/r5s.txt
@@ -16,11 +16,11 @@ hideall "--sync--"
 15.3 "Deep Cut" Ability { id: "A722", source: "Dancing Green" }
 20.9 "--middle--" Ability { id: "A6C5", source: "Dancing Green" }
 27.0 "Flip to A-side/Flip to B-side" Ability { id: ["A780", "A781"], source: "Dancing Green" }
-34.1 "2-snap Twist Drop the Needle/3-snap Twist Drop the Needle/4-snap Twist & Drop the Needle" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
+34.1 "2-snap Twist & Drop the Needle/3-snap Twist & Drop the Needle/4-snap Twist & Drop the Needle" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
 37.8 "Drop the Needle" #Ability { id: "A738", source: "Dancing Green" }
 39.6 "Play A-side/Play B-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
 46.5 "Flip to B-side/Flip to A-side" Ability { id: ["A780", "A781"], source: "Dancing Green" }
-53.6 "2-snap Twist Drop the Needle/3-snap Twist Drop the Needle/4-snap Twist & Drop the Needle" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
+53.6 "2-snap Twist & Drop the Needle/3-snap Twist & Drop the Needle/4-snap Twist & Drop the Needle" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
 57.2 "Drop the Needle" #Ability { id: "A738", source: "Dancing Green" }
 59.0 "Play B-side/Play A-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
 65.0 "Celebrate Good Times" Ability { id: "A723", source: "Dancing Green" }
@@ -40,7 +40,7 @@ hideall "--sync--"
 106.7 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
 110.7 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
 114.7 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
-116.8 "2-snap Twist Drop the Needle/3-snap Twist Drop the Needle/4-snap Twist & Drop the Needle" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
+116.8 "2-snap Twist & Drop the Needle/3-snap Twist & Drop the Needle/4-snap Twist & Drop the Needle" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
 118.7 "Funky Floor" Ability { id: "A753", source: "Dancing Green" }
 120.4 "Drop the Needle" #Ability { id: "A738", source: "Dancing Green" }
 122.2 "Play A-side/Play B-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
@@ -52,39 +52,24 @@ hideall "--sync--"
 146.9 "Ensemble Assemble" Ability { id: "9A32", source: "Dancing Green" }
 154.9 "Arcady Night Fever" Ability { id: "A760", source: "Dancing Green" }
 # Set 1
-155.2 "Get Down! (Out)" Ability { id: "9BE4", source: "Dancing Green" }
-155.5 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
+155.2 "Get Down! (Out+Protean) 1" Ability { id: "9BE4", source: "Dancing Green" }
 # Set 2
-157.9 "Get Down! (In)" Ability { id: "A763", source: "Dancing Green" }
-157.9 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
-158.0 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+157.9 "Get Down! (In+Protean+Echo) 2" Ability { id: "A763", source: "Dancing Green" }
 # Set 3
-160.3 "Get Down! (Out)" Ability { id: "A762", source: "Dancing Green" }
-160.3 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
-160.3 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+160.3 "Get Down! (Out+Protean+Echo) 3" Ability { id: "A762", source: "Dancing Green" }
 # Set 4
-162.6 "Get Down! (In)" Ability { id: "A763", source: "Dancing Green" }
-162.6 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
-162.7 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+162.6 "Get Down! (In+Protean+Echo) 4" Ability { id: "A763", source: "Dancing Green" }
 # Set 5
-165.0 "Get Down! (Out)" Ability { id: "A762", source: "Dancing Green" }
-165.0 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
-165.1 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+165.0 "Get Down! (Out+Protean+Echo) 5" Ability { id: "A762", source: "Dancing Green" }
 # Set 6
-167.4 "Get Down! (In)" Ability { id: "A763", source: "Dancing Green" }
-167.4 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
-167.5 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+167.4 "Get Down! (In+Protean+Echo) 6" Ability { id: "A763", source: "Dancing Green" }
 # Set 7
-169.8 "Get Down! (Out)" Ability { id: "A762", source: "Dancing Green" }
-169.8 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
-169.9 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+169.8 "Get Down! (Out+Protean+Echo) 7" Ability { id: "A762", source: "Dancing Green" }
 # Set 8
-172.2 "Get Down! (In)" Ability { id: "A763", source: "Dancing Green" }
-172.2 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
-172.3 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+172.2 "Get Down! (In+Protean+Echo) 8" Ability { id: "A763", source: "Dancing Green" }
 
 174.2 "Fire" Ability { id: "98B5", source: "Dancing Green" }
-174.8 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+174.8 "Get Down! (Echo)" #Ability { id: "A765", source: "Dancing Green" }
 
 # Debuff and Dodge Dance
 182.2 "Let's Dance! (Cleave) 1" Ability { id: ["A76D", "A76E"], source: "Dancing Green" }
@@ -109,7 +94,7 @@ hideall "--sync--"
 253.6 "--middle--" Ability { id: "A6C5", source: "Dancing Green" }
 260.7 "Inside Out/Outside In" Ability { id: ["A77C", "A77E"], source: "Dancing Green" }
 263.3 "Inside Out/Outside In" Ability { id: ["A77D", "A77F"], source: "Dancing Green" }
-270.7 "2-snap Twist Drop the Needle/3-snap Twist Drop the Needle/4-snap Twist & Drop the Needle" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
+270.7 "2-snap Twist & Drop the Needle/3-snap Twist & Drop the Needle/4-snap Twist & Drop the Needle" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
 274.1 "Drop the Needle" #Ability { id: "A738", source: "Dancing Green" }
 275.9 "Play A-side/Play B-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
 283.6 "Deep Cut" Ability { id: "A722", source: "Dancing Green" }
@@ -124,7 +109,7 @@ hideall "--sync--"
 335.2 "Back-up Dance" Ability { id: "A778", source: "Dancing Green" }
 344.6 "Flip to A-side/Flip to B-side" Ability { id: ["A780", "A781"], source: "Dancing Green" }
 345.1 "Back-up Dance" Ability { id: "A778", source: "Dancing Green" }
-351.5 "2-snap Twist Drop the Needle/3-snap Twist Drop the Needle/4-snap Twist & Drop the Needle" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
+351.5 "2-snap Twist & Drop the Needle/3-snap Twist & Drop the Needle/4-snap Twist & Drop the Needle" Ability { id: ["A728", "A729", "A72A", "A4DB", "A72B", "A72C", "A72D", "A4DC", "A730", "A731", "A732", "A4DD", "A733", "A734", "A735", "A4DE", "A739", "A73A", "A73B", "A4DF", "A73C", "A73D", "A73E", "A4E0"], source: "Dancing Green" } duration 2
 355.1 "Drop the Needle" #Ability { id: "A738", source: "Dancing Green" }
 356.9 "Play A-side/Play B-side" Ability { id: ["A783", "A784"], source: "Dancing Green" }
 362.9 "Celebrate Good Times" Ability { id: "A723", source: "Dancing Green" }
@@ -134,39 +119,24 @@ hideall "--sync--"
 374.3 "Ensemble Assemble" Ability { id: "9A32", source: "Dancing Green" }
 382.3 "Arcady Night Encore" Ability { id: "A370", source: "Dancing Green" }
 # Set 1
-382.6 "Get Down! (Out)" Ability { id: "9BE4", source: "Dancing Green" }
-382.9 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
+382.6 "Get Down! (Out+Protean) 1" Ability { id: "9BE4", source: "Dancing Green" }
 # Set 2
-385.3 "Get Down! (In)" Ability { id: "A763", source: "Dancing Green" }
-385.3 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
-385.3 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+385.3 "Get Down! (In+Protean+Echo) 2" Ability { id: "A763", source: "Dancing Green" }
 # Set 3
-387.6 "Get Down! (Out)" Ability { id: "A762", source: "Dancing Green" }
-387.6 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
-387.7 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+387.6 "Get Down! (Out+Protean+Echo) 3" Ability { id: "A762", source: "Dancing Green" }
 # Set 4
-390.0 "Get Down! (In)" Ability { id: "A763", source: "Dancing Green" }
-390.0 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
-390.1 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+390.0 "Get Down! (In+Protean+Echo) 4" Ability { id: "A763", source: "Dancing Green" }
 # Set 5
-392.4 "Get Down! (Out)" Ability { id: "A762", source: "Dancing Green" }
-392.4 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
-392.5 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+392.4 "Get Down! (Out+Protean+Echo) 5" Ability { id: "A762", source: "Dancing Green" }
 # Set 6
-394.8 "Get Down! (In)" Ability { id: "A763", source: "Dancing Green" }
-394.8 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
-394.9 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+394.8 "Get Down! (In+Protean+Echo) 6" Ability { id: "A763", source: "Dancing Green" }
 # Set 7
-397.2 "Get Down! (Out)" Ability { id: "A762", source: "Dancing Green" }
-397.2 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
-397.3 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+397.2 "Get Down! (Out+Protean+Echo) 7" Ability { id: "A762", source: "Dancing Green" }
 # Set 8
-399.6 "Get Down! (In)" Ability { id: "A763", source: "Dancing Green" }
-399.6 "Get Down! (Protean)" #Ability { id: "A764", source: "Dancing Green" }
-399.7 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+399.6 "Get Down! (In+Protean+Echo) 8" Ability { id: "A763", source: "Dancing Green" }
 
 401.6 "Fire" Ability { id: "98B5", source: "Dancing Green" }
-402.2 "Get Down! (Flamethrower)" #Ability { id: "A765", source: "Dancing Green" }
+402.2 "Get Down! (Echo)" #Ability { id: "A765", source: "Dancing Green" }
 
 # Dodge Dance
 409.6 "Let's Dance! Remix 1" #Ability { id: ["A391", "A392", "A393", "A394"], source: "Dancing Green" }


### PR DESCRIPTION
Timeline in this initial part of the PR for review.

Took some liberties with the snap/twist timeline entries, otherwise they'd be even more ugly.

Working on triggers for the Frogtourage cleaves at `454.6`, `458.7`, and `504.5`, but those aren't ready yet, I'll add those to this PR when they're good to go.