### PR TITLE
raidboss: The Meso Terminal -- timeline and triggers

### DIFF
--- a/ui/raidboss/data/07-dt/dungeon/meso-terminal.ts
+++ b/ui/raidboss/data/07-dt/dungeon/meso-terminal.ts
@@ -8,7 +8,6 @@ import { RaidbossData } from '../../../../../types/data';
 import { PluginCombatantState } from '../../../../../types/event';
 import { TriggerSet } from '../../../../../types/trigger';
 
-
 export interface Data extends RaidbossData {
   chirurgeonSpots: chirurgeonCoords[];
   playerExecutionerId?: string;
@@ -21,7 +20,7 @@ export interface Data extends RaidbossData {
 type chirurgeonCoords = {
   x: number;
   y: number;
-}
+};
 
 // List out the dangerous intercardinals for each Keraunograhpy.
 const diagPositive: DirectionOutputIntercard[] = ['dirSW', 'dirNE'];
@@ -69,7 +68,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Meso Terminal Chirurgeon Medicine Field',
       type: 'StartsUsing',
-      netRegex: { id: 'AB16', source: 'Chirurgeon General', capture: false, },
+      netRegex: { id: 'AB16', source: 'Chirurgeon General', capture: false },
       response: Responses.aoe(),
     },
     {
@@ -79,7 +78,7 @@ const triggerSet: TriggerSet<Data> = {
       // (270,22), (280,12), (270,2),(260,12)
       id: 'Meso Terminal Chirurgeon Pungent Aerosol',
       type: 'StartsUsingExtra',
-      netRegex: { id: 'AB1F', capture: true, },
+      netRegex: { id: 'AB1F', capture: true },
       infoText: (_data, matches, output) => {
         const x = parseFloat(matches.x);
         const y = parseFloat(matches.y);
@@ -96,26 +95,26 @@ const triggerSet: TriggerSet<Data> = {
         dirS: Outputs.south,
         dirW: Outputs.west,
         unknown: Outputs.unknown,
-      }
+      },
     },
     {
       // AB1E is the big Sterile Sphere
       // AB1D is small
       id: 'Meso Terminal Chirurgeon Sterile Sphere Collect',
       type: 'StartsUsingExtra',
-      netRegex: { id: 'AB1D', capture: true, },
+      netRegex: { id: 'AB1D', capture: true },
       run: (data, matches) => {
         const location = {
           x: Math.round(parseFloat(matches.x)),
           y: Math.round(parseFloat(matches.y)),
         };
         data.chirurgeonSpots.push(location);
-      }
+      },
     },
     {
       id: 'Meso Terminal Chirurgeon Sterile Sphere Call',
       type: 'StartsUsing',
-      netRegex: { id: 'AB1D', source: 'Chirurgeon General', capture: false, },
+      netRegex: { id: 'AB1D', source: 'Chirurgeon General', capture: false },
       delaySeconds: 1,
       suppressSeconds: 1,
       alertText: (data, _matches, output) => {
@@ -147,45 +146,45 @@ const triggerSet: TriggerSet<Data> = {
         goSouth: Outputs.south,
         goWest: Outputs.west,
         unknown: Outputs.unknown,
-      }
+      },
     },
     {
       id: 'Meso Terminal Chirurgeon Concentrated Dose',
       type: 'StartsUsing',
-      netRegex: { id: 'AB17', source: 'Chirurgeon General', capture: true, },
+      netRegex: { id: 'AB17', source: 'Chirurgeon General', capture: true },
       response: Responses.tankBuster(),
     },
     {
       id: 'Meso Terminal Executioners Shackles Of Fate Tracking',
       type: 'StartsUsing',
-      netRegex: { id: 'AA3D', capture: true, },
+      netRegex: { id: 'AA3D', capture: true },
       condition: Conditions.targetIsYou(),
       run: (data, matches) => data.playerExecutionerId = matches.sourceId,
     },
     {
       id: 'Meso Terminal Executioners Head-Splitting Roar',
       type: 'StartsUsing',
-      netRegex: { id: 'AA3B', source: 'Hooded Headsman', capture: false, },
+      netRegex: { id: 'AA3B', source: 'Hooded Headsman', capture: false },
       response: Responses.aoe(),
     },
     {
       id: 'Meso Terminal Executioners Chopping Block',
       type: 'StartsUsing',
-      netRegex: { id: 'AA4B', capture: true, },
+      netRegex: { id: 'AA4B', capture: true },
       condition: (data, matches) => data.playerExecutionerId === matches.sourceId,
       response: Responses.getOut(),
     },
     {
       id: 'Meso Terminal Executioners Execution Wheel',
       type: 'StartsUsing',
-      netRegex: { id: 'AA4C', capture: true, },
+      netRegex: { id: 'AA4C', capture: true },
       condition: (data, matches) => data.playerExecutionerId === matches.sourceId,
       response: Responses.getIn(),
     },
     {
       id: 'Meso Terminal Executioners Flaying Flail',
       type: 'StartsUsing',
-      netRegex: { id: 'AA48', capture: false, },
+      netRegex: { id: 'AA48', capture: false },
       suppressSeconds: 1,
       infoText: (_data, _matches, output) => output.avoidFlails!(),
       outputStrings: {
@@ -197,7 +196,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Meso Terminal Executioners Hellmaker Adds',
       type: 'AddedCombatant',
-      netRegex: { npcBaseId: '48D2', capture: false, },
+      netRegex: { npcBaseId: '48D2', capture: false },
       condition: (data) => data.role === 'dps',
       suppressSeconds: 1,
       response: Responses.killAdds(),
@@ -217,32 +216,32 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Meso Terminal Immortal Remains Recollection',
       type: 'StartsUsing',
-      netRegex: { id: 'AB31', source: 'Immortal Remains', capture: false, },
+      netRegex: { id: 'AB31', source: 'Immortal Remains', capture: false },
       response: Responses.aoe(),
     },
     {
       id: 'Meso Terminal Immortal Remains Memory Of The Storm',
       type: 'StartsUsing',
-      netRegex: { id: 'AB2D', source: 'Immortal Remains', capture: false, },
+      netRegex: { id: 'AB2D', source: 'Immortal Remains', capture: false },
       response: Responses.stackMarker(),
       run: (data) => data.seenFirstStorm = true,
     },
     {
       id: 'Meso Terminal Immortal Remains Memory Of The Pyre',
       type: 'StartsUsing',
-      netRegex: { id: 'AB30', source: 'Immortal Remains', capture: true, },
+      netRegex: { id: 'AB30', source: 'Immortal Remains', capture: true },
       response: Responses.tankBuster(),
     },
     {
       id: 'Meso Terminal Immortal Remains Turmoil Left',
       type: 'Ability',
-      netRegex: { id: 'AB26', source: 'Immortal Remains', capture: false, },
+      netRegex: { id: 'AB26', source: 'Immortal Remains', capture: false },
       response: Responses.goEast(),
     },
     {
       id: 'Meso Terminal Immortal Remains Turmoil Right',
       type: 'Ability',
-      netRegex: { id: 'AB27', source: 'Immortal Remains', capture: false, },
+      netRegex: { id: 'AB27', source: 'Immortal Remains', capture: false },
       response: Responses.goWest(),
     },
 
@@ -278,7 +277,7 @@ const triggerSet: TriggerSet<Data> = {
           return;
         const terrors = callData.combatants.filter((actor) => actor.BNpcID === 18624);
         data.safeTerror = findNorthTerror(terrors);
-      }
+      },
     },
     {
       id: 'Meso Terminal Immortal Remains Bombardment No Knockback',
@@ -338,7 +337,7 @@ const triggerSet: TriggerSet<Data> = {
         northwest: Outputs.northwest,
         northeast: Outputs.northeast,
         unknown: Outputs.unknown,
-      }
+      },
     },
     {
       // One Keraunography laser is always diagonal,
@@ -374,7 +373,7 @@ const triggerSet: TriggerSet<Data> = {
           const unsafeHorizontalSpots = isNorth ? horizNorth : horizSouth;
           data.kerauUnsafe.push(...unsafeHorizontalSpots);
         }
-      }
+      },
     },
     {
       id: 'Meso Terminal Immortal Remains Keraunography Call',
@@ -397,11 +396,10 @@ const triggerSet: TriggerSet<Data> = {
         dirSW: Outputs.southwest,
         dirSE: Outputs.southeast,
         unknown: Outputs.unknown,
-      }
-    }
+      },
+    },
   ],
-  timelineReplace: [
-  ]
+  timelineReplace: [],
 };
 
 export default triggerSet;

--- a/ui/raidboss/data/07-dt/dungeon/meso-terminal.ts
+++ b/ui/raidboss/data/07-dt/dungeon/meso-terminal.ts
@@ -1,0 +1,407 @@
+import Conditions from '../../../../../resources/conditions';
+import Outputs from '../../../../../resources/outputs';
+import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
+import { Responses } from '../../../../../resources/responses';
+import { DirectionOutputIntercard, Directions } from '../../../../../resources/util';
+import ZoneId from '../../../../../resources/zone_id';
+import { RaidbossData } from '../../../../../types/data';
+import { PluginCombatantState } from '../../../../../types/event';
+import { TriggerSet } from '../../../../../types/trigger';
+
+
+export interface Data extends RaidbossData {
+  chirurgeonSpots: chirurgeonCoords[];
+  playerExecutionerId?: string;
+  seenFirstStorm: boolean;
+  seenFirstBombardment: boolean;
+  safeTerror?: PluginCombatantState;
+  kerauUnsafe: DirectionOutputIntercard[];
+}
+
+type chirurgeonCoords = {
+  x: number;
+  y: number;
+}
+
+// List out the dangerous intercardinals for each Keraunograhpy.
+const diagPositive: DirectionOutputIntercard[] = ['dirSW', 'dirNE'];
+const diagNegative: DirectionOutputIntercard[] = ['dirNW', 'dirSE'];
+const horizNorth: DirectionOutputIntercard[] = ['dirNW', 'dirNE'];
+const horizSouth: DirectionOutputIntercard[] = ['dirSW', 'dirSE'];
+const vertWest: DirectionOutputIntercard[] = ['dirNW', 'dirSW'];
+const vertEast: DirectionOutputIntercard[] = ['dirNE', 'dirSE'];
+
+const filterDirs = (
+  possSafe: DirectionOutputIntercard[],
+  knownUnsafe: DirectionOutputIntercard[],
+): DirectionOutputIntercard[] => {
+  return possSafe.filter((dir) => !knownUnsafe.includes(dir));
+};
+
+const findNorthTerror = (terrors: PluginCombatantState[]): PluginCombatantState | undefined => {
+  return terrors.filter((terror) => {
+    const terX = Math.round(Math.abs(terror.PosX));
+    const terY = Math.round(Math.abs(terror.PosY));
+    const x1 = 10;
+    const y1 = 13;
+    const x2 = 17;
+    const y2 = 12;
+    return (terX === x1 && terY === y1) || (terX === x2 && terY === y2);
+  })[0];
+};
+
+const triggerSet: TriggerSet<Data> = {
+  id: 'themesoterminal',
+  zoneId: ZoneId.TheMesoTerminal,
+  timelineFile: 'meso-terminal.txt',
+  initData: () => {
+    return {
+      chirurgeonSpots: [],
+      playerExecutionerId: undefined,
+      seenFirstStorm: false,
+      seenFirstBombardment: false,
+      impressionActive: false,
+      safeTerror: undefined,
+      kerauUnsafe: [],
+    };
+  },
+  triggers: [
+    {
+      id: 'Meso Terminal Chirurgeon Medicine Field',
+      type: 'StartsUsing',
+      netRegex: { id: 'AB16', source: 'Chirurgeon General', capture: false, },
+      response: Responses.aoe(),
+    },
+    {
+      // The origin for the Chirurgeon is (270,12).
+      // Aerosol can be cast at four cardinal points,
+      // each ten units along an axis from the origin.
+      // (270,22), (280,12), (270,2),(260,12)
+      id: 'Meso Terminal Chirurgeon Pungent Aerosol',
+      type: 'StartsUsingExtra',
+      netRegex: { id: 'AB1F', capture: true, },
+      infoText: (_data, matches, output) => {
+        const x = parseFloat(matches.x);
+        const y = parseFloat(matches.y);
+        const kbNum = Directions.xyTo4DirNum(x, y, 270, 12);
+        const safeDir = Directions.outputFromCardinalNum(kbNum);
+        return output.knockbackFrom!({ dir: output[safeDir]!() });
+      },
+      outputStrings: {
+        knockbackFrom: {
+          en: 'Knockback from ${dir}',
+        },
+        dirN: Outputs.north,
+        dirE: Outputs.east,
+        dirS: Outputs.south,
+        dirW: Outputs.west,
+        unknown: Outputs.unknown,
+      }
+    },
+    {
+      // AB1E is the big Sterile Sphere
+      // AB1D is small
+      id: 'Meso Terminal Chirurgeon Sterile Sphere Collect',
+      type: 'StartsUsingExtra',
+      netRegex: { id: 'AB1D', capture: true, },
+      run: (data, matches) => {
+        const location = {
+          x: Math.round(parseFloat(matches.x)),
+          y: Math.round(parseFloat(matches.y)),
+        };
+        data.chirurgeonSpots.push(location);
+      }
+    },
+    {
+      id: 'Meso Terminal Chirurgeon Sterile Sphere Call',
+      type: 'StartsUsing',
+      netRegex: { id: 'AB1D', source: 'Chirurgeon General', capture: false, },
+      delaySeconds: 1,
+      suppressSeconds: 1,
+      alertText: (data, _matches, output) => {
+        if (!data.chirurgeonSpots[0] || !data.chirurgeonSpots[1])
+          return;
+        const spot1 = data.chirurgeonSpots[0];
+        const spot2 = data.chirurgeonSpots[1];
+        // Both spheres east or both west.
+        // X value under 270 means east safe.
+        if (spot1.x === spot2.x) {
+          if (spot1.x < 270)
+            return output.goEast!();
+          return output.goWest!();
+        }
+        // Both spheres north or south.
+        // Y values increase from north to south.
+        // Y value over 12 means north safe.
+        if (spot1.y === spot2.y) {
+          if (spot1.y > 12)
+            return output.goNorth!();
+          return output.goSouth!();
+        }
+        return output.unknown!();
+      },
+      run: (data) => data.chirurgeonSpots = [],
+      outputStrings: {
+        goNorth: Outputs.north,
+        goEast: Outputs.east,
+        goSouth: Outputs.south,
+        goWest: Outputs.west,
+        unknown: Outputs.unknown,
+      }
+    },
+    {
+      id: 'Meso Terminal Chirurgeon Concentrated Dose',
+      type: 'StartsUsing',
+      netRegex: { id: 'AB17', source: 'Chirurgeon General', capture: true, },
+      response: Responses.tankBuster(),
+    },
+    {
+      id: 'Meso Terminal Executioners Shackles Of Fate Tracking',
+      type: 'StartsUsing',
+      netRegex: { id: 'AA3D', capture: true, },
+      condition: Conditions.targetIsYou(),
+      run: (data, matches) => data.playerExecutionerId = matches.sourceId,
+    },
+    {
+      id: 'Meso Terminal Executioners Head-Splitting Roar',
+      type: 'StartsUsing',
+      netRegex: { id: 'AA3B', source: 'Hooded Headsman', capture: false, },
+      response: Responses.aoe(),
+    },
+    {
+      id: 'Meso Terminal Executioners Chopping Block',
+      type: 'StartsUsing',
+      netRegex: { id: 'AA4B', capture: true, },
+      condition: (data, matches) => data.playerExecutionerId === matches.sourceId,
+      response: Responses.getOut(),
+    },
+    {
+      id: 'Meso Terminal Executioners Execution Wheel',
+      type: 'StartsUsing',
+      netRegex: { id: 'AA4C', capture: true, },
+      condition: (data, matches) => data.playerExecutionerId === matches.sourceId,
+      response: Responses.getIn(),
+    },
+    {
+      id: 'Meso Terminal Executioners Flaying Flail',
+      type: 'StartsUsing',
+      netRegex: { id: 'AA48', capture: false, },
+      suppressSeconds: 1,
+      infoText: (_data, _matches, output) => output.avoidFlails!(),
+      outputStrings: {
+        avoidFlails: {
+          en: 'Away from flails',
+        },
+      },
+    },
+    {
+      id: 'Meso Terminal Executioners Hellmaker Adds',
+      type: 'AddedCombatant',
+      netRegex: { npcBaseId: '48D2', capture: false, },
+      condition: (data) => data.role === 'dps',
+      suppressSeconds: 1,
+      response: Responses.killAdds(),
+    },
+    {
+      id: 'Meso Terminal Executioners Death Penalty',
+      type: 'GainsEffect',
+      netRegex: { effectId: '11F2', capture: true },
+      condition: (data) => data.CanCleanse(),
+      alarmText: (_data, matches, output) => output.cleanseDoom!({ target: matches.target }),
+      outputStrings: {
+        cleanseDoom: {
+          en: 'Cleanse ${target}',
+        },
+      },
+    },
+    {
+      id: 'Meso Terminal Immortal Remains Recollection',
+      type: 'StartsUsing',
+      netRegex: { id: 'AB31', source: 'Immortal Remains', capture: false, },
+      response: Responses.aoe(),
+    },
+    {
+      id: 'Meso Terminal Immortal Remains Memory Of The Storm',
+      type: 'StartsUsing',
+      netRegex: { id: 'AB2D', source: 'Immortal Remains', capture: false, },
+      response: Responses.stackMarker(),
+      run: (data) => data.seenFirstStorm = true,
+    },
+    {
+      id: 'Meso Terminal Immortal Remains Memory Of The Pyre',
+      type: 'StartsUsing',
+      netRegex: { id: 'AB30', source: 'Immortal Remains', capture: true, },
+      response: Responses.tankBuster(),
+    },
+    {
+      id: 'Meso Terminal Immortal Remains Turmoil Left',
+      type: 'Ability',
+      netRegex: { id: 'AB26', source: 'Immortal Remains', capture: false, },
+      response: Responses.goEast(),
+    },
+    {
+      id: 'Meso Terminal Immortal Remains Turmoil Right',
+      type: 'Ability',
+      netRegex: { id: 'AB27', source: 'Immortal Remains', capture: false, },
+      response: Responses.goWest(),
+    },
+
+    // There aren't a lot of good indications where the Bombardments will go.
+    // The mechanic places the Preserved Terror adds where the tethers are,
+    // then does a very short Bombardment cast on the add locations.
+    // If there is one add, it's a small circle, AB23.
+    // If there are five adds, it's a large circle, AB24,
+    // centered equidistant from its five adds.
+    // On the second and later Bombardments,
+    // we can trigger off the AB29 Impression cast, but we have nothing like that for the first.
+    // The best case for finding the locations is to find all the Preserved Terrors,
+    // then filter down which one is in a safe position in front.
+    {
+      id: 'Meso Terminal Immortal Remains First Bombardment Collect',
+      type: 'GainsEffect',
+      netRegex: { effectId: '9F8', capture: false },
+      // The Preserved Terror adds are used for more mechanics than just Bombardment.
+      // Unfortunately, we don't have any good way to separate out
+      // which ones are used for which mechanics.
+      // The tethers for Bombardment are also used on Electray
+      // and Keraunography, so we have to be very careful how we find the adds.
+      condition: (data) => {
+        // The first Memory of the Storm cast immediately precedes Bombardment.
+        return data.seenFirstStorm && !data.seenFirstBombardment;
+      },
+      suppressSeconds: 1,
+      promise: async (data) => {
+        const callData = await callOverlayHandler({
+          call: 'getCombatants',
+        });
+        if (!callData.combatants.length)
+          return;
+        const terrors = callData.combatants.filter((actor) => actor.BNpcID === 18624);
+        data.safeTerror = findNorthTerror(terrors);
+      }
+    },
+    {
+      id: 'Meso Terminal Immortal Remains Bombardment No Knockback',
+      type: 'GainsEffect',
+      netRegex: { effectId: '9F8', capture: false },
+      condition: (data) => data.seenFirstStorm && !data.seenFirstBombardment,
+      delaySeconds: 1,
+      suppressSeconds: 1,
+      alertText: (data, _matches, output) => {
+        if (data.safeTerror === undefined)
+          return output.unknown!();
+        const safeDir = data.safeTerror.PosX < 0 ? 'west' : 'east';
+        return output.staticBombardment!({ safe: output[safeDir]!() });
+      },
+      run: (data) => {
+        data.seenFirstBombardment = true;
+        data.safeTerror = undefined;
+      },
+      outputStrings: {
+        staticBombardment: {
+          en: 'Go ${safe}; Avoid small AoE',
+        },
+        west: Outputs.west,
+        east: Outputs.east,
+        unknown: Outputs.unknown,
+      },
+    },
+    {
+      id: 'Meso Terminal Immortal Remains Bombardment Knockback',
+      type: 'Ability',
+      netRegex: { id: 'AB29', source: 'Immortal Remains', capture: false }, // Impression
+      condition: (data) => data.seenFirstBombardment,
+      delaySeconds: 1,
+      suppressSeconds: 1,
+      promise: async (data) => {
+        const callData = await callOverlayHandler({
+          call: 'getCombatants',
+        });
+        if (!callData.combatants.length)
+          return;
+        const terrors = callData.combatants.filter((actor) => actor.BNpcID === 18624);
+        data.safeTerror = findNorthTerror(terrors);
+      },
+      alertText: (data, _matches, output) => {
+        if (data.safeTerror === undefined)
+          return output.unknown!();
+        const safeDir = data.safeTerror.PosX < 0 ? 'northwest' : 'northeast';
+        return output.knockbackBombardment!({ safe: output[safeDir]!() });
+      },
+      run: (data) => {
+        data.safeTerror = undefined;
+      },
+      outputStrings: {
+        knockbackBombardment: {
+          en: 'Knockback to ${safe}; Avoid AoE',
+        },
+        northwest: Outputs.northwest,
+        northeast: Outputs.northeast,
+        unknown: Outputs.unknown,
+      }
+    },
+    {
+      // One Keraunography laser is always diagonal,
+      // one is always orthogonal.
+      // There are technically smaller safespots available
+      // outside the main intercardinal locations,
+      // but that's difficult to account for programmatically.
+      // The data.kerauUnsafe array will end up with a duplicated direction value,
+      // but since we only care about whether or not a value is present in the array,
+      // it doesn't make a difference.
+      id: 'Meso Terminal Immortal Remains Keraunography Collect',
+      type: 'StartsUsingExtra',
+      netRegex: { id: 'AB25', capture: true },
+      run: (data, matches) => {
+        const headingNum = Directions.hdgTo8DirNum(parseFloat(matches.heading));
+        // Odd heading numbers are diagonal.
+        if (headingNum % 2 === 1) {
+          // Check which diagonal we're working with.
+          // 1 and 5 are equivalent, as are 3 and 7.
+          // In practice, only 5 and 3 will ever be seen,
+          // since the diagonals always originate from the north end of the arena.
+          const diagIsPositive = (headingNum + 4) % 4 === 1;
+          const unsafeDiagonalSpots = diagIsPositive ? diagPositive : diagNegative;
+          data.kerauUnsafe.push(...unsafeDiagonalSpots);
+        } else if (headingNum % 4 === 0) { // Vertical
+          // As with the diagonals, in practice we will only ever see a 0 heading number.
+          const isWest = parseFloat(matches.x) < 0;
+          const unsafeVerticalSpots = isWest ? vertWest : vertEast;
+          data.kerauUnsafe.push(...unsafeVerticalSpots);
+        } else { // Horizontal
+          // It is possible to see both 2 and 6 in practice.
+          const isNorth = parseFloat(matches.y) < 0;
+          const unsafeHorizontalSpots = isNorth ? horizNorth : horizSouth;
+          data.kerauUnsafe.push(...unsafeHorizontalSpots);
+        }
+      }
+    },
+    {
+      id: 'Meso Terminal Immortal Remains Keraunography Call',
+      type: 'StartsUsing',
+      netRegex: { id: 'AB25', source: 'Immortal Remains', capture: false },
+      delaySeconds: 0.1,
+      suppressSeconds: 1,
+      alertText: (data, _matches, output) => {
+        const kerauSafespots: DirectionOutputIntercard[] = ['dirNE', 'dirNW', 'dirSE', 'dirSW'];
+        const safeDirs = filterDirs(kerauSafespots, data.kerauUnsafe);
+        if (safeDirs.length !== 1 || safeDirs[0] === undefined)
+          return output.unknown!();
+        const safeDir = safeDirs[0];
+        return output[safeDir]!();
+      },
+      run: (data) => data.kerauUnsafe = [],
+      outputStrings: {
+        dirNW: Outputs.northwest,
+        dirNE: Outputs.northeast,
+        dirSW: Outputs.southwest,
+        dirSE: Outputs.southeast,
+        unknown: Outputs.unknown,
+      }
+    }
+  ],
+  timelineReplace: [
+  ]
+};
+
+export default triggerSet;

--- a/ui/raidboss/data/07-dt/dungeon/meso-terminal.txt
+++ b/ui/raidboss/data/07-dt/dungeon/meso-terminal.txt
@@ -1,0 +1,164 @@
+### THE MESO TERMINAL
+# ZoneId: 1292
+
+hideall "--Reset--"
+hideall "--sync--"
+
+# .*is no longer sealed
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,100000 jump 0
+
+#~~~~~~~~~~~~~~~~~~~~#
+# Chirurgeon General #
+#~~~~~~~~~~~~~~~~~~~~#
+# -ii ACD6
+
+# The Triage Module will be sealed off
+1000.0 "--sync--" SystemLogMessage { id: "7DC", param1: "1496" } window 1000,1
+1009.1 "Medicine Field" Ability { id: "AB16", source: "Chirurgeon General" }
+1016.5 "No Man's Land" Ability { id: "AB1C", source: "Chirurgeon General" }
+1027.1 "Pungent Aerosol" Ability { id: "AB1F", source: "Chirurgeon General" }
+1035.1 "Sterile Sphere" Ability { id: "AB1D", source: "Chirurgeon General" }
+1041.7 "Biochemical Front" Ability { id: "AB1A", source: "Chirurgeon General" }
+1043.8 "No Man's Land" Ability { id: "AB1C", source: "Chirurgeon General" }
+1051.8 "Sensory Deprivation" Ability { id: "AB15", source: "Chirurgeon General" }
+1063.2 "Pungent Aerosol" Ability { id: "AB1F", source: "Chirurgeon General" }
+1069.9 "Concentrated Dose" Ability { id: "AB17", source: "Chirurgeon General" }
+
+1072.1 label "chirurgeonLoop"
+1072.1 "No Man's Land" Ability { id: "AB1C", source: "Chirurgeon General" }
+1077.1 "Sensory Deprivation" Ability { id: "AB15", source: "Chirurgeon General" }
+1086.7 "Sterile Sphere/Pungent Aerosol" Ability { id: ["AB1D", "AB1E", "AB1F"], source: "Chirurgeon General" }
+1094.7 "Pungent Aerosol/Sterile Sphere" Ability { id: ["AB1D", "AB1E", "AB1F"], source: "Chirurgeon General" }
+1101.3 "Biochemical Front" Ability { id: "AB1A", source: "Chirurgeon General" }
+1108.3 "Medicine Field" Ability { id: "AB16", source: "Chirurgeon General" }
+1118.3 "Concentrated Dose" Ability { id: "AB17", source: "Chirurgeon General" }
+
+1123.6 "No Man's Land" Ability { id: "AB1C", source: "Chirurgeon General" } forcejump "chirurgeonLoop"
+
+# ALL ENCOUNTER ABILITIES
+# AB15 Sensory Deprivation: Cloaks mechanic indicators
+# AB16 Medicine Field: raidwide
+# AB17 Concentrated Dose: tank buster
+# AB1A Biochemical Front: 180-degree frontal cleave
+# AB1C No Man's Land: sets up sphere and aerosol mechanics
+# AB1D Sterile Sphere: small sphere explosion
+# AB1E Sterile Sphere: large sphere explosion
+# AB1F Pungent Aerosol: knockback
+# ACD6 --sync--: auto-attack
+
+#~~~~~~~~~~~~~~#
+# Executioners #
+#~~~~~~~~~~~~~~#
+
+# -ii AA3A AA3C AA3D AA4A AA4E AA4F AA50
+
+# The Executioner timeline is "best-effort" and will quickly
+# desync depending on player or enemy deaths.
+
+# The Public Forum will be sealed off
+2000.0 "--sync--" SystemLogMessage { id: "7DC", param1: "1497" } window 2000,1
+2003.2 "Lawless Pursuit" Ability { id: "AA39" }
+2011.8 "Head-splitting Roar" Ability { id: "AA3B", source: "Hooded Headsman" }
+2014.9 "--sync--" Ability { id: "AA3C" }
+2022.5 "Shackles of Fate" #Ability { id: "AA3E" }
+2027.4 "Dismemberment (cast)" Ability { id: "AA42" }
+2034.3 "Dismemberment 1" Ability { id: "AA43" }
+2036.7 "Peal of Judgment (castbar)" Ability { id: "AA49" }
+2037.4 "Dismemberment 2" Ability { id: "AA43" }
+2039.8 "Peal of Judgment (active)" duration 7 #Ability { id: "AA4A" }
+2042.8 "Chopping Block/Execution Wheel" Ability { id: ["AA4B", "AA4C"] }
+2047.7 "Flaying Flail (castbar)" Ability { id: "AA47" }
+2053.6 "Flaying Flail" Ability { id: "AA48", source: "Bloody Headsman" }
+2055.5 "--sync--" StartsUsing { id: "AF38", source: "Pale Headsman" } # Will Breaker
+2058.0 "Peal of Judgment" Ability { id: "AA49", source: "Pestilent Headsman" }
+2060.0 "Death Penalty" Ability { id: "AA44", source: "Bloody Headsman" }
+2060.0 "--hellmaker adds--"
+2060.9 "Peal of Judgment (active)" duration 7 #Ability { id: "AA4A" }
+2062.0 "Will Breaker?" #Ability { id: "AF38", source: "Pale Headsman" }
+2064.2 "Flaying Flail" Ability { id: "AA47", source: "Pestilent Headsman" }
+2066.0 "Relentless Torment" Ability { id: "AA45", source: "Pale Headsman" }
+2066.4 "Relentless Torment" #Ability { id: "AA46", source: "Pale Headsman" }
+2067.1 "Relentless Torment" #Ability { id: "AA46", source: "Pale Headsman" }
+2067.9 "Relentless Torment" #Ability { id: "AA46", source: "Pale Headsman" }
+2068.8 "Flaying Flail" Ability { id: "AA48", source: "Ravenous Headsman" }
+2078.8 "Serial Torture" #Ability { id: "AA4D", source: "Pestilent Headsman" }
+2085.6 "Dismemberment" #Ability { id: "AA43", source: "Bloody Headsman" }
+2087.6 "Flaying Flail" #Ability { id: "AA48", source: "Bloody Headsman" }
+2089.6 "Dismemberment" #Ability { id: "AA43", source: "Bloody Headsman" }
+2091.3 "Chopping Block/Execution Wheel" Ability { id: ["AA4B", "AA4C"] }
+2101.8 "Head-splitting Roar" Ability { id: "AA3B", source: "Hooded Headsman" }
+2111.5 "Peal of Judgment" #Ability { id: "AA49", source: "Pestilent Headsman" }
+2117.6 "Chopping Block/Execution Wheel" Ability { id: ["AA4B", "AA4C"] }
+2119.2 "Peal of Judgment" #Ability { id: "AA4A", source: "Bloody Headsman" }
+2119.2 "Peal of Judgment" #Ability { id: "AA4A", source: "Pale Headsman" }
+2128.2 "Death Penalty" Ability { id: "AA44", source: "Bloody Headsman" }
+2140.0 "Serial Torture" Ability { id: "AA4D", source: "Ravenous Headsman" }
+2146.9 "Dismemberment" Ability { id: "AA43", source: "Bloody Headsman" }
+2148.9 "Flaying Flail" Ability { id: "AA48", source: "Bloody Headsman" }
+2150.9 "Dismemberment" Ability { id: "AA43", source: "Bloody Headsman" }
+2152.6 "Chopping Block/Execution Wheel" Ability { id: ["AA4B", "AA4C"] }
+2169.6 "Head-splitting Roar" Ability { id: "AA3B", source: "Hooded Headsman" }
+2179.4 "Peal of Judgment" Ability { id: "AA49", source: "Ravenous Headsman" }
+
+# ALL ENCOUNTER ABILITIES
+# AA39 Lawless Pursuit: Tether targeted player
+# AA3A Head-splitting Roar: raidwide castbar
+# AA3B Head-splitting Roar: raidwide (invisible add)
+# AA3C --sync--: reposition in own circle
+# AA3D Shackles of Fate: chain castbar
+# AA3E Shackles of Fate: chain and draw player in
+# AA42 Dismemberment
+# AA43 Dismemberment
+# AA44 Death Penalty
+# AA45 Relentless Torment
+# AA46 Relentless Torment
+# AA47 Flaying Flail: triangle of circle AoEs castbar
+# AA48 Flaying Flail: triangle of circle AoEs
+# AA49 Peal of Judgment: lightning lines castbar
+# AA4A Peal of Judgment: lightning lines
+# AA4B Chopping Block: chariot AoE
+# AA4C Execution Wheel: dynamo AoE
+# AA4D Serial Torture
+# AA4E --sync--: auto-attack
+# AA4F --sync--: auto-attack
+# AA50 --sync--: auto-attack
+
+#~~~~~~~~~~~~~~~~~~#
+# Immortal Remains #
+#~~~~~~~~~~~~~~~~~~#
+
+# -ii AB32 AB2E AB24 AB25 AB2B AB30
+
+# Non-Volatile Memory will be sealed off
+3000.0 "--sync--" SystemLogMessage { id: "7DC", param1: "1498" } window 3000,1
+3010.1 "Recollection" Ability { id: "AB31", source: "Immortal Remains" }
+3019.9 "Memento" Ability { id: "AB21", source: "Immortal Remains" }
+3039.3 "Electray 1" #Ability { id: "AB22", source: "Bygone Aerostat" }
+3042.3 "Electray 2" #Ability { id: "AB22", source: "Bygone Aerostat" }
+3047.1 "Memory of the Storm" Ability { id: "AB2D", source: "Immortal Remains" }
+3057.2 "Memento" Ability { id: "AB21", source: "Immortal Remains" }
+3073.3 "Bombardment" Ability { id: "AB23", source: "Immortal Remains" }
+3075.3 "--sync--" Ability { id: ["AB26", "AB27"], source: "Immortal Remains" } # Turmoil
+3079.7 "Turmoil" Ability { id: "AB28", source: "Immortal Remains" }
+3088.5 "--sync--" Ability { id: "AB29", source: "Immortal Remains" } # Impression tethers
+3093.5 "Impression" Ability { id: "AB2A", source: "Immortal Remains" }
+3096.5 "Bombardment" Ability { id: "AB23", source: "Immortal Remains" }
+3105.6 "Memory of the Pyre" Ability { id: "AB2F", source: "Immortal Remains" }
+3114.7 "Memento" Ability { id: "AB21", source: "Immortal Remains" }
+3126.8 "Keraunography" Ability { id: "B078", source: "Immortal Remains" }
+
+3141.8 label "remainsLoop"
+3141.8 "Keraunography" Ability { id: "B078", source: "Immortal Remains" }
+3148.0 "Electray 1" Ability { id: "AB22", source: "Bygone Aerostat" }
+3151.0 "Electray 2" Ability { id: "AB22", source: "Bygone Aerostat" }
+3153.8 "--sync--" Ability { id: ["AB26", "AB27"], source: "Immortal Remains" } # Turmoil
+3158.2 "Turmoil" Ability { id: "AB28", source: "Immortal Remains" }
+3171.9 "Keraunography" Ability { id: "B078", source: "Immortal Remains" }
+3179.9 "--sync--" Ability { id: "AB29", source: "Immortal Remains" } # Impression tethers
+3184.9 "Impression" Ability { id: "AB2A", source: "Immortal Remains" }
+3187.9 "Bombardment" Ability { id: "AB23", source: "Immortal Remains" }
+3197.0 "Memory of the Storm" Ability { id: "AB2D", source: "Immortal Remains" }
+3206.1 "Memory of the Pyre" Ability { id: "AB2F", source: "Immortal Remains" }
+3216.2 "Recollection" Ability { id: "AB31", source: "Immortal Remains" }
+
+3234.0 "Keraunography" Ability { id: "B078", source: "Immortal Remains" } forcejump "remainsLoop"


### PR DESCRIPTION
Boss 1 is clean and should be mostly fine.

Boss 2 is very best-effort and will rely on the player using their eyes if they finish early and go to help someone else out. The timeline is fairly accurate but I'm not sure what all is real and what is due to one of the bosses being idle at any give point. More research is needed.

Boss 3 was pain. Most of the triggers were reasonably straightforward, but as you can see from the in-line comments, Bombardment was *very* complex to figure out initially. I ended up just fixing on the north safespots, since there are four consistent locations for those. 

I don't like the condition mess needed for the first Bombardment, but we don't have a clean way to trigger for it otherwise. We could maybe count Memento casts and trigger off the second one with a delay, but I figured the logic as it stands is a little easier to follow.

Please do offer better suggestions for Bombardment and Keraunography. I'm not particularly happy with either, but I don't have the math background to simplify Keraunography, and Bombardment is just really tricky to work with altogether.

Oopsy will be forthcoming At Some Point.