### PR TITLE
raidboss: Add cactus triggers to m6s

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r6s.ts
+++ b/ui/raidboss/data/07-dt/raid/r6s.ts
@@ -70,6 +70,38 @@ const headMarkerData = {
   'puddingPartyMarker': '0131',
 } as const;
 
+type CactusPattern = {
+  readonly id: string;
+  readonly x: number;
+  readonly y: number;
+};
+
+// Unique positions for cacti in first set for each pattern
+const cactusSpamPatterns: CactusPattern[] = [
+  { id: '1', x: 100.009, y: 89.999 },
+  { id: '2', x: 116.001, y: 116.001 },
+  { id: '3', x: 100.009, y: 100.009 },
+  { id: '4', x: 110.996, y: 116.001 },
+];
+
+// Positions for cacti corresponding to danger corner
+const cactusQuicksandPatterns: CactusPattern[] = [
+  { id: 'dirNE', x: 116.001, y: 83.987 },
+  { id: 'dirSE', x: 116.001, y: 116.001 },
+  { id: 'dirSW', x: 83.987, y: 116.001 },
+  { id: 'dirNW', x: 83.987, y: 83.987 },
+];
+
+const findCactus = <T extends CactusPattern>(
+  patterns: T[],
+  x: number,
+  y: number,
+): T | undefined => {
+  return patterns.find((coords) => {
+    return Math.abs(coords.x - x) < 0.005 && Math.abs(coords.y - y) < 0.005;
+  });
+};
+
 const triggerSet: TriggerSet<Data> = {
   id: 'AacCruiserweightM2Savage',
   zoneId: ZoneId.AacCruiserweightM2Savage,
@@ -401,6 +433,89 @@ const triggerSet: TriggerSet<Data> = {
         stackOn: {
           en: 'Stack on ${target} x5',
           ko: '쉐어 x5 ${target}',
+        },
+      },
+    },
+    {
+      id: 'R6S Cactus Spam Pattern Identifier',
+      type: 'StartsUsingExtra',
+      netRegex: { id: 'A6A1' },
+      condition: (_data, matches) => {
+        const matchX = parseFloat(matches.x);
+        const matchY = parseFloat(matches.y);
+        const cactus = findCactus(cactusSpamPatterns, matchX, matchY);
+        return cactus !== undefined;
+      },
+      suppressSeconds: 9999,
+      infoText: (_data, matches, output) => {
+        const matchX = parseFloat(matches.x);
+        const matchY = parseFloat(matches.y);
+        const cactus = findCactus(cactusSpamPatterns, matchX, matchY);
+        if (cactus === undefined)
+          return;
+
+        switch (cactus.id) {
+          case '1':
+            return output.pattern1!();
+          case '2':
+            return output.pattern2!();
+          case '3':
+            return output.pattern3!();
+          case '4':
+            return output.pattern4!();
+        }
+
+        return output.unknown!();
+      },
+      outputStrings: {
+        unknown: Outputs.unknown,
+        pattern1: {
+          en: 'Cactus Pattern 1',
+        },
+        pattern2: {
+          en: 'Cactus Pattern 2 (bad)',
+        },
+        pattern3: {
+          en: 'Cactus Pattern 3',
+        },
+        pattern4: {
+          en: 'Cactus Pattern 4',
+        },
+      },
+    },
+    {
+      id: 'R6S Cactus Quicksand Pattern Identifier',
+      type: 'StartsUsingExtra',
+      netRegex: { id: '9A2C' },
+      condition: (_data, matches) => {
+        const matchX = parseFloat(matches.x);
+        const matchY = parseFloat(matches.y);
+        const cactus = findCactus(cactusQuicksandPatterns, matchX, matchY);
+        return cactus !== undefined;
+      },
+      suppressSeconds: 9999,
+      infoText: (_data, matches, output) => {
+        const matchX = parseFloat(matches.x);
+        const matchY = parseFloat(matches.y);
+        const cactus = findCactus(cactusQuicksandPatterns, matchX, matchY);
+        if (cactus === undefined)
+          return;
+
+        switch (cactus.id) {
+          case 'dirNE':
+          case 'dirSE':
+          case 'dirSW':
+          case 'dirNW':
+            return output.cactus!({ dir: output[cactus.id]!() });
+        }
+
+        return output.unknown!();
+      },
+      outputStrings: {
+        unknown: Outputs.unknown,
+        ...Directions.outputStrings8Dir,
+        cactus: {
+          en: 'Cactus ${dir}',
         },
       },
     },

--- a/ui/raidboss/data/07-dt/raid/r6s.ts
+++ b/ui/raidboss/data/07-dt/raid/r6s.ts
@@ -14,7 +14,7 @@ import { TriggerSet } from '../../../../../types/trigger';
 // TODOs:
 // - clean up timeline
 // - Crowd Brûlée - party stack (non-defamations)?
-// - safe corners for quicksand?
+// - safe corners for quicksand? (Latte / party fill strats?)
 // - Live Painting - add wave # spawn call?
 // - Ore-rigato - Mu enrage
 // - Hangry Hiss - Gimme Cat enrage

--- a/ui/raidboss/data/07-dt/raid/r6s.ts
+++ b/ui/raidboss/data/07-dt/raid/r6s.ts
@@ -515,7 +515,7 @@ const triggerSet: TriggerSet<Data> = {
         unknown: Outputs.unknown,
         ...Directions.outputStrings8Dir,
         cactus: {
-          en: 'Cactus ${dir}',
+          en: 'Danger Cactus ${dir}',
         },
       },
     },


### PR DESCRIPTION
Untested in-game. Not sure if this should remove the TODO item for `safe corners for quicksand?` at the top, as this calls the danger corner instead (since there are at least two strats going around for that mechanic).

Pattern numbers should correspond to the patterns on this image, unless I have misassociated them somewhere:

![image](https://github.com/user-attachments/assets/cdd0e951-326e-4a83-aaf3-ba244c02f3ea)

Possible initial cactus spawns (not in pattern # order, these were in the order I encountered them):

```
83.987|116.001
107.517|107.517
89.999|100.009
100.009|89.999
116.001|83.987

116.001|116.001
83.987|108.005
109.989|100.009
92.502|92.502
100.009|83.987

110.996|116.001
83.987|108.005
89.999|100.009
116.001|92.013
110.996|83.987

83.987|116.001
107.517|107.517
100.009|100.009
107.517|92.502
88.992|83.987
```