### PR TITLE
raidboss: fix typo in necron-ex

### DIFF
--- a/ui/raidboss/data/07-dt/trial/necron-ex.ts
+++ b/ui/raidboss/data/07-dt/trial/necron-ex.ts
@@ -742,7 +742,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'fr',
-      'missingTranslations': true,
       'replaceSync': {
         'Azure Aether': 'sphère d\'énergie bleue',
         'Beckoning Hands': 'grand attrape-mort',

--- a/ui/raidboss/data/07-dt/trial/necron-ex.txt
+++ b/ui/raidboss/data/07-dt/trial/necron-ex.txt
@@ -15,7 +15,7 @@ hideall "--sync--"
 0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,100000 jump 0
 
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
-8.0 "--sync" StartsUsing { id: "AE30", source: "Necron" }
+8.0 "--sync--" StartsUsing { id: "AE30", source: "Necron" }
 14.8 "Blue Shockwave 1" Ability { id: "AE31", source: "Necron" }
 18.9 "Blue Shockwave 2" Ability { id: "AE31", source: "Necron" }
 


### PR DESCRIPTION
https://github.com/OverlayPlugin/cactbot/actions/runs/17731178637/job/50382512658?pr=781

`--sync` -> `--sync--`
