### PR TITLE
raidemulator: Add new log lines to CombatantTracker

### DIFF
--- a/ui/raidboss/emulator/data/CombatantTracker.ts
+++ b/ui/raidboss/emulator/data/CombatantTracker.ts
@@ -8,6 +8,15 @@ import CombatantState from './CombatantState';
 import LineEvent, {
   isLineEvent0x03,
   isLineEvent0x105,
+  isLineEvent0x107,
+  isLineEvent0x108,
+  isLineEvent0x10A,
+  isLineEvent0x10B,
+  isLineEvent0x10E,
+  isLineEvent0x10F,
+  isLineEvent0x110,
+  isLineEvent0x111,
+  isLineEvent0x112,
   isLineEventAbility,
   isLineEventJobLevel,
   isLineEventSource,
@@ -65,6 +74,64 @@ export default class CombatantTracker {
         eventTracker[line.idHex] = eventTracker[line.idHex] ?? 0;
         ++eventTracker[line.idHex];
         this.combatants[line.idHex]?.pushPartialState(line.timestamp, line.state);
+      }
+
+      // StartsUsingExtra / AbilityExtra
+      if (isLineEvent0x107(line) || isLineEvent0x108(line)) {
+        const c = this.initCombatant(line.id);
+        c?.pushPartialState(line.timestamp, {
+          PosX: line.x,
+          PosY: line.y,
+          PosZ: line.z,
+          Heading: line.heading,
+        });
+      }
+
+      // NpcYell / BattleTalk2
+      if (isLineEvent0x10A(line) || isLineEvent0x10B(line)) {
+        const c = this.initCombatant(line.npcId);
+        c?.pushPartialState(line.timestamp, {});
+      }
+
+      // ActorMove / ActorSetPos
+      if (isLineEvent0x10E(line) || isLineEvent0x10F(line)) {
+        const c = this.initCombatant(line.id);
+        c?.pushPartialState(line.timestamp, {
+          PosX: line.x,
+          PosY: line.y,
+          PosZ: line.z,
+          Heading: line.heading,
+        });
+      }
+
+      // SpawnNPCExtra
+      if (isLineEvent0x110(line)) {
+        const c = this.initCombatant(line.id);
+        c?.pushPartialState(line.timestamp, {
+          OwnerID: parseInt(line.parentId, 16),
+        });
+      }
+
+      // ActorControlExtra
+      if (isLineEvent0x111(line)) {
+        const c = this.initCombatant(line.id);
+        const state: Partial<CombatantState> = {};
+        const category = parseInt(line.category, 16);
+        if (category === 0x3F) {
+          state.WeaponId = parseInt(line.param1, 16);
+        }
+        c?.pushPartialState(line.timestamp, state);
+      }
+
+      // ActorControlSelfExtra
+      if (isLineEvent0x112(line)) {
+        const c = this.initCombatant(line.id);
+        const state: Partial<CombatantState> = {};
+        const category = parseInt(line.category, 16);
+        if (category === 0x3F) {
+          state.WeaponId = parseInt(line.param1, 16);
+        }
+        c?.pushPartialState(line.timestamp, state);
       }
     }
 

--- a/ui/raidboss/emulator/data/Encounter.ts
+++ b/ui/raidboss/emulator/data/Encounter.ts
@@ -27,7 +27,7 @@ const isValidTimestamp = (timestamp: number) => {
 };
 
 export default class Encounter {
-  private static readonly encounterVersion = 2;
+  private static readonly encounterVersion = 3;
   public id?: number;
   version: number;
   initialOffset = Number.MAX_SAFE_INTEGER;

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent.ts
@@ -5,6 +5,15 @@ import { Job } from '../../../../../types/job';
 
 import { LineEvent0x03 } from './LineEvent0x03';
 import { LineEvent0x105 } from './LineEvent0x105';
+import { LineEvent0x107 } from './LineEvent0x107';
+import { LineEvent0x108 } from './LineEvent0x108';
+import { LineEvent0x10A } from './LineEvent0x10A';
+import { LineEvent0x10B } from './LineEvent0x10B';
+import { LineEvent0x10E } from './LineEvent0x10E';
+import { LineEvent0x10F } from './LineEvent0x10F';
+import { LineEvent0x110 } from './LineEvent0x110';
+import { LineEvent0x111 } from './LineEvent0x111';
+import { LineEvent0x112 } from './LineEvent0x112';
 import LogRepository from './LogRepository';
 
 const fields = {
@@ -153,4 +162,40 @@ export const isLineEvent0x03 = (line: LineEvent): line is LineEvent0x03 => {
 
 export const isLineEvent0x105 = (event: LineEvent): event is LineEvent0x105 => {
   return event.decEvent === 261;
+};
+
+export const isLineEvent0x107 = (event: LineEvent): event is LineEvent0x107 => {
+  return event.decEvent === 0x107;
+};
+
+export const isLineEvent0x108 = (event: LineEvent): event is LineEvent0x108 => {
+  return event.decEvent === 0x108;
+};
+
+export const isLineEvent0x10A = (event: LineEvent): event is LineEvent0x10A => {
+  return event.decEvent === 0x10A;
+};
+
+export const isLineEvent0x10B = (event: LineEvent): event is LineEvent0x10B => {
+  return event.decEvent === 0x10B;
+};
+
+export const isLineEvent0x10E = (event: LineEvent): event is LineEvent0x10E => {
+  return event.decEvent === 0x10E;
+};
+
+export const isLineEvent0x10F = (event: LineEvent): event is LineEvent0x10F => {
+  return event.decEvent === 0x10F;
+};
+
+export const isLineEvent0x110 = (event: LineEvent): event is LineEvent0x110 => {
+  return event.decEvent === 0x110;
+};
+
+export const isLineEvent0x111 = (event: LineEvent): event is LineEvent0x111 => {
+  return event.decEvent === 0x111;
+};
+
+export const isLineEvent0x112 = (event: LineEvent): event is LineEvent0x112 => {
+  return event.decEvent === 0x112;
 };

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x107.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x107.ts
@@ -1,0 +1,32 @@
+import logDefinitions from '../../../../../resources/netlog_defs';
+
+import LineEvent from './LineEvent';
+import LogRepository from './LogRepository';
+
+const fields = logDefinitions.StartsUsingExtra.fields;
+
+// StartsUsingExtra line
+export class LineEvent0x107 extends LineEvent {
+  public readonly abilityIdHex: string;
+  public readonly abilityId: number;
+  public readonly id: string;
+  public readonly x: number;
+  public readonly y: number;
+  public readonly z: number;
+  public readonly heading: number;
+
+  constructor(repo: LogRepository, networkLine: string, parts: string[]) {
+    super(repo, networkLine, parts);
+
+    this.abilityIdHex = parts[fields.id]?.toUpperCase() ?? '';
+    this.abilityId = parseInt(this.abilityIdHex, 16);
+    this.id = parts[fields.sourceId]?.toUpperCase() ?? '';
+
+    this.x = parseFloat(parts[fields.x] ?? '');
+    this.y = parseFloat(parts[fields.y] ?? '');
+    this.z = parseFloat(parts[fields.z] ?? '');
+    this.heading = parseFloat(parts[fields.heading] ?? '');
+  }
+}
+
+export class LineEvent263 extends LineEvent0x107 {}

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x108.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x108.ts
@@ -1,0 +1,32 @@
+import logDefinitions from '../../../../../resources/netlog_defs';
+
+import LineEvent from './LineEvent';
+import LogRepository from './LogRepository';
+
+const fields = logDefinitions.AbilityExtra.fields;
+
+// AbilityExtra line
+export class LineEvent0x108 extends LineEvent {
+  public readonly abilityIdHex: string;
+  public readonly abilityId: number;
+  public readonly id: string;
+  public readonly x: number;
+  public readonly y: number;
+  public readonly z: number;
+  public readonly heading: number;
+
+  constructor(repo: LogRepository, networkLine: string, parts: string[]) {
+    super(repo, networkLine, parts);
+
+    this.abilityIdHex = parts[fields.id]?.toUpperCase() ?? '';
+    this.abilityId = parseInt(this.abilityIdHex, 16);
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+
+    this.x = parseFloat(parts[fields.x] ?? '');
+    this.y = parseFloat(parts[fields.y] ?? '');
+    this.z = parseFloat(parts[fields.z] ?? '');
+    this.heading = parseFloat(parts[fields.heading] ?? '');
+  }
+}
+
+export class LineEvent264 extends LineEvent0x108 {}

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x10A.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x10A.ts
@@ -1,0 +1,23 @@
+import logDefinitions from '../../../../../resources/netlog_defs';
+
+import LineEvent from './LineEvent';
+import LogRepository from './LogRepository';
+
+const fields = logDefinitions.NpcYell.fields;
+
+// NpcYell line
+export class LineEvent0x10A extends LineEvent {
+  public readonly npcId: string;
+  public readonly npcNameId: string;
+  public readonly npcYellId: string;
+
+  constructor(repo: LogRepository, networkLine: string, parts: string[]) {
+    super(repo, networkLine, parts);
+
+    this.npcId = parts[fields.npcId]?.toUpperCase() ?? '';
+    this.npcNameId = parts[fields.npcNameId] ?? '';
+    this.npcYellId = parts[fields.npcYellId] ?? '';
+  }
+}
+
+export class LineEvent266 extends LineEvent0x10A {}

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x10B.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x10B.ts
@@ -1,0 +1,23 @@
+import logDefinitions from '../../../../../resources/netlog_defs';
+
+import LineEvent from './LineEvent';
+import LogRepository from './LogRepository';
+
+const fields = logDefinitions.BattleTalk2.fields;
+
+// NpcYell line
+export class LineEvent0x10B extends LineEvent {
+  public readonly npcId: string;
+  public readonly npcNameId: string;
+  public readonly instanceContentTextId: string;
+
+  constructor(repo: LogRepository, networkLine: string, parts: string[]) {
+    super(repo, networkLine, parts);
+
+    this.npcId = parts[fields.npcId]?.toUpperCase() ?? '';
+    this.npcNameId = parts[fields.npcNameId] ?? '';
+    this.instanceContentTextId = parts[fields.instanceContentTextId] ?? '';
+  }
+}
+
+export class LineEvent267 extends LineEvent0x10B {}

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x10E.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x10E.ts
@@ -1,0 +1,28 @@
+import logDefinitions from '../../../../../resources/netlog_defs';
+
+import LineEvent from './LineEvent';
+import LogRepository from './LogRepository';
+
+const fields = logDefinitions.ActorMove.fields;
+
+// ActorMove line
+export class LineEvent0x10E extends LineEvent {
+  public readonly id: string;
+  public readonly heading: number;
+  public readonly x: number;
+  public readonly y: number;
+  public readonly z: number;
+
+  constructor(repo: LogRepository, networkLine: string, parts: string[]) {
+    super(repo, networkLine, parts);
+
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+
+    this.x = parseFloat(parts[fields.x] ?? '');
+    this.y = parseFloat(parts[fields.y] ?? '');
+    this.z = parseFloat(parts[fields.z] ?? '');
+    this.heading = parseFloat(parts[fields.heading] ?? '');
+  }
+}
+
+export class LineEvent270 extends LineEvent0x10E {}

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x10F.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x10F.ts
@@ -1,0 +1,28 @@
+import logDefinitions from '../../../../../resources/netlog_defs';
+
+import LineEvent from './LineEvent';
+import LogRepository from './LogRepository';
+
+const fields = logDefinitions.ActorSetPos.fields;
+
+// ActorSetPos line
+export class LineEvent0x10F extends LineEvent {
+  public readonly id: string;
+  public readonly heading: number;
+  public readonly x: number;
+  public readonly y: number;
+  public readonly z: number;
+
+  constructor(repo: LogRepository, networkLine: string, parts: string[]) {
+    super(repo, networkLine, parts);
+
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+
+    this.x = parseFloat(parts[fields.x] ?? '');
+    this.y = parseFloat(parts[fields.y] ?? '');
+    this.z = parseFloat(parts[fields.z] ?? '');
+    this.heading = parseFloat(parts[fields.heading] ?? '');
+  }
+}
+
+export class LineEvent271 extends LineEvent0x10F {}

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x110.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x110.ts
@@ -1,0 +1,25 @@
+import logDefinitions from '../../../../../resources/netlog_defs';
+
+import LineEvent from './LineEvent';
+import LogRepository from './LogRepository';
+
+const fields = logDefinitions.SpawnNpcExtra.fields;
+
+// SpawnNpcExtra line
+export class LineEvent0x110 extends LineEvent {
+  public readonly id: string;
+  public readonly parentId: string;
+  public readonly tetherId: string;
+  public readonly animationState: string;
+
+  constructor(repo: LogRepository, networkLine: string, parts: string[]) {
+    super(repo, networkLine, parts);
+
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+    this.parentId = parts[fields.parentId]?.toUpperCase() ?? '';
+    this.tetherId = parts[fields.tetherId] ?? '';
+    this.animationState = parts[fields.animationState] ?? '';
+  }
+}
+
+export class LineEvent272 extends LineEvent0x110 {}

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x111.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x111.ts
@@ -1,0 +1,29 @@
+import logDefinitions from '../../../../../resources/netlog_defs';
+
+import LineEvent from './LineEvent';
+import LogRepository from './LogRepository';
+
+const fields = logDefinitions.ActorControlExtra.fields;
+
+// ActorControlExtra line
+export class LineEvent0x111 extends LineEvent {
+  public readonly id: string;
+  public readonly category: string;
+  public readonly param1: string;
+  public readonly param2: string;
+  public readonly param3: string;
+  public readonly param4: string;
+
+  constructor(repo: LogRepository, networkLine: string, parts: string[]) {
+    super(repo, networkLine, parts);
+
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+    this.category = parts[fields.category] ?? '';
+    this.param1 = parts[fields.param1] ?? '';
+    this.param2 = parts[fields.param2] ?? '';
+    this.param3 = parts[fields.param3] ?? '';
+    this.param4 = parts[fields.param4] ?? '';
+  }
+}
+
+export class LineEvent273 extends LineEvent0x111 {}

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x112.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x112.ts
@@ -1,0 +1,29 @@
+import logDefinitions from '../../../../../resources/netlog_defs';
+
+import LineEvent from './LineEvent';
+import LogRepository from './LogRepository';
+
+const fields = logDefinitions.ActorControlSelfExtra.fields;
+
+// ActorControlSelfExtra line
+export class LineEvent0x112 extends LineEvent {
+  public readonly id: string;
+  public readonly category: string;
+  public readonly param1: string;
+  public readonly param2: string;
+  public readonly param3: string;
+  public readonly param4: string;
+
+  constructor(repo: LogRepository, networkLine: string, parts: string[]) {
+    super(repo, networkLine, parts);
+
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+    this.category = parts[fields.category] ?? '';
+    this.param1 = parts[fields.param1] ?? '';
+    this.param2 = parts[fields.param2] ?? '';
+    this.param3 = parts[fields.param3] ?? '';
+    this.param4 = parts[fields.param4] ?? '';
+  }
+}
+
+export class LineEvent274 extends LineEvent0x112 {}

--- a/ui/raidboss/emulator/data/network_log_converter/ParseLine.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/ParseLine.ts
@@ -6,6 +6,15 @@ import { LineEvent03 } from './LineEvent0x03';
 import { LineEvent04 } from './LineEvent0x04';
 import { LineEvent12 } from './LineEvent0x0C';
 import { LineEvent261 } from './LineEvent0x105';
+import { LineEvent263 } from './LineEvent0x107';
+import { LineEvent264 } from './LineEvent0x108';
+import { LineEvent266 } from './LineEvent0x10A';
+import { LineEvent267 } from './LineEvent0x10B';
+import { LineEvent270 } from './LineEvent0x10E';
+import { LineEvent271 } from './LineEvent0x10F';
+import { LineEvent272 } from './LineEvent0x110';
+import { LineEvent273 } from './LineEvent0x111';
+import { LineEvent274 } from './LineEvent0x112';
 import { LineEvent20 } from './LineEvent0x14';
 import { LineEvent21 } from './LineEvent0x15';
 import { LineEvent22 } from './LineEvent0x16';
@@ -121,6 +130,41 @@ export default class ParseLine {
         break;
       case 'LineEvent261':
         ret = new LineEvent261(repo, line, parts);
+        break;
+      case 'LineEvent263':
+        ret = new LineEvent263(repo, line, parts);
+        break;
+
+      case 'LineEvent274':
+        ret = new LineEvent274(repo, line, parts);
+        break;
+
+      case 'LineEvent264':
+        ret = new LineEvent264(repo, line, parts);
+        break;
+
+      case 'LineEvent266':
+        ret = new LineEvent266(repo, line, parts);
+        break;
+
+      case 'LineEvent267':
+        ret = new LineEvent267(repo, line, parts);
+        break;
+
+      case 'LineEvent270':
+        ret = new LineEvent270(repo, line, parts);
+        break;
+
+      case 'LineEvent271':
+        ret = new LineEvent271(repo, line, parts);
+        break;
+
+      case 'LineEvent272':
+        ret = new LineEvent272(repo, line, parts);
+        break;
+
+      case 'LineEvent273':
+        ret = new LineEvent273(repo, line, parts);
         break;
       default:
         ret = new LineEvent(repo, line, parts);


### PR DESCRIPTION
This PR adds missing newer log lines to raidemulator and maps them in CombatantTracker to resolve issues like the one mentioned in https://github.com/OverlayPlugin/cactbot/pull/782#discussion_r2365881086

I opted to bump the version number of the `Encounter` dexie DB object, so this will cause encounters to be re-parsed when loading with these changes.

---

As an aside, the `LineEvent` portion of raidemulator is starting to become a bit unwieldy and it may be due for a rewrite at some point to make it easier to add new lines. I poked at doing that instead, went down a rabbit hole of "well every modeled line should map all the associated properties", then remembered "oh right that's terrible for performance" and abandoned that attempt 🙃 