### PR TITLE
raidboss: r8s champion's circuit counterclockwise fix

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r8s.ts
+++ b/ui/raidboss/data/07-dt/raid/r8s.ts
@@ -196,12 +196,13 @@ const championCounterOrders: ChampionOrders = {
 };
 
 // Map donutPlatform to mechIndex for Counterclockwise
-const championCounterIndex =
-  [[0, 1, 2, 3, 4],
-  [4, 0, 1, 2, 3],
-  [3, 4, 0, 1, 2],
-  [2, 3, 4, 0, 1],
-  [1, 2, 3, 4, 0]];
+const championCounterIndex = [[0, 1, 2, 3, 4], [4, 0, 1, 2, 3],  [3, 4, 0, 1, 2], [2, 3, 4, 0, 1], [
+  1,
+  2,
+  3,
+  4,
+  0,
+]];
 
 // Return the combatant's platform by number
 const getPlatformNum = (
@@ -1854,8 +1855,8 @@ const triggerSet: TriggerSet<Data> = {
         const mechIndex = donutPlatform === undefined
           ? undefined
           : clock === 'clockwise'
-            ? (donutPlatform + count) % 5
-            : championCounterIndex[donutPlatform]?.[count];
+          ? (donutPlatform + count) % 5
+          : championCounterIndex[donutPlatform]?.[count];
 
         // Retrieve the mech based on our platform, donut platform, and mech index
         const mech = (

--- a/ui/raidboss/data/07-dt/raid/r8s.ts
+++ b/ui/raidboss/data/07-dt/raid/r8s.ts
@@ -196,7 +196,7 @@ const championCounterOrders: ChampionOrders = {
 };
 
 // Map donutPlatform to mechIndex for Counterclockwise
-const championCounterIndex = [[0, 1, 2, 3, 4], [4, 0, 1, 2, 3],  [3, 4, 0, 1, 2], [2, 3, 4, 0, 1], [
+const championCounterIndex = [[0, 1, 2, 3, 4], [4, 0, 1, 2, 3], [3, 4, 0, 1, 2], [2, 3, 4, 0, 1], [
   1,
   2,
   3,

--- a/ui/raidboss/data/07-dt/raid/r8s.ts
+++ b/ui/raidboss/data/07-dt/raid/r8s.ts
@@ -195,6 +195,14 @@ const championCounterOrders: ChampionOrders = {
   4: ['sides', 'in', 'out', 'in', 'donut'],
 };
 
+// Map donutPlatform to mechIndex for Counterclockwise
+const championCounterIndex =
+  [[0, 1, 2, 3, 4],
+  [4, 0, 1, 2, 3],
+  [3, 4, 0, 1, 2],
+  [2, 3, 4, 0, 1],
+  [1, 2, 3, 4, 0]];
+
 // Return the combatant's platform by number
 const getPlatformNum = (
   x: number,
@@ -1764,8 +1772,12 @@ const triggerSet: TriggerSet<Data> = {
           mechs: ChampionOrders,
           count: number,
         ): string => {
-          const mechIndex = (donutPlatform + count) % 5;
+          const mechIndex = clock === 'clockwise'
+            ? (donutPlatform + count) % 5
+            : championCounterIndex[donutPlatform]?.[count];
 
+          if (mechIndex === undefined)
+            return 'unknown';
           return mechs[playerPlatform]?.[mechIndex] ?? 'unknown';
         };
 
@@ -1835,17 +1847,22 @@ const triggerSet: TriggerSet<Data> = {
         const donutPlatform = data.championDonutStart;
         const myPlatform = data.myLastPlatformNum;
         const orders = data.championOrders;
+        const clock = data.championClock;
+        const count = data.championTracker;
 
         // Calculate next mech index with wrap around
         const mechIndex = donutPlatform === undefined
           ? undefined
-          : (donutPlatform + data.championTracker) % 5;
+          : clock === 'clockwise'
+            ? (donutPlatform + count) % 5
+            : championCounterIndex[donutPlatform]?.[count];
 
         // Retrieve the mech based on our platform, donut platform, and mech index
         const mech = (
             myPlatform === undefined ||
             mechIndex === undefined ||
-            orders === undefined
+            orders === undefined ||
+            clock === undefined
           )
           ? 'unknown'
           : orders[myPlatform]?.[mechIndex] ?? 'unknown';

--- a/ui/raidboss/data/07-dt/raid/r8s.ts
+++ b/ui/raidboss/data/07-dt/raid/r8s.ts
@@ -13,6 +13,9 @@ type Phase = 'one' | 'adds' | 'rage' | 'moonlight' | 'two' | 'twofold' | 'champi
 type ChampionOrders = {
   [key: number]: string[];
 };
+type ChampionCounterMap = {
+  [key: number]: number[];
+};
 
 export interface Data extends RaidbossData {
   phase: Phase;
@@ -196,13 +199,13 @@ const championCounterOrders: ChampionOrders = {
 };
 
 // Map donutPlatform to mechIndex for Counterclockwise
-const championCounterIndex = [[0, 1, 2, 3, 4], [4, 0, 1, 2, 3], [3, 4, 0, 1, 2], [2, 3, 4, 0, 1], [
-  1,
-  2,
-  3,
-  4,
-  0,
-]];
+const championCounterIndex: ChampionCounterMap = {
+  0: [0, 1, 2, 3, 4],
+  1: [4, 0, 1, 2, 3],
+  2: [3, 4, 0, 1, 2],
+  3: [2, 3, 4, 0, 1],
+  4: [1, 2, 3, 4, 0],
+};
 
 // Return the combatant's platform by number
 const getPlatformNum = (


### PR DESCRIPTION
Based on my logs, this change will fix the current wrong calls when counterclockwise.

The root of the issue seemed to be that the current trigger iterates through the array incorrectly when counterclockwise. Clockwise iterates 0 => 4, but counterclock requires different iteration method based on the current storing of orders.

This PR uses an integer map of the indices to iterate, cheaper operation than trying to pop and insert.