### PR TITLE
i18n: ex5 cn translations

### DIFF
--- a/ui/raidboss/data/07-dt/trial/necron-ex.ts
+++ b/ui/raidboss/data/07-dt/trial/necron-ex.ts
@@ -312,7 +312,10 @@ const triggerSet: TriggerSet<Data> = {
       condition: Conditions.targetIsYou(),
       infoText: (_data, _matches, output) => output.cleanse!(),
       outputStrings: {
-        cleanse: 'Cleanse Slow',
+        cleanse: {
+          en: 'Cleanse Slow',
+          cn: '康复减速',
+        },
       },
     },
     {


### PR DESCRIPTION
fixed a missing i18n entry 'cleanse'