### PR TITLE
raidboss: r8s fix typo in assignment

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r8s.ts
+++ b/ui/raidboss/data/07-dt/raid/r8s.ts
@@ -1403,7 +1403,7 @@ const triggerSet: TriggerSet<Data> = {
       },
       run: (data) => {
         if (data.uvFangSafeSide !== undefined) {
-          data.myPlatformNum === undefined;
+          data.myPlatformNum = undefined;
           data.uvFangSafeSide = undefined;
           data.hasUVRay = false;
         }
@@ -1867,7 +1867,7 @@ const triggerSet: TriggerSet<Data> = {
           data.championTracker = data.championTracker + 1;
           // Shift platform history
           data.myLastPlatformNum = data.myPlatformNum;
-          data.myPlatformNum === undefined;
+          data.myPlatformNum = undefined;
           data.championFangSafeSide = undefined;
         }
       },


### PR DESCRIPTION
Thanks to @Bing-su for pointing it out.

I do not know that this caused any issues, but this should be fixed as my original intention was to undefine the variable.