### PR TITLE
raidboss: r8s increase alert level for followups

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r8s.ts
+++ b/ui/raidboss/data/07-dt/raid/r8s.ts
@@ -1201,7 +1201,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'StartsUsing',
       netRegex: { id: 'A78E', source: 'Wolf of Stone', capture: false },
       suppressSeconds: 1,
-      infoText: (_data, _matches, output) => {
+      alertText: (_data, _matches, output) => {
         return output.lines!();
       },
       outputStrings: {
@@ -1400,7 +1400,7 @@ const triggerSet: TriggerSet<Data> = {
         return false;
       },
       delaySeconds: (_data, matches) => parseFloat(matches.castTime) + 1,
-      infoText: (_data, _matches, output) => {
+      alertText: (_data, _matches, output) => {
         return output.cardinals!();
       },
       outputStrings: {


### PR DESCRIPTION
- Weal of Stone

<img width="1276" height="719" alt="brave_jauP5pGWzt" src="https://github.com/user-attachments/assets/6a2abb42-0f12-497b-87fd-b32649c0045e" />

https://youtu.be/vvJdDyZD3So?si=DAphfIoXLoEDiHLv&t=792

- Weal of Stone Cardinals

<img width="1277" height="718" alt="brave_O65hCCY8Wx" src="https://github.com/user-attachments/assets/6c908050-4e83-4687-81bc-11e65bc9fa47" />

https://youtu.be/vvJdDyZD3So?si=Kc9Zx0LNzTK_gOin&t=1057

Personally, I think it's really easy to forget, and it would be good to raise the alert level by one level.
