### PR TITLE
build: Bump version to 0.35.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cactbot",
-  "version": "0.34.8",
+  "version": "0.35.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cactbot",
-      "version": "0.34.8",
+      "version": "0.35.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fast-csv/parse": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cactbot",
-  "version": "0.34.8",
-  "releaseSummary": "7.2 ko resources, i18n",
+  "version": "0.35.0",
+  "releaseSummary": "7.3 sigs/resources",
   "releaseInDraft": "false",
   "license": "Apache-2.0",
   "type": "module",

--- a/plugin/CactbotEventSource/Properties/AssemblyInfo.cs
+++ b/plugin/CactbotEventSource/Properties/AssemblyInfo.cs
@@ -21,5 +21,5 @@ using System.Runtime.InteropServices;
 // - Revision
 // GitHub has only 3 version components, so Revision should always be 0.
 // CactbotOverlay and CactbotEventSource version should match.
-[assembly: AssemblyVersion("0.34.8.0")]
-[assembly: AssemblyFileVersion("0.34.8.0")]
+[assembly: AssemblyVersion("0.35.0.0")]
+[assembly: AssemblyFileVersion("0.35.0.0")]

--- a/plugin/CactbotOverlay/Properties/AssemblyInfo.cs
+++ b/plugin/CactbotOverlay/Properties/AssemblyInfo.cs
@@ -20,5 +20,5 @@ using System.Runtime.InteropServices;
 // - Build Number
 // - Revision
 // GitHub has only 3 version components, so Revision should always be 0.
-[assembly: AssemblyVersion("0.34.8.0")]
-[assembly: AssemblyFileVersion("0.34.8.0")]
+[assembly: AssemblyVersion("0.35.0.0")]
+[assembly: AssemblyFileVersion("0.35.0.0")]


### PR DESCRIPTION
Breaking changes to support 7.3 signatures and memory offsets.