### PR TITLE
raidboss: oc add additional timelines

### DIFF
--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.ts
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.ts
@@ -195,6 +195,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'cn',
+      'missingTranslations': true,
       'replaceSync': {
         'Ball of Fire': '火球',
         'Black Star': '黑色天星',
@@ -256,6 +257,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
+      'missingTranslations': true,
       'replaceSync': {
         'Ball of Fire': '화염 구체',
         'Black Star': '검은 죽음의 운성',

--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.ts
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.ts
@@ -191,7 +191,8 @@ const triggerSet: TriggerSet<Data> = {
       'locale': 'en',
       'replaceText': {
         'Vertical Crosshatch/Horizontal Crosshatch': 'Vertical/Horizontal Crosshatch',
-        'Twopenny Inflation / Onepenny Inflation / Fourpenny Inflation': 'Penny Inflation (knockback)',
+        'Twopenny Inflation / Onepenny Inflation / Fourpenny Inflation':
+          'Penny Inflation (knockback)',
       },
     },
     {

--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.ts
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.ts
@@ -191,6 +191,7 @@ const triggerSet: TriggerSet<Data> = {
       'locale': 'en',
       'replaceText': {
         'Vertical Crosshatch/Horizontal Crosshatch': 'Vertical/Horizontal Crosshatch',
+        'Twopenny Inflation / Onepenny Inflation / Fourpenny Inflation': 'Penny Inflation (knockback)',
       },
     },
     {

--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
@@ -237,8 +237,138 @@ hideall "--sync--"
 4411.3 "What're You Buying?" #Ability { id: "A9BC", source: "Trade Tortoise" }
 
 ### Eternal Watch
+# -ii 366 A181 413C A141 A149 A147 A1B3 A144
+# -p A13F:5122.2
+# -it "Repaired Lion"
+# IGNORED ABILITIES
+# 366 attack
+# A181 Radiant Wave (damage)
+# A13C Aetherial Exchange (Sand Holy Sphere Spawn)
+# A141 Aetherial Exchange (Wind Holy Sphere Spawn)
+# A147 Ancient Aero III (damage)
+# A149 Ancient Stone III (damage)
+# A1B3 Ancient Holy (damage)
+# A144 Ancient Holy (damage)
+#
+# ALL ENCOUNTER ABILITIES
+# A13F Radiant Wave
+# A140 Aetherial Exchange
+# A142 Ancient Holy (spawns evenly in centers)
+# A143 Ancient Holy (Tutorial - spawns more to one side)
+# A146 Ancient Aero III
+# A148 Ancient Stone III
+# A14A Double Cast
+# A14B Double Cast
+# A14C Ancient Aero III
+# A14D Ancient Stone III
+# A14E Light Surge
+# A14F Wind Surge
+# A150 Sand Surge
+# A151 Holy Blaze
+# A155 Scratch
 5000.0 "--sync--" ActorControl { command: "80000014", data0: "329" } window 100000,0
 5100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
+5117.2 "--sync--" StartsUsing { id: "A13F", source: "Repaired Lion" } window 20,5
+5122.2 "Radiant Wave" Ability { id: "A13F", source: "Repaired Lion" } duration 1
+
+# Ancient Stone and Ancient Aero Tutorial
+5128.3 "Aetherial Exchange" Ability { id: "A140", source: "Repaired Lion" }
+5129.3 "--wind spheres x2--" #Ability { id: "A13C", source: "Repaired Lion" }
+5129.3 "--sand spheres x2--" #Ability { id: "A141", source: "Repaired Lion" }
+5134.3 "Ancient Stone III" Ability { id: "A148", source: "Repaired Lion" } duration 1
+5138.0 "Sand Surge" Ability { id: "A150", source: "Holy Sphere" }
+5141.4 "Ancient Aero III" Ability { id: "A146", source: "Repaired Lion" } duration 1
+5145.0 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
+5149.8 "Holy Blaze" Ability { id: "A151", source: "Repaired Lion" }
+5158.7 "Scratch" Ability { id: "A155", source: "Repaired Lion" }
+
+# Ancient Holy Tutorial
+5170.8 "Radiant Wave" Ability { id: "A13F", source: "Repaired Lion" } duration 1
+5172.9 "Ancient Holy" Ability { id: "A143", source: "Repaired Lion" }
+5183.9 "--holy spheres x4--" #Ability { id: ["A1B3", "A144"], source: "Repaired Lion" }
+5186.4 "Light Surge" #Ability { id: "A14E", source: "Holy Sphere" }
+5188.2 "Holy Blaze" Ability { id: "A151", source: "Repaired Lion" }
+5197.0 "Scratch" Ability { id: "A155", source: "Repaired Lion" }
+
+# Loop Block
+5206.1 label "oc-eternal-watch-loop"
+5211.1 "Radiant Wave" Ability { id: "A13F", source: "Repaired Lion" } duration 1
+5216.2 "Aetherial Exchange" Ability { id: "A140", source: "Repaired Lion" }
+5217.2 "--wind spheres x4--" #Ability { id: "A13C", source: "Repaired Lion" }
+5217.2 "--sand spheres x4--" #Ability { id: "A141", source: "Repaired Lion" }
+
+# There is a Pattern here with Double Cast, but currently not displaying text differently
+# Double cast will be A14A or A14B and the subsequent will be opposite
+5229.8 "Double Cast" Ability { id: ["A14B", "A14A"], source: "Repaired Lion" }
+5230.2 "Ancient Stone III" Ability { id: "A14D", source: "Repaired Lion" }
+5230.2 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
+5232.8 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
+5232.8 "Sand Surge" #Ability { id: "A150", source: "Holy Sphere" }
+5234.2 "Ancient Stone III" Ability { id: "A14D", source: "Repaired Lion" }
+5234.2 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
+5236.8 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
+5236.8 "Sand Surge" #Ability { id: "A150", source: "Holy Sphere" }
+5238.2 "Ancient Stone III" Ability { id: "A14D", source: "Repaired Lion" }
+5238.2 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
+5240.9 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
+5240.9 "Sand Surge" #Ability { id: "A150", source: "Holy Sphere" }
+5252.9 "Double Cast" Ability { id: ["A14A", "A14B"], source: "Repaired Lion" }
+5253.3 "Ancient Stone III" Ability { id: "A14D", source: "Repaired Lion" }
+5253.3 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
+5255.9 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
+5255.9 "Sand Surge" #Ability { id: "A150", source: "Holy Sphere" }
+5257.3 "Ancient Stone III" Ability { id: "A14D", source: "Repaired Lion" }
+5257.3 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
+5259.9 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
+5259.9 "Sand Surge" #Ability { id: "A150", source: "Holy Sphere" }
+5261.3 "Ancient Stone III" Ability { id: "A14D", source: "Repaired Lion" }
+5261.3 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
+5263.9 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
+5263.9 "Sand Surge" #Ability { id: "A150", source: "Holy Sphere" }
+
+5268.8 "Holy Blaze" Ability { id: "A151", source: "Repaired Lion" }
+5278.6 "Scratch" Ability { id: "A155", source: "Repaired Lion" }
+5291.5 "Radiant Wave" Ability { id: "A13F", source: "Repaired Lion" }
+5293.6 "Ancient Holy" Ability { id: "A142", source: "Repaired Lion" }
+5298.6 "Aetherial Exchange" Ability { id: "A140", source: "Repaired Lion" }
+5299.6 "--wind spheres x2--" #Ability { id: "A13C", source: "Repaired Lion" }
+5299.6 "--sand spheres x2--" #Ability { id: "A141", source: "Repaired Lion" }
+5304.5 "--holy spheres x4--" #Ability { id: ["A1B3", "A144"], source: "Repaired Lion" }
+5306.8 "--sync--" StartsUsing { id: "A148", source: "Repaired Lion" } forcejump "oc-eternal-watch-stone"
+5306.8 "--sync--" StartsUsing { id: "A146", source: "Repaired Lion" } forcejump "oc-eternal-watch-aero"
+5307.8 "Light Surge" #Ability { id: "A14E", source: "Holy Sphere" }
+5310.8 "Ancient Stone III/Ancient Aero III?" #Ability { id: ["A148", "A146"], source: "Repaired Lion" } 
+
+# Pattern 2 - Stone First
+5406.8 label "oc-eternal-watch-stone"
+5407.8 "Light Surge" Ability { id: "A14E", source: "Holy Sphere" }
+5410.8 "Ancient Stone III" Ability { id: "A148", source: "Repaired Lion" } duration 1
+5414.4 "Sand Surge" Ability { id: "A150", source: "Holy Sphere" }
+5418.0 "Ancient Aero III" Ability { id: "A146", source: "Repaired Lion" } duration 1
+5421.7 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
+5422.4 "--sync--" StartsUsing { id: "A151", source: "Repaired Lion" } forcejump "oc-eternal-watch-p1-end"
+5426.4 "Holy Blaze" #Ability { id: "A151", source: "Repaired Lion" }
+
+# Pattern 2 - Aero First
+5505.9 label "oc-eternal-watch-aero"
+5507.1 "Light Surge" Ability { id: "A14E", source: "Holy Sphere" }
+5509.9 "Ancient Aero III" Ability { id: "A146", source: "Repaired Lion" } duration 1
+5513.5 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
+5517.1 "Ancient Stone III" Ability { id: "A148", source: "Repaired Lion" } duration 1
+5520.8 "Sand Surge" Ability { id: "A150", source: "Holy Sphere" }
+
+5521.4 label "oc-eternal-watch-p1-end"
+5525.4 "Holy Blaze" Ability { id: "A151", source: "Repaired Lion" }
+5535.2 "Scratch" Ability { id: "A155", source: "Repaired Lion" }
+
+# Loop
+5542.5 "--sync--" StartsUsing { id: "A13F", source: "Repaired Lion" } forcejump "oc-eternal-watch-loop"
+5547.5 "Radiant Wave" #Ability { id: "A13F", source: "Repaired Lion" }
+5552.6 "--wind spheres x4--" #Ability { id: "A13C", source: "Repaired Lion" }
+5553.6 "--sand spheres x4--" #Ability { id: "A141", source: "Repaired Lion" }
+5566.2 "Double Cast" #Ability { id: "A14B", source: "Repaired Lion" }
+5566.6 "Ancient Stone III" #Ability { id: "A14D", source: "Repaired Lion" }
+5566.6 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
 
 ### Flame Of Dusk
 6000.0 "--sync--" ActorControl { command: "80000014", data0: "32A" } window 100000,0

--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
@@ -171,8 +171,69 @@ hideall "--sync--"
 3344.5 "Threefold Marks" Ability { id: "A15E", source: "Death Claw" } forcejump "crosshatch-loop"
 
 ### Cursed Concern
+# -ii 368 A2EF A239 A2CC
+# -p A22E:4131.8
+# -it "Trade Tortoise"
+# IGNORED ABILITIES
+# 368 attack
+# A23F --sync--
+# A239 Earthquake (damage)
+# A22C What're You Buying?
+#
+# ALL ENCOUNTER ABILITIES
+# A22B What're You Buying?
+# A22D Material World
+# A22E Ill-gotten Goods
+# A230 Fourpenny Inflation
+# A231 Onepenny Inflation
+# A232 Cost of Living
+# A236 Waterspout
+# A237 Waterspout
+# A238 Earthquake
+# A409 Recommended for You
+# A915 Twopenny Inflation
+# A96C Hoard Wealth
+# A9BC What're You Buying?
 4000.0 "--sync--" ActorControl { command: "80000014", data0: "32B" } window 100000,0
 4100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
+4128.8 "--sync--" StartsUsing { id: "A22E", source: "Trade Tortoise" } window 30,5
+4131.8 "Ill-gotten Goods (Red)" Ability { id: "A22E", source: "Trade Tortoise" }
+4138.9 "Material World (Stop)" Ability { id: "A22D", source: "Trade Tortoise" }
+4153.0 "Ill-gotten Goods (Blue)" Ability { id: "A22E", source: "Trade Tortoise" }
+4160.1 "Material World (Move)" Ability { id: "A22D", source: "Trade Tortoise" }
+4174.2 "Ill-gotten Goods (Green)" Ability { id: "A22E", source: "Trade Tortoise" }
+4181.3 "Material World (Forced Move)" Ability { id: "A22D", source: "Trade Tortoise" }
+4196.4 "Earthquake" Ability { id: "A238", source: "Trade Tortoise" } duration 1
+4207.7 "Recommended for You" Ability { id: "A409", source: "Trade Tortoise" }
+4235.8 "What're You Buying?" Ability { id: "A22B", source: "Trade Tortoise" }
+4242.8 "Material World" Ability { id: "A22D", source: "Trade Tortoise" }
+4267.1 "Twopenny Inflation / Onepenny Inflation / Fourpenny Inflation" Ability { id: ["A915", "A231", "A230"], source: "Trade Tortoise" }
+4267.1 "Cost of Living" Ability { id: "A232", source: "Trade Tortoise" }
+
+# Loop Begins
+4275.4 label "oc-cursed-concern-loop"
+4279.4 "Recommended for You" Ability { id: "A409", source: "Trade Tortoise" }
+4307.5 "What're You Buying?" Ability { id: "A9BC", source: "Trade Tortoise" }
+4319.6 "Waterspout" Ability { id: "A236", source: "Trade Tortoise" } duration 10
+4325.7 "Material World" Ability { id: "A22D", source: "Trade Tortoise" }
+4329.9 "Waterspout 1" #Ability { id: "A237", source: "Trade Tortoise" }
+4330.9 "Waterspout 2" #Ability { id: "A237", source: "Trade Tortoise" }
+4331.8 "Waterspout 3" #Ability { id: "A237", source: "Trade Tortoise" }
+4332.7 "Waterspout 4" #Ability { id: "A237", source: "Trade Tortoise" }
+4333.6 "Waterspout 5" #Ability { id: "A237", source: "Trade Tortoise" }
+4334.6 "Waterspout 6" #Ability { id: "A237", source: "Trade Tortoise" }
+4335.5 "Waterspout 7" #Ability { id: "A237", source: "Trade Tortoise" }
+4336.4 "Waterspout 8" #Ability { id: "A237", source: "Trade Tortoise" }
+4337.3 "Waterspout (middle)" #Ability { id: "A237", source: "Trade Tortoise" }
+4351.1 "Twopenny Inflation / Onepenny Inflation / Fourpenny Inflation" Ability { id: ["A915", "A231", "A230"], source: "Trade Tortoise" }
+4351.1 "Cost of Living" Ability { id: "A232", source: "Trade Tortoise" }
+4353.1 "Hoard Wealth 1" Ability { id: "A96C", source: "Trade Tortoise" }
+4356.1 "Hoard Wealth 2" Ability { id: "A96C", source: "Trade Tortoise" }
+4368.8 "Earthquake" Ability { id: "A238", source: "Trade Tortoise" } duration 1
+
+4379.2 "--sync--" StartsUsing { id: "A409", source: "Trade Tortoise" } forcejump "oc-cursed-concern-loop"
+4383.2 "Recommended for You" #Ability { id: "A409", source: "Trade Tortoise" }
+4411.3 "What're You Buying?" #Ability { id: "A9BC", source: "Trade Tortoise" }
 
 ### Eternal Watch
 5000.0 "--sync--" ActorControl { command: "80000014", data0: "329" } window 100000,0

--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
@@ -278,7 +278,7 @@ hideall "--sync--"
 5127.9 "Aetherial Exchange" Ability { id: "A140", source: "Repaired Lion" }
 5128.9 "--wind spheres x2--" #Ability { id: "A13C", source: "Repaired Lion" }
 5128.9 "--sand spheres x2--" #Ability { id: "A141", source: "Repaired Lion" }
-5129.9 "--sync--" StartsUsing { id: "A148", source: "Repaired Lion" } jump 5330.3
+5129.9 "--sync--" StartsUsing { id: "A148", source: "Repaired Lion" } jump "oc-eternal-watch-stone-tutorial"
 5129.9 "--sync--" StartsUsing { id: "A146", source: "Repaired Lion" } forcejump "oc-eternal-watch-aero-tutorial"
 5133.9 "Ancient Stone III/Ancient Aero III?" #Ability { id: ["A148", "A146"], source: "Repaired Lion" } duration 1
 5137.6 "Sand Surge/Wind Surge?" #Ability { id: ["A150", "A14F"], source: "Holy Sphere" }
@@ -361,7 +361,7 @@ hideall "--sync--"
 5499.6 "--wind spheres x2--" #Ability { id: "A13C", source: "Repaired Lion" }
 5499.6 "--sand spheres x2--" #Ability { id: "A141", source: "Repaired Lion" }
 5504.5 "--holy spheres x4--" #Ability { id: ["A1B3", "A144"], source: "Repaired Lion" }
-5506.8 "--sync--" StartsUsing { id: "A148", source: "Repaired Lion" } jump 5606.8
+5506.8 "--sync--" StartsUsing { id: "A148", source: "Repaired Lion" } jump "oc-eternal-watch-stone"
 5506.8 "--sync--" StartsUsing { id: "A146", source: "Repaired Lion" } forcejump "oc-eternal-watch-aero"
 5507.8 "Light Surge" Ability { id: "A14E", source: "Holy Sphere" }
 5510.8 "Ancient Stone III/Ancient Aero III?" #Ability { id: ["A148", "A146"], source: "Repaired Lion" }
@@ -489,7 +489,7 @@ hideall "--sync--"
 7230.3 "--sync--" Ability { id: "A0A7", source: "Mythic Idol" }
 7231.0 "--Mythic Mirror x2--" Ability { id: "A0A9", source: "Mythic Mirror" }
 
-7232.6 "--sync--" StartsUsing { id: "A0AA", source: "Mythic Mirror" } jump 7632.6
+7232.6 "--sync--" StartsUsing { id: "A0AA", source: "Mythic Mirror" } jump "oc-from-times-bygone-burst1"
 7232.6 "--sync--" StartsUsing { id: "A0AD", source: "Mythic Mirror" } forcejump "oc-from-times-bygone-death1"
 7236.9 "--sync--" #Ability { id: "A0A7", source: "Mythic Idol" }
 7237.6 "--Mythic Mirror x2--" #Ability { id: "A0A9", source: "Mythic Mirror" }
@@ -511,7 +511,7 @@ hideall "--sync--"
 7356.3 "--sync--" Ability { id: "A0A7", source: "Mythic Idol" }
 7357.0 "--Mythic Mirror x2--" Ability { id: "A0A9", source: "Mythic Mirror" }
 
-7358.6 "--sync--" StartsUsing { id: "A0AA", source: "Mythic Mirror" } jump 7558.6
+7358.6 "--sync--" StartsUsing { id: "A0AA", source: "Mythic Mirror" } jump "oc-from-times-bygone-burst2"
 7358.6 "--sync--" StartsUsing { id: "A0AD", source: "Mythic Mirror" } forcejump "oc-from-times-bygone-death2"
 7360.0 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
 7360.0 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
@@ -567,7 +567,7 @@ hideall "--sync--"
 7643.5 "--sync--" Ability { id: "A0A7", source: "Mythic Idol" }
 7644.2 "--Mythic Mirror x2--" Ability { id: "A0A9", source: "Mythic Mirror" }
 
-7645.8 "--sync--" StartsUsing { id: "A0AA", source: "Mythic Mirror" } jump 7558.6
+7645.8 "--sync--" StartsUsing { id: "A0AA", source: "Mythic Mirror" } jump "oc-from-times-bygone-burst2"
 7645.8 "--sync--" StartsUsing { id: "A0AD", source: "Mythic Mirror" } forcejump "oc-from-times-bygone-death2"
 7647.2 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
 7647.2 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
@@ -608,7 +608,7 @@ hideall "--sync--"
 
 # Check for Steelstrike, else assume Death Ray + Big Burst
 # This can be Steelstrike + Death Ray, Steelstrike + Big Burst, or Big Burst + Death Ray
-7708.9 "--sync--" StartsUsing { id: "A0AB", source: "Mythic Mirror" } jump 7908.9
+7708.9 "--sync--" StartsUsing { id: "A0AB", source: "Mythic Mirror" } jump "oc-from-times-bygone-no-steelstrike"
 7709.2 "--sync--" Ability { id: "A0A8", source: "Mythic Idol" } forcejump "oc-from-times-bygone-no-steelstrike"
 7716.9 "Death Ray + Big Burst?" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
 7716.9 "Steelstrike + Death Ray?" #Ability { id: "A0AB", source: "Mythic Mirror" }
@@ -656,8 +656,145 @@ hideall "--sync--"
 7960.0 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
 
 ### Noise Complaint
+# -ii 368 A12B A0E6 A0E0
+# -p A0E5:8122.4
+# -it "Neo Garula"
+# IGNORED ABILITIES
+# 368 attack
+# A12B --sync--
+# A0E6 Agitated Groan (damage)
+# A0E0 Lightning Crossing (damage)
+#
+# ALL ENCOUNTER ABILITIES
+# A0D7 Rushing Rumble
+# A0D8 Birdserk Rush
+# A0D9 Rushing Rumble Rampage
+# A0DA Rush
+# A0DB Rumble
+# A0DC Heave
+# A0DD --sync--
+# A0DE Lightning Crossing (Intercards)
+# A0DF Lightning Crossing (Cardinals)
+# A0E1 Lightning Charge
+# A0E2 Epicenter Shock
+# A0E3 Mammoth Bolt
+# A0E4 Agitated Groan
+# A0E5 Squash
+# A7E8 Lightning Crossing (charge towards ! bird)
+# A8FE Heave
 8000.0 "--sync--" ActorControl { command: "80000014", data0: "327" } window 100000,0
 8100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
+# Tutorial
+8117.4 "--sync--" StartsUsing { id: "A0E5", source: "Neo Garula" } window 20,5
+8122.4 "Squash" Ability { id: "A0E5", source: "Neo Garula" }
+8128.7 "--middle--"
+
+# NOTE: Pulling boss away from middle at start can cause delay
+8128.7 "--sync--" StartsUsing { id: "A0DF", source: "Neo Garula" } jump "oc-noise-complaint-crossing1-cards" window 5,5
+8128.8 "--sync--" StartsUsing { id: "A0DE", source: "Neo Garula" } jump "oc-noise-complaint-crossing1-intercards" window 5,5
+8132.2 "Lightning Crossing (Cards/Intercards?)" #Ability { id: ["A0DF", "A0DE"], source: "Neo Garula" }
+8141.5 "Heave" #Ability { id: "A8FE", source: "Neo Garula" }
+8150.9 "Heave" #Ability { id: "A8FE", source: "Neo Garula" }
+8156.0 "--middle--" #StartsUsing { id: "A0E4", source: "Neo Garula" } window 5,5
+8161.0 "Agitated Groan" #Ability { id: "A0E4", source: "Neo Garula" } duration 0.9
+8177.1 "Rushing Rumble" #Ability { id: "A0D7", source: "Neo Garula" }
+
+8228.7 label "oc-noise-complaint-crossing1-cards"
+8232.2 "Lightning Crossing (Cards)" Ability { id: "A0DF", source: "Neo Garula" }
+8237.5 "--sync--" StartsUsing { id: "A8FE", source: "Neo Garula" } jump "oc-noise-compliant-crossingl-end"
+8241.5 "Heave" #Ability { id: "A8FE", source: "Neo Garula" }
+8250.9 "Heave" #Ability { id: "A8FE", source: "Neo Garula" }
+8256.0 "--middle--" #StartsUsing { id: "A0E4", source: "Neo Garula" } window 5,5
+8261.0 "Agitated Groan" #Ability { id: "A0E4", source: "Neo Garula" } duration 0.9
+8277.1 "Rushing Rumble" #Ability { id: "A0D7", source: "Neo Garula" }
+
+8328.7 label "oc-noise-complaint-crossing1-intercards"
+8332.2 "Lightning Crossing (Intercards)" Ability { id: "A0DE", source: "Neo Garula" }
+
+8337.5 label "oc-noise-compliant-crossingl-end"
+8341.5 "Heave" Ability { id: "A8FE", source: "Neo Garula" }
+8350.9 "Heave" Ability { id: "A8FE", source: "Neo Garula" }
+8356.0 "--middle--" StartsUsing { id: "A0E4", source: "Neo Garula" } window 5,5
+8361.0 "Agitated Groan" Ability { id: "A0E4", source: "Neo Garula" } duration 0.9
+8377.1 "Rushing Rumble" Ability { id: "A0D7", source: "Neo Garula" }
+8377.3 "Rush" #Ability { id: "A0DA", source: "Neo Garula" }
+8378.0 "--sync--" Ability { id: "A0DD", source: "Chatterbird" }
+8380.4 "Rumble" Ability { id: "A0DB", source: "Neo Garula" }
+8381.5 "Lightning Crossing" Ability { id: "A7E8", source: "Neo Garula" }
+
+# Loop Begins
+8397.5 label "oc-noise-complaint-loop"
+8397.5 "--middle--"
+8402.5 "Agitated Groan" Ability { id: "A0E4", source: "Neo Garula" } duration 0.9
+8410.6 "Birdserk Rush" Ability { id: "A0D8", source: "Neo Garula" }
+8410.8 "Rush" #Ability { id: "A0DA", source: "Neo Garula" }
+8415.0 "Heave" Ability { id: "A0DC", source: "Neo Garula" }
+8426.6 "Squash" Ability { id: "A0E5", source: "Neo Garula" }
+8441.3 "--middle--"
+8441.3 "Lightning Charge" Ability { id: "A0E1", source: "Neo Garula" } window 5,5
+8443.5 "--sync--" StartsUsing { id: "A0DF", source: "Neo Garula" } jump "oc-noise-complaint-crossing2-cards"
+8443.6 "--sync--" StartsUsing { id: "A0DE", source: "Neo Garula" } forcejump "oc-noise-complaint-crossing2-intercards"
+8447.0 "Lightning Crossing (Cards/Intercards?)" #Ability { id: ["A0DF", "A0DE"], source: "Neo Garula" }
+8447.2 "Epicenter Shock 1" #Ability { id: "A0E2", source: "Neo Garula" }
+8451.2 "Epicenter Shock 2" #Ability { id: "A0E2", source: "Neo Garula" }
+8452.4 "Mammoth Bolt" #Ability { id: "A0E3", source: "Neo Garula" }
+8455.1 "Lightning Crossing (Cards/Intercards?)" #Ability { id: "["A0DF", "A0DE"], source: "Neo Garula" }
+8469.4 "--middle--" #StartsUsing { id: "A0E4", source: "Neo Garula" } window 5,5
+
+# NOTE: Third Lightning Crossing Ability conflicts with startsUsing of Epicenter Shock so the branch is longer
+8543.5 label "oc-noise-complaint-crossing2-cards"
+8547.0 "Lightning Crossing (Cards)" Ability { id: "A0DF", source: "Neo Garula" }
+8547.2 "Epicenter Shock 1" #Ability { id: "A0E2", source: "Neo Garula" }
+8551.2 "Epicenter Shock 2" Ability { id: "A0E2", source: "Neo Garula" }
+8551.6 "--sync--" StartsUsing StartsUsing { id: "A0DF", source: "Neo Garula" } jump "oc-noise-complaint-crossing3-cards"
+8551.7 "--sync--" StartsUsing StartsUsing { id: "A0DE", source: "Neo Garula" } forcejump "oc-noise-complaint-crossing3-intercards"
+8552.4 "Mammoth Bolt" #Ability { id: "A0E3", source: "Neo Garula" }
+8555.1 "Lightning Crossing (Cards/Intercards?)" #Ability { id: ["A0DF", "A0DE"], source: "Neo Garula" }
+8569.4 "--middle--" #StartsUsing { id: "A0E4", source: "Neo Garula" } window 5,5
+
+8643.5 label "oc-noise-complaint-crossing2-intercards"
+8647.0 "Lightning Crossing (Intercards)" Ability { id: "A0DE", source: "Neo Garula" }
+8647.2 "Epicenter Shock 1" #Ability { id: "A0E2", source: "Neo Garula" }
+8651.2 "Epicenter Shock 2" Ability { id: "A0E2", source: "Neo Garula" }
+8651.6 "--sync--" StartsUsing StartsUsing { id: "A0DF", source: "Neo Garula" } jump "oc-noise-complaint-crossing3-cards"
+8651.7 "--sync--" StartsUsing StartsUsing { id: "A0DE", source: "Neo Garula" } forcejump "oc-noise-complaint-crossing3-intercards"
+8652.4 "Mammoth Bolt" #Ability { id: "A0E3", source: "Neo Garula" }
+8655.1 "Lightning Crossing (Cards/Intercards?)" #Ability { id: ["A0DF", "A0DE"], source: "Neo Garula" }
+8669.4 "--middle--" #StartsUsing { id: "A0E4", source: "Neo Garula" } window 5,5
+8674.4 "Agitated Groan" #Ability { id: "A0E4", source: "Neo Garula" } duration 0.9
+8683.5 "Rushing Rumble Rampage" #Ability { id: "A0D9", source: "Neo Garula" }
+
+8751.6 label "oc-noise-complaint-crossing3-cards"
+8752.4 "Mammoth Bolt" Ability { id: "A0E3", source: "Neo Garula" }
+8755.1 "Lightning Crossing (Cards)" Ability { id: "A0DF", source: "Neo Garula" }
+8769.4 "--middle--" StartsUsing { id: "A0E4", source: "Neo Garula" } window 5,5 forcejump "oc-noise-complaint-crossing3-end"
+8774.4 "Agitated Groan" #Ability { id: "A0E4", source: "Neo Garula" } duration 0.9
+8783.5 "Rushing Rumble Rampage" #Ability { id: "A0D9", source: "Neo Garula" }
+8783.7 "Rush" #Ability { id: "A0DA", source: "Neo Garula" }
+8784.4 "--sync--" #Ability { id: "A0DD", source: "Chatterbird" }
+8786.8 "Rumble" #Ability { id: "A0DB", source: "Neo Garula" }
+
+8851.6 label "oc-noise-complaint-crossing3-intercards"
+8852.4 "Mammoth Bolt" Ability { id: "A0E3", source: "Neo Garula" }
+8855.1 "Lightning Crossing (Intercards)" Ability { id: "A0DE", source: "Neo Garula" }
+8869.4 "--middle--" StartsUsing { id: "A0E4", source: "Neo Garula" }
+
+8869.4 label "oc-noise-complaint-crossing3-end"
+8874.4 "Agitated Groan" Ability { id: "A0E4", source: "Neo Garula" } duration 0.9
+8883.5 "Rushing Rumble Rampage" Ability { id: "A0D9", source: "Neo Garula" }
+8883.7 "Rush" #Ability { id: "A0DA", source: "Neo Garula" }
+8884.4 "--sync--" Ability { id: "A0DD", source: "Chatterbird" }
+8886.8 "Rumble" Ability { id: "A0DB", source: "Neo Garula" }
+8887.9 "Lightning Crossing" Ability { id: "A7E8", source: "Neo Garula" }
+8890.9 "Rush" Ability { id: "A0DA", source: "Neo Garula" }
+8891.6 "--sync--" Ability { id: "A0DD", source: "Chatterbird" }
+8894.0 "Rumble" Ability { id: "A0DB", source: "Neo Garula" }
+8895.1 "Lightning Crossing" Ability { id: "A7E8", source: "Neo Garula" }
+8898.1 "Rush" Ability { id: "A0DA", source: "Neo Garula" }
+8898.8 "--sync--" Ability { id: "A0DD", source: "Chatterbird" }
+8901.2 "Rumble" Ability { id: "A0DB", source: "Neo Garula" }
+8902.3 "Lightning Crossing" Ability { id: "A7E8", source: "Neo Garula" }
+8915.6 "Squash" Ability { id: "A0E5", source: "Neo Garula" }
 
 ### On The Hunt
 9000.0 "--sync--" ActorControl { command: "80000014", data0: "338" } window 100000,0
@@ -1037,7 +1174,7 @@ hideall "--sync--"
 15262.4 label "oc-extreme-prejudice-loop"
 15262.4 "Assail" Ability { id: "A1C9", source: "Command Urn" }
 15269.3 "Rockslide/Stone Swell?" #Ability { id: ["9A2F", "9A2E"], source: "Vassal Vessel" }
-15269.3 "--sync--" Ability { id: "9A2F", source: "Vassal Vessel" } jump 15369.3
+15269.3 "--sync--" Ability { id: "9A2F", source: "Vassal Vessel" } jump "oc-extreme-prejudice-rockslide"
 15269.3 "--sync--" Ability { id: "9A2E", source: "Vassal Vessel" } forcejump "oc-extreme-prejudice-stoneswell"
 15269.3 "Rockslide/Stone Swell?" #Ability { id: ["9A2F", "92AE"], source: "Vassal Vessel" }
 15274.3 "Stone Swell/Rockslide?" #Ability { id: ["9A2E", "9A2F"], source: "Vassal Vessel" }

--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
@@ -203,8 +203,102 @@ hideall "--sync--"
 11100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
 
 ### The Black Regiment
+# -ii A818 A8FC A1B2 A0CD A0CB
+# -p A0CB:12247.3 A0CC:12402.6 A0BB:12560.4
+# -it "Black Star" "Black Chocobo"
+# IGNORED ABILITIES
+# A818 Attack from Black Chocobo
+# A8FC Attack from Black Star
+# A1B2 movement from Black Chocobo
+# A0BD Choco Slaughter Start of Choco Slaughter
+# A0CD Choco Aero cast from Black Chocobo before main fight
+#
+# ALL ENCOUNTER ABILITIES
+# A0BB Choco Windstorm
+# A0BC Choco Cyclone
+# A0BF Choco Slaughter
+# A0C0 Choco Slaughter
+# A0C1 Choco Doublades
+# A0C2 --sync--
+# A0C3 Choco Blades
+# A0C4 Choco Blades
+# A0CA Choco Aero II
+# A0CB Choco Beak
+# A0CC Choco Maelfeather
+# 
 12000.0 "--sync--" ActorControl { command: "80000014", data0: "322" } window 100000,0
 12100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
+# Adds 1
+
+# Adds 2 + Choco Beak Tutorial
+# TODO: Does Choco Beak have a loop?
+12243.1 "--sync--" AddedCombatant { name: "Black Chocobo" } window 130,2
+12247.3 "--sync--" StartsUsing { id: "A0CB", source: "Black Chocobo" } window 135,20
+12252.3 "Choco Beak" Ability { id: "A0CB", source: "Black Chocobo" }
+
+# Adds 3 + Choco Malefeather Tutorial
+12392.9 "--sync--" AddedCombatant { name: "Black Chocobo" } window 140,2
+12397.6 "--sync--" StartsUsing { id: "A0CC", source: "Black Chocobo" } window 250,10
+
+# This loops every 12.2s until adds are killed
+12402.6 label "black-regiment-malefeather-loop"
+12402.6 "Choco Maelfeather" Ability { id: "A0CC", source: "Black Chocobo" }
+12414.8 "Choco Maelfeather" #Ability { id: "A0CC", source: "Black Chocobo" } forcejump "black-regiment-malefeather-loop"
+12427.0 "Choco Maelfeather" #Ability { id: "A0CC", source: "Black Chocobo" }
+12439.2 "Choco Maelfeather" #Ability { id: "A0CC", source: "Black Chocobo" } 
+
+# Boss + Windstorm and Cyclone Tutorial
+12544.0 "--sync--" AddedCombatant { name: "Black Star" } window 445,2
+12553.4 "--sync--" StartsUsing { id: "A0BB", source: "Black Star" } window 20,20
+12560.4 "Choco Windstorm" Ability { id: "A0BB", source: "Black Star" }
+12569.5 "Choco Cyclone" Ability { id: "A0BC", source: "Black Star" }
+12589.2 "Choco Windstorm" Ability { id: "A0BB", source: "Black Star" }
+12589.3 "Choco Beak" #Ability { id: "A0CB", source: "Black Chocobo" }
+12603.9 "Choco Cyclone" Ability { id: "A0BC", source: "Black Star" }
+12603.9 "Choco Maelfeather" #Ability { id: "A0CC", source: "Black Chocobo" }
+12618.3 "Choco Slaughter" Ability { id: "A0BF", source: "Black Star" } duration 4.4
+12619.4 "Choco Slaughter 1" #Ability { id: "A0C0", source: "Black Star" }
+12620.5 "Choco Slaughter 2" #Ability { id: "A0C0", source: "Black Star" }
+12621.4 "Choco Slaughter" Ability { id: "A0BF", source: "Black Star" } duration 4.4
+12621.6 "Choco Slaughter 3" #Ability { id: "A0C0", source: "Black Star" }
+12622.5 "Choco Slaughter 1" #Ability { id: "A0C0", source: "Black Star" }
+12622.7 "Choco Slaughter 4" #Ability { id: "A0C0", source: "Black Star" }
+12623.6 "Choco Slaughter 2" #Ability { id: "A0C0", source: "Black Star" }
+12624.7 "Choco Slaughter 3" #Ability { id: "A0C0", source: "Black Star" }
+12625.8 "Choco Slaughter 4" #Ability { id: "A0C0", source: "Black Star" }
+12626.5 "Choco Doublades" Ability { id: "A0C1", source: "Black Star" }
+12626.5 "Choco Blades" #Ability { id: "A0C3", source: "Black Star" }
+
+12628.5 label "black-regiment-loop"
+12628.5 "--middle--" Ability { id: "A0C2", source: "Black Star" }
+12629.5 "Choco Blades" Ability { id: "A0C4", source: "Black Star" }
+12631.5 "Choco Beak" Ability { id: "A0CB", source: "Black Chocobo" }
+12633.5 "Choco Aero II" Ability { id: "A0CA", source: "Black Star" }
+12651.5 "Choco Windstorm" Ability { id: "A0BB", source: "Black Star" }
+12651.6 "Choco Beak" #Ability { id: "A0CB", source: "Black Chocobo" }
+12660.6 "Choco Cyclone" Ability { id: "A0BC", source: "Black Star" }
+12660.8 "Choco Maelfeather" #Ability { id: "A0CC", source: "Black Chocobo" }
+12670.7 "Choco Aero II" #Ability { id: "A0CA", source: "Black Star" }
+12672.7 "Choco Aero II" #Ability { id: "A0CA", source: "Black Star" }
+12685.0 "Choco Windstorm" Ability { id: "A0BB", source: "Black Star" }
+12685.1 "Choco Beak" #Ability { id: "A0CB", source: "Black Chocobo" }
+12699.7 "Choco Cyclone" Ability { id: "A0BC", source: "Black Star" }
+12699.7 "Choco Maelfeather" #Ability { id: "A0CC", source: "Black Chocobo" }
+12714.4 "Choco Slaughter" Ability { id: "A0BF", source: "Black Star" } duration 4.4
+12715.5 "Choco Slaughter 1" #Ability { id: "A0C0", source: "Black Star" }
+12716.6 "Choco Slaughter 2" #Ability { id: "A0C0", source: "Black Star" }
+12717.5 "Choco Slaughter" Ability { id: "A0BF", source: "Black Star" } duration 4.4
+12717.7 "Choco Slaughter 3" #Ability { id: "A0C0", source: "Black Star" }
+12718.6 "Choco Slaughter 1" #Ability { id: "A0C0", source: "Black Star" }
+12718.8 "Choco Slaughter 4" #Ability { id: "A0C0", source: "Black Star" }
+12719.7 "Choco Slaughter 2" #Ability { id: "A0C0", source: "Black Star" }
+12720.8 "Choco Slaughter 3" #Ability { id: "A0C0", source: "Black Star" }
+12721.9 "Choco Slaughter 4" #Ability { id: "A0C0", source: "Black Star" }
+12722.6 "Choco Doublades" Ability { id: "A0C1", source: "Black Star" }
+12722.6 "Choco Blades" #Ability { id: "A0C3", source: "Black Star" }
+
+# Loop
+12724.6 "--middle--" Ability { id: "A0C2", source: "Black Star" } forcejump "black-regiment-loop"
 
 ### The Unbridled
 # ALL ENCOUNTER ABILITIES

--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
@@ -690,8 +690,8 @@ hideall "--sync--"
 8128.7 "--middle--"
 
 # NOTE: Pulling boss away from middle at start can cause delay
-8128.7 "--sync--" StartsUsing { id: "A0DF", source: "Neo Garula" } jump "oc-noise-complaint-crossing1-cards" window 5,5
-8128.8 "--sync--" StartsUsing { id: "A0DE", source: "Neo Garula" } jump "oc-noise-complaint-crossing1-intercards" window 5,5
+8128.7 "--sync--" StartsUsing { id: "A0DF", source: "Neo Garula" } window 5,5 jump "oc-noise-complaint-crossing1-cards"
+8128.8 "--sync--" StartsUsing { id: "A0DE", source: "Neo Garula" } window 5,5 jump "oc-noise-complaint-crossing1-intercards"
 8132.2 "Lightning Crossing (Cards/Intercards?)" #Ability { id: ["A0DF", "A0DE"], source: "Neo Garula" }
 8141.5 "Heave" #Ability { id: "A8FE", source: "Neo Garula" }
 8150.9 "Heave" #Ability { id: "A8FE", source: "Neo Garula" }
@@ -746,8 +746,8 @@ hideall "--sync--"
 8547.0 "Lightning Crossing (Cards)" Ability { id: "A0DF", source: "Neo Garula" }
 8547.2 "Epicenter Shock 1" #Ability { id: "A0E2", source: "Neo Garula" }
 8551.2 "Epicenter Shock 2" Ability { id: "A0E2", source: "Neo Garula" }
-8551.6 "--sync--" StartsUsing StartsUsing { id: "A0DF", source: "Neo Garula" } jump "oc-noise-complaint-crossing3-cards"
-8551.7 "--sync--" StartsUsing StartsUsing { id: "A0DE", source: "Neo Garula" } forcejump "oc-noise-complaint-crossing3-intercards"
+8551.6 "--sync--" StartsUsing { id: "A0DF", source: "Neo Garula" } jump "oc-noise-complaint-crossing3-cards"
+8551.7 "--sync--" StartsUsing { id: "A0DE", source: "Neo Garula" } forcejump "oc-noise-complaint-crossing3-intercards"
 8552.4 "Mammoth Bolt" #Ability { id: "A0E3", source: "Neo Garula" }
 8555.1 "Lightning Crossing (Cards/Intercards?)" #Ability { id: ["A0DF", "A0DE"], source: "Neo Garula" }
 8569.4 "--middle--" #StartsUsing { id: "A0E4", source: "Neo Garula" } window 5,5
@@ -756,8 +756,8 @@ hideall "--sync--"
 8647.0 "Lightning Crossing (Intercards)" Ability { id: "A0DE", source: "Neo Garula" }
 8647.2 "Epicenter Shock 1" #Ability { id: "A0E2", source: "Neo Garula" }
 8651.2 "Epicenter Shock 2" Ability { id: "A0E2", source: "Neo Garula" }
-8651.6 "--sync--" StartsUsing StartsUsing { id: "A0DF", source: "Neo Garula" } jump "oc-noise-complaint-crossing3-cards"
-8651.7 "--sync--" StartsUsing StartsUsing { id: "A0DE", source: "Neo Garula" } forcejump "oc-noise-complaint-crossing3-intercards"
+8651.6 "--sync--" StartsUsing { id: "A0DF", source: "Neo Garula" } jump "oc-noise-complaint-crossing3-cards"
+8651.7 "--sync--" StartsUsing { id: "A0DE", source: "Neo Garula" } forcejump "oc-noise-complaint-crossing3-intercards"
 8652.4 "Mammoth Bolt" #Ability { id: "A0E3", source: "Neo Garula" }
 8655.1 "Lightning Crossing (Cards/Intercards?)" #Ability { id: ["A0DF", "A0DE"], source: "Neo Garula" }
 8669.4 "--middle--" #StartsUsing { id: "A0E4", source: "Neo Garula" } window 5,5
@@ -795,6 +795,18 @@ hideall "--sync--"
 8901.2 "Rumble" Ability { id: "A0DB", source: "Neo Garula" }
 8902.3 "Lightning Crossing" Ability { id: "A7E8", source: "Neo Garula" }
 8915.6 "Squash" Ability { id: "A0E5", source: "Neo Garula" }
+
+# Loop
+8931.8 "--middle--" StartsUsing { id: "A0E4", source: "Neo Garula" } forcejump "oc-noise-complaint-loop"
+8936.8 "Agitated Groan" #Ability { id: "A0E4", source: "Neo Garula" } duration 0.9
+8944.9 "Birdserk Rush" #Ability { id: "A0D8", source: "Neo Garula" }
+8945.1 "Rush" #Ability { id: "A0DA", source: "Neo Garula" }
+8949.3 "Heave" #Ability { id: "A0DC", source: "Neo Garula" }
+8960.7 "Squash" #Ability { id: "A0E5", source: "Neo Garula" }
+8974.6 "--middle--"
+8974.6 "Lightning Charge" #Ability { id: "A0E1", source: "Neo Garula" }
+8980.3 "Lightning Crossing (Intercards)" #Ability { id: "A0DE", source: "Neo Garula" }
+8980.5 "Epicenter Shock 1" #Ability { id: "A0E2", source: "Neo Garula" }
 
 ### On The Hunt
 9000.0 "--sync--" ActorControl { command: "80000014", data0: "338" } window 100000,0

--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
@@ -375,8 +375,258 @@ hideall "--sync--"
 6100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
 
 ### From Times Bygone
+# -ii A240 A0AC A0B6 A324
+# -p A0B1:7123.6
+# -it "Mythic Idol"
+# IGNORED ABILITIES
+# A240 --sync-- Attack
+# A0AC Steelstrike Cast by Mythic Iodl coincides with Steelstrike A0AB, intercards
+# A0B6 Arcane Light damage 0.9s after A0B5 cast
+# A324 Lots Cast damage 0.8s after A0B2 cast
+#
+# ALL ENCOUNTER ABILITIES
+# A0A6 Shifting Shape, Boss will go middle about 0.5s before this cast start
+# A0A7 --sync--
+# A0A8 --sync--
+# A0A9 --sync-- Spawn of a Mythic Mirror
+# A0AA Big Burst
+# A0AB Steelstrike cast by Mythic Mirror with A0AC, cardinals
+# A0AD Death Ray
+# A0AE Arcane Design, Boss will go middle about 0.5s before this cast start
+# A0AF --sync-- Tells for Arcane Orb A0B0
+# A0B0 Arcane Orb
+# A0B1 Mystic Heat
+# A0B2 Lots Cast
+# A0B3 Lots Cast tankbuster aoes
+# A0B4 Lots Cast spread aoes
+# A0B5 Arcane Light
 7000.0 "--sync--" ActorControl { command: "80000014", data0: "323" } window 100000,0
 7100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
+7118.6 "--sync--" StartsUsing { id: "A0B1", source: "Mythic Idol" } window 20,5
+7123.6 "Mystic Heat" Ability { id: "A0B1", source: "Mythic Idol" }
+7129.5 "--middle--"
+7133.4 "Shifting Shape" Ability { id: "A0A6", source: "Mythic Idol" }
+7135.5 "--sync--" Ability { id: "A0A7", source: "Mythic Idol" }
+7136.5 "--sync--" Ability { id: "A0A8", source: "Mythic Idol" }
+
+# Bomb Mirror - Big Burst Tutorial
+7139.6 "--Bomb Mirror--" Ability { id: "A0A9", source: "Mythic Mirror" }
+7145.6 "Shifting Shape" Ability { id: "A0A6", source: "Mythic Idol" }
+7147.8 "--sync--" Ability { id: "A0A7", source: "Mythic Idol" }
+7148.8 "--sync--" Ability { id: "A0A8", source: "Mythic Idol" }
+7149.1 "Big Burst" Ability { id: "A0AA", source: "Mythic Mirror" }
+
+# Demon Mirror - Death Ray Tutorial
+7151.9 "--Demon Mirror--" Ability { id: "A0A9", source: "Mythic Mirror" }
+7157.9 "Shifting Shape" Ability { id: "A0A6", source: "Mythic Idol" }
+7160.0 "--sync--" Ability { id: "A0A7", source: "Mythic Idol" }
+7161.0 "--sync--" Ability { id: "A0A8", source: "Mythic Idol" }
+7161.4 "Death Ray" Ability { id: "A0AD", source: "Mythic Mirror" }
+
+# Swords Mirror - Steelstrike Tutorial
+7164.2 "--Swords Mirror--" Ability { id: "A0A9", source: "Mythic Mirror" }
+7173.8 "Steelstrike" Ability { id: "A0AB", source: "Mythic Mirror" }
+
+# Arcane Design Tutorial: 8 Spirals, each with 6 aoes
+7179.9 "--middle--"
+7183.4 "Arcane Design" Ability { id: "A0AE", source: "Mythic Idol" }
+7186.3 "--1--" #Ability { id: "A0AF", source: "Mythic Idol" } duration 0.5
+7186.7 "--2--" #Ability { id: "A0AF", source: "Mythic Idol" } duration 0.5
+7187.1 "--3--" #Ability { id: "A0AF", source: "Mythic Idol" } duration 0.5
+7187.5 "--4--" #Ability { id: "A0AF", source: "Mythic Idol" } duration 0.5
+7187.9 "--5--" #Ability { id: "A0AF", source: "Mythic Idol" } duration 0.5
+7188.3 "--6--" #Ability { id: "A0AF", source: "Mythic Idol" } duration 0.5
+7188.7 "--7--" #Ability { id: "A0AF", source: "Mythic Idol" } duration 0.5
+7189.1 "--8--" #Ability { id: "A0AF", source: "Mythic Idol" } duration 0.5
+7192.3 "Arcane Orb Spiral 1" #Ability { id: "A0B0", source: "Mythic Idol" } duration 0.5
+7192.7 "Arcane Orb Spiral 2" #Ability { id: "A0B0", source: "Mythic Idol" } duration 0.5
+7193.1 "Arcane Orb Spiral 3" #Ability { id: "A0B0", source: "Mythic Idol" } duration 0.5
+7193.5 "Arcane Orb Spiral 4" #Ability { id: "A0B0", source: "Mythic Idol" } duration 0.5
+7193.9 "Arcane Orb Spiral 5" #Ability { id: "A0B0", source: "Mythic Idol" } duration 0.5
+7194.3 "Arcane Orb Spiral 6" #Ability { id: "A0B0", source: "Mythic Idol" } duration 0.5
+7194.7 "Arcane Orb Spiral 7" #Ability { id: "A0B0", source: "Mythic Idol" } duration 0.5
+7195.1 "Arcane Orb Spiral 8" #Ability { id: "A0B0", source: "Mythic Idol" } duration 0.5
+
+# There can be late syncs here, adding window fixes it
+7197.6 "--sync--" Ability { id: "A0A8", source: "Mythic Idol" } window 5,5
+7204.6 "Lots Cast" Ability { id: "A0B2", source: "Mythic Idol" } duration 0.8
+7210.4 "Lots Cast (tankbusters)" Ability { id: "A0B3", source: "Mythic Idol" }
+7211.4 "Lots Cast (spreads)" Ability { id: "A0B4", source: "Mythic Idol" }
+7215.0 "Mystic Heat" Ability { id: "A0B1", source: "Mythic Idol" }
+7218.1 "--middle--"
+
+# Loop Block
+7218.6 label "oc-from-times-bygone-loop"
+7221.6 "Shifting Shape" Ability { id: "A0A6", source: "Mythic Idol" }
+7223.7 "--sync--" Ability { id: "A0A7", source: "Mythic Idol" }
+7230.3 "--sync--" Ability { id: "A0A7", source: "Mythic Idol" }
+7231.0 "--Mythic Mirror x2--" Ability { id: "A0A9", source: "Mythic Mirror" }
+
+7232.6 "--sync--" StartsUsing { id: "A0AA", source: "Mythic Mirror" } forcejump "oc-from-times-bygone-burst1"
+7232.6 "--sync--" StartsUsing { id: "A0AD", source: "Mythic Mirror" } forcejump "oc-from-times-bygone-death1"
+7236.9 "--sync--" #Ability { id: "A0A7", source: "Mythic Idol" }
+7237.6 "--Mythic Mirror x2--" #Ability { id: "A0A9", source: "Mythic Mirror" }
+7240.6 "Steelstrike" #Ability { id: "A0AB", source: "Mythic Mirror" }
+7240.6 "Big Burst/Death Ray?" #Ability { id: ["A0AA", "A0AD"], source: "Mythic Mirror" }
+
+# The Mystic Mirrors don't spawn double Steelstrike
+# 1: Streelstrike + Death Ray or Steelstrike + Big Burst
+# 2: Big Burst + Death Ray, Death Ray x2, or Big Burst x2
+# 3: Streelstrike + Death Ray or Steelstrike + Big Burst
+# 4: Big Burst + Death Ray, Death Ray x2, or Big Burst x2
+
+# Pattern 1 - Steelstrike + Death Ray first
+7345.4 label "oc-from-times-bygone-death1"
+7343.8 "--Mythic Mirror x2--" Ability { id: "A0A9", source: "Mythic Mirror" }
+7349.7 "--sync--" Ability { id: "A0A7", source: "Mythic Idol" }
+7350.4 "--Mythic Mirror x2--" Ability { id: "A0A9", source: "Mythic Mirror" }
+7353.4 "Steelstrike" Ability { id: "A0AB", source: "Mythic Mirror" }
+7353.4 "Death Ray" #Ability { id: "A0AD", source: "Mythic Mirror" }
+7356.3 "--sync--" Ability { id: "A0A7", source: "Mythic Idol" }
+7357.0 "--Mythic Mirror x2--" Ability { id: "A0A9", source: "Mythic Mirror" }
+
+7358.6 "--sync--" StartsUsing { id: "A0AA", source: "Mythic Mirror" } forcejump "oc-from-times-bygone-burst2"
+7358.6 "--sync--" StartsUsing { id: "A0AD", source: "Mythic Mirror" } forcejump "oc-from-times-bygone-death2"
+7360.0 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+7360.0 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+7362.9 "--sync--" #Ability { id: "A0A8", source: "Mythic Idol" }
+7363.6 "--Mythic Mirror x2--" #Ability { id: "A0A9", source: "Mythic Mirror" }
+7366.6 "Steelstrike" #Ability { id: "A0AB", source: "Mythic Mirror" }
+7366.6 "Big Burst/Death Ray?" #Ability { id: ["A0AA", "A0AD"], source: "Mythic Mirror" }
+7373.2 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+7373.2 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+
+# Pattern 1 - Steelstrike + Death Ray third
+7458.6 label "oc-from-times-bygone-death2"
+7460.0 "Death Ray/Big Burst" Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+7460.0 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+7462.9 "--sync--" Ability { id: "A0A8", source: "Mythic Idol" }
+7463.6 "--Mythic Mirror x2--" Ability { id: "A0A9", source: "Mythic Mirror" }
+7466.6 "Steelstrike" Ability { id: "A0AB", source: "Mythic Mirror" }
+7466.6 "Death Ray" #Ability { id: "A0AD", source: "Mythic Mirror" }
+7473.2 "Death Ray/Big Burst" Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+7473.2 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+
+7474.1 "--sync--" StartsUsing { id: "A0B2", source: "Mythic Idol" } forcejump "oc-from-times-bygone-p1-end"
+7479.1 "Lots Cast" #Ability { id: "A0B2", source: "Mythic Idol" } duration 0.8
+7484.9 "Lots Cast (tankbusters)" #Ability { id: "A0B3", source: "Mythic Idol" }
+7485.9 "Lots Cast (spreads)" #Ability { id: "A0B4", source: "Mythic Idol" }
+7489.6 "Mystic Heat" #Ability { id: "A0B1", source: "Mythic Idol" }
+7496.7 "Arcane Light" #Ability { id: "A0B5", source: "Mythic Idol" } duration 0.9
+
+# Pattern 1 - Steelstrike + Big Burst third
+7558.6 label "oc-from-times-bygone-burst2"
+7560.0 "Death Ray/Big Burst" Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+7560.0 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+7562.9 "--sync--" Ability { id: "A0A8", source: "Mythic Idol" }
+7563.6 "--Mythic Mirror x2--" Ability { id: "A0A9", source: "Mythic Mirror" }
+7566.6 "Steelstrike" Ability { id: "A0AB", source: "Mythic Mirror" }
+7566.6 "Big Burst" #Ability { id: "A0AA", source: "Mythic Mirror" }
+7573.2 "Death Ray/Big Burst" Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+7573.2 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+
+7574.1 "--sync--" StartsUsing { id: "A0B2", source: "Mythic Idol" } forcejump "oc-from-times-bygone-p1-end"
+7579.1 "Lots Cast" #Ability { id: "A0B2", source: "Mythic Idol" } duration 0.8
+7584.9 "Lots Cast (tankbusters)" #Ability { id: "A0B3", source: "Mythic Idol" }
+7585.9 "Lots Cast (spreads)" #Ability { id: "A0B4", source: "Mythic Idol" }
+7589.6 "Mystic Heat" #Ability { id: "A0B1", source: "Mythic Idol" }
+7596.7 "Arcane Light" #Ability { id: "A0B5", source: "Mythic Idol" } duration 0.9
+
+# Pattern 1 - Steelstrike + Big Burst first
+7632.6 label "oc-from-times-bygone-burst1"
+7637.6 "--Mythic Mirror x2--" Ability { id: "A0A9", source: "Mythic Mirror" }
+7640.6 "Steelstrike" Ability { id: "A0AB", source: "Mythic Mirror" }
+7640.6 "Big Burst" #Ability { id: "A0AA", source: "Mythic Mirror" }
+7643.5 "--sync--" Ability { id: "A0A7", source: "Mythic Idol" }
+7644.2 "--Mythic Mirror x2--" Ability { id: "A0A9", source: "Mythic Mirror" }
+
+7645.8 "--sync--" StartsUsing { id: "A0AA", source: "Mythic Mirror" } forcejump "oc-from-times-bygone-burst2"
+7645.8 "--sync--" StartsUsing { id: "A0AD", source: "Mythic Mirror" } forcejump "oc-from-times-bygone-death2"
+7647.2 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+7647.2 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+7650.1 "--sync--" #Ability { id: "A0A8", source: "Mythic Idol" }
+7650.8 "--Mythic Mirror x2--" #Ability { id: "A0A9", source: "Mythic Mirror" }
+7653.8 "Death Ray/Big Burst?" #Ability { id: ["A0AA", "A0AD"], source: "Mythic Mirror" }
+7653.8 "Steelstrike" #Ability { id: "A0AB", source: "Mythic Mirror" }
+7660.4 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+7660.4 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+
+7661.3 label "oc-from-times-bygone-p1-end"
+7666.3 "Lots Cast" Ability { id: "A0B2", source: "Mythic Idol" } duration 0.8
+7672.1 "Lots Cast (tankbusters)" Ability { id: "A0B3", source: "Mythic Idol" }
+7673.1 "Lots Cast (spreads)" Ability { id: "A0B4", source: "Mythic Idol" }
+7676.8 "Mystic Heat" Ability { id: "A0B1", source: "Mythic Idol" }
+7683.9 "Arcane Light" Ability { id: "A0B5", source: "Mythic Idol" } duration 0.9
+
+7693.7 "--middle--"
+7697.2 "Arcane Design" Ability { id: "A0AE", source: "Mythic Idol" }
+7700.1 "--1--" #Ability { id: "A0AF", source: "Mythic Idol" } duration 0.5
+7700.5 "--2--" #Ability { id: "A0AF", source: "Mythic Idol" } duration 0.5
+7700.9 "--3--" #Ability { id: "A0AF", source: "Mythic Idol" } duration 0.5
+7701.3 "--4--" #Ability { id: "A0AF", source: "Mythic Idol" } duration 0.5
+7701.7 "--5--" #Ability { id: "A0AF", source: "Mythic Idol" } duration 0.5
+7702.1 "--6--" #Ability { id: "A0AF", source: "Mythic Idol" } duration 0.5
+7702.5 "--7--" #Ability { id: "A0AF", source: "Mythic Idol" } duration 0.5
+7702.9 "--8--" #Ability { id: "A0AF", source: "Mythic Idol" } duration 0.5
+7705.7 "--sync--" Ability { id: "A0A7", source: "Mythic Idol" }
+7706.0 "Arcane Orb Spiral 1" #Ability { id: "A0B0", source: "Mythic Idol" } duration 0.5
+7706.4 "Arcane Orb Spiral 2" #Ability { id: "A0B0", source: "Mythic Idol" } duration 0.5
+7706.8 "Arcane Orb Spiral 3" #Ability { id: "A0B0", source: "Mythic Idol" } duration 0.5
+7707.2 "Arcane Orb Spiral 4" #Ability { id: "A0B0", source: "Mythic Idol" } duration 0.5
+7707.6 "Arcane Orb Spiral 5" #Ability { id: "A0B0", source: "Mythic Idol" } duration 0.5
+7708.0 "Arcane Orb Spiral 6" #Ability { id: "A0B0", source: "Mythic Idol" } duration 0.5
+7708.2 "--Mythic Mirror x2--" Ability { id: "A0A9", source: "Mythic Mirror" }
+7708.3 "Arcane Orb Spiral 7" #Ability { id: "A0B0", source: "Mythic Idol" } duration 0.5
+7708.7 "Arcane Orb Spiral 8" #Ability { id: "A0B0", source: "Mythic Idol" } duration 0.5
+
+# Check for Steelstrike, else assume Death Ray + Big Burst
+# This can be Steelstrike + Death Ray, Steelstrike + Big Burst, or Big Burst + Death Ray
+7708.9 "--sync--" StartsUsing { id: "A0AB", source: "Mythic Mirror" } forcejump "oc-from-times-bygone-steelstrike"
+7709.2 "--sync--" Ability { id: "A0A8", source: "Mythic Idol" } forcejump "oc-from-times-bygone-no-steelstrike"
+7716.9 "Death Ray + Big Burst?" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+7716.9 "Steelstrike + Death Ray?" #Ability { id: "A0AB", source: "Mythic Mirror" }
+7716.9 "Steelstrike + Big Burst?" #Ability { id: "A0AB", source: "Mythic Mirror" }
+7725.3 "Arcane Light" #Ability { id: "A0B5", source: "Mythic Idol" } duration 0.9
+7730.9 "--middle--"
+7734.4 "Shifting Shape" #Ability { id: "A0A6", source: "Mythic Idol" }
+7736.5 "--sync--" #Ability { id: "A0A7", source: "Mythic Idol" }
+7743.1 "--sync--" #Ability { id: "A0A7", source: "Mythic Idol" }
+7743.8 "--Mythic Mirror x2--" #Ability { id: "A0A9", source: "Mythic Mirror" }
+
+7809.2 label "oc-from-times-bygone-no-steelstrike"
+7816.9 "Death Ray/Big Burst" Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+7816.9 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+7820.3 "--sync--" StartsUsing { id: "A0B5", source: "Mythic Idol" } forcejump "oc-from-times-bygone-pre-loop"
+7825.3 "Arcane Light" #Ability { id: "A0B5", source: "Mythic Idol" } duration 0.9
+7830.9 "--middle--"
+7834.4 "Shifting Shape" #Ability { id: "A0A6", source: "Mythic Idol" }
+7836.5 "--sync--" #Ability { id: "A0A7", source: "Mythic Idol" }
+7843.1 "--sync--" #Ability { id: "A0A7", source: "Mythic Idol" }
+7843.8 "--Mythic Mirror x2--" #Ability { id: "A0A9", source: "Mythic Mirror" }
+
+7908.9 label "oc-from-times-bygone-steelstrike"
+7909.2 "--sync--" Ability { id: "A0A8", source: "Mythic Idol" }
+7916.9 "Steelstrike" Ability { id: "A0AB", source: "Mythic Mirror" }
+7916.9 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+
+7920.3 label "oc-from-times-bygone-pre-loop"
+7925.3 "Arcane Light" Ability { id: "A0B5", source: "Mythic Idol" } duration 0.9
+7930.9 "--middle--"
+
+# Loop
+7931.4 "--sync--" StartsUsing { id: "A0A6", source: "Mythic Idol" } forcejump "oc-from-times-bygone-loop"
+7934.4 "Shifting Shape" #Ability { id: "A0A6", source: "Mythic Idol" }
+7936.5 "--sync--" #Ability { id: "A0A7", source: "Mythic Idol" }
+7943.1 "--sync--" #Ability { id: "A0A7", source: "Mythic Idol" }
+7943.8 "--Mythic Mirror x2--" #Ability { id: "A0A9", source: "Mythic Mirror" }
+7949.7 "--sync--" #Ability { id: "A0A7", source: "Mythic Idol" }
+7950.4 "--Mythic Mirror x2--" #Ability { id: "A0A9", source: "Mythic Mirror" }
+7953.4 "Steelstrike" #Ability { id: "A0AB", source: "Mythic Mirror" }
+7953.4 "Death Ray/Big Burst?" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+7956.3 "--sync--" #Ability { id: "A0A7", source: "Mythic Idol" }
+7957.0 "--Mythic Mirror x2--" #Ability { id: "A0A9", source: "Mythic Mirror" }
+7960.0 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
+7960.0 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
 
 ### Noise Complaint
 8000.0 "--sync--" ActorControl { command: "80000014", data0: "327" } window 100000,0

--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
@@ -511,7 +511,7 @@ hideall "--sync--"
 7356.3 "--sync--" Ability { id: "A0A7", source: "Mythic Idol" }
 7357.0 "--Mythic Mirror x2--" Ability { id: "A0A9", source: "Mythic Mirror" }
 
-7358.6 "--sync--" StartsUsing { id: "A0AA", source: "Mythic Mirror" } forcejump 7558.6
+7358.6 "--sync--" StartsUsing { id: "A0AA", source: "Mythic Mirror" } jump 7558.6
 7358.6 "--sync--" StartsUsing { id: "A0AD", source: "Mythic Mirror" } forcejump "oc-from-times-bygone-death2"
 7360.0 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
 7360.0 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }

--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
@@ -198,11 +198,14 @@ hideall "--sync--"
 4100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
 4128.8 "--sync--" StartsUsing { id: "A22E", source: "Trade Tortoise" } window 30,5
 4131.8 "Ill-gotten Goods (Red)" Ability { id: "A22E", source: "Trade Tortoise" }
-4138.9 "Material World (Stop)" Ability { id: "A22D", source: "Trade Tortoise" }
+4138.9 "Material World " Ability { id: "A22D", source: "Trade Tortoise" }
+4146.8 "Ruby Blaze (Stop)" #Ability { id: "A23D" }
 4153.0 "Ill-gotten Goods (Blue)" Ability { id: "A22E", source: "Trade Tortoise" }
-4160.1 "Material World (Move)" Ability { id: "A22D", source: "Trade Tortoise" }
+4160.1 "Material World" Ability { id: "A22D", source: "Trade Tortoise" }
+4168.0 "Deep Freeze (Move)"
 4174.2 "Ill-gotten Goods (Green)" Ability { id: "A22E", source: "Trade Tortoise" }
-4181.3 "Material World (Forced Move)" Ability { id: "A22D", source: "Trade Tortoise" }
+4181.3 "Material World" Ability { id: "A22D", source: "Trade Tortoise" }
+4189.6 "--forced move--"
 4196.4 "Earthquake" Ability { id: "A238", source: "Trade Tortoise" } duration 1
 4207.7 "Recommended for You" Ability { id: "A409", source: "Trade Tortoise" }
 4235.8 "What're You Buying?" Ability { id: "A22B", source: "Trade Tortoise" }

--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
@@ -337,7 +337,7 @@ hideall "--sync--"
 5306.8 "--sync--" StartsUsing { id: "A148", source: "Repaired Lion" } forcejump "oc-eternal-watch-stone"
 5306.8 "--sync--" StartsUsing { id: "A146", source: "Repaired Lion" } forcejump "oc-eternal-watch-aero"
 5307.8 "Light Surge" #Ability { id: "A14E", source: "Holy Sphere" }
-5310.8 "Ancient Stone III/Ancient Aero III?" #Ability { id: ["A148", "A146"], source: "Repaired Lion" } 
+5310.8 "Ancient Stone III/Ancient Aero III?" #Ability { id: ["A148", "A146"], source: "Repaired Lion" }
 
 # Pattern 2 - Stone First
 5406.8 label "oc-eternal-watch-stone"

--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
@@ -275,103 +275,127 @@ hideall "--sync--"
 5122.2 "Radiant Wave" Ability { id: "A13F", source: "Repaired Lion" } duration 1
 
 # Ancient Stone and Ancient Aero Tutorial
-5128.3 "Aetherial Exchange" Ability { id: "A140", source: "Repaired Lion" }
-5129.3 "--wind spheres x2--" #Ability { id: "A13C", source: "Repaired Lion" }
-5129.3 "--sand spheres x2--" #Ability { id: "A141", source: "Repaired Lion" }
-5134.3 "Ancient Stone III" Ability { id: "A148", source: "Repaired Lion" } duration 1
-5138.0 "Sand Surge" Ability { id: "A150", source: "Holy Sphere" }
-5141.4 "Ancient Aero III" Ability { id: "A146", source: "Repaired Lion" } duration 1
-5145.0 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
-5149.8 "Holy Blaze" Ability { id: "A151", source: "Repaired Lion" }
-5158.7 "Scratch" Ability { id: "A155", source: "Repaired Lion" }
+5127.9 "Aetherial Exchange" Ability { id: "A140", source: "Repaired Lion" }
+5128.9 "--wind spheres x2--" #Ability { id: "A13C", source: "Repaired Lion" }
+5128.9 "--sand spheres x2--" #Ability { id: "A141", source: "Repaired Lion" }
+5129.9 "--sync--" StartsUsing { id: "A148", source: "Repaired Lion" } jump 5330.3
+5129.9 "--sync--" StartsUsing { id: "A146", source: "Repaired Lion" } forcejump "oc-eternal-watch-aero-tutorial"
+5133.9 "Ancient Stone III/Ancient Aero III?" #Ability { id: ["A148", "A146"], source: "Repaired Lion" } duration 1
+5137.6 "Sand Surge/Wind Surge?" #Ability { id: ["A150", "A14F"], source: "Holy Sphere" }
+5141.2 "Ancient Aero III/Ancient Stone III?" #Ability { id: ["A146", "A148"], source: "Repaired Lion" } duration 1
+5144.9 "Wind Surge/Sand Surge?" #Ability { id: ["A14F", "A150"], source: "Holy Sphere" }
+5149.6 "Holy Blaze" #Ability { id: "A151", source: "Repaired Lion" }
+5158.4 "Scratch" #Ability { id: "A155", source: "Repaired Lion" }
+
+# Pattern 1 - Ancient Aero III First
+5229.9 label "oc-eternal-watch-aero-tutorial"
+5233.9 "Ancient Aero III" Ability { id: "A146", source: "Repaired Lion" } duration 1
+5237.6 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
+5241.2 "Ancient Stone III" Ability { id: "A148", source: "Repaired Lion" } duration 1
+5244.9 "Sand Surge" Ability { id: "A150", source: "Holy Sphere" }
+5245.8 "--sync--" StartsUsing { id: "A151", source: "Repaired Lion" } forcejump "oc-eternal-watch-stone-aero-tutorial-end"
+5249.8 "Holy Blaze" #Ability { id: "A151", source: "Repaired Lion" }
+5258.7 "Scratch" #Ability { id: "A155", source: "Repaired Lion" }
+5270.8 "Radiant Wave" #Ability { id: "A13F", source: "Repaired Lion" } duration 1
+
+# Pattern 1 - Ancient Stone III First
+5330.3 label "oc-eternal-watch-stone-tutorial"
+5334.3 "Ancient Stone III" Ability { id: "A148", source: "Repaired Lion" } duration 1
+5338.0 "Sand Surge" Ability { id: "A150", source: "Holy Sphere" }
+5341.4 "Ancient Aero III" Ability { id: "A146", source: "Repaired Lion" } duration 1
+5345.0 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
+
+5345.6 label "oc-eternal-watch-stone-aero-tutorial-end"
+5349.6 "Holy Blaze" Ability { id: "A151", source: "Repaired Lion" }
+5358.4 "Scratch" Ability { id: "A155", source: "Repaired Lion" }
 
 # Ancient Holy Tutorial
-5170.8 "Radiant Wave" Ability { id: "A13F", source: "Repaired Lion" } duration 1
-5172.9 "Ancient Holy" Ability { id: "A143", source: "Repaired Lion" }
-5183.9 "--holy spheres x4--" #Ability { id: ["A1B3", "A144"], source: "Repaired Lion" }
-5186.4 "Light Surge" #Ability { id: "A14E", source: "Holy Sphere" }
-5188.2 "Holy Blaze" Ability { id: "A151", source: "Repaired Lion" }
-5197.0 "Scratch" Ability { id: "A155", source: "Repaired Lion" }
+5370.8 "Radiant Wave" Ability { id: "A13F", source: "Repaired Lion" } duration 1
+5372.9 "Ancient Holy" Ability { id: "A143", source: "Repaired Lion" }
+5383.9 "--holy spheres x4--" #Ability { id: ["A1B3", "A144"], source: "Repaired Lion" }
+5386.4 "Light Surge" Ability { id: "A14E", source: "Holy Sphere" }
+5388.2 "Holy Blaze" Ability { id: "A151", source: "Repaired Lion" }
+5397.0 "Scratch" Ability { id: "A155", source: "Repaired Lion" }
 
 # Loop Block
-5206.1 label "oc-eternal-watch-loop"
-5211.1 "Radiant Wave" Ability { id: "A13F", source: "Repaired Lion" } duration 1
-5216.2 "Aetherial Exchange" Ability { id: "A140", source: "Repaired Lion" }
-5217.2 "--wind spheres x4--" #Ability { id: "A13C", source: "Repaired Lion" }
-5217.2 "--sand spheres x4--" #Ability { id: "A141", source: "Repaired Lion" }
+5406.1 label "oc-eternal-watch-loop"
+5411.1 "Radiant Wave" Ability { id: "A13F", source: "Repaired Lion" } duration 1
+5416.2 "Aetherial Exchange" Ability { id: "A140", source: "Repaired Lion" }
+5417.2 "--wind spheres x4--" #Ability { id: "A13C", source: "Repaired Lion" }
+5417.2 "--sand spheres x4--" #Ability { id: "A141", source: "Repaired Lion" }
 
 # There is a Pattern here with Double Cast, but currently not displaying text differently
 # Double cast will be A14A or A14B and the subsequent will be opposite
-5229.8 "Double Cast" Ability { id: ["A14B", "A14A"], source: "Repaired Lion" }
-5230.2 "Ancient Stone III" Ability { id: "A14D", source: "Repaired Lion" }
-5230.2 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
-5232.8 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
-5232.8 "Sand Surge" #Ability { id: "A150", source: "Holy Sphere" }
-5234.2 "Ancient Stone III" Ability { id: "A14D", source: "Repaired Lion" }
-5234.2 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
-5236.8 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
-5236.8 "Sand Surge" #Ability { id: "A150", source: "Holy Sphere" }
-5238.2 "Ancient Stone III" Ability { id: "A14D", source: "Repaired Lion" }
-5238.2 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
-5240.9 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
-5240.9 "Sand Surge" #Ability { id: "A150", source: "Holy Sphere" }
-5252.9 "Double Cast" Ability { id: ["A14A", "A14B"], source: "Repaired Lion" }
-5253.3 "Ancient Stone III" Ability { id: "A14D", source: "Repaired Lion" }
-5253.3 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
-5255.9 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
-5255.9 "Sand Surge" #Ability { id: "A150", source: "Holy Sphere" }
-5257.3 "Ancient Stone III" Ability { id: "A14D", source: "Repaired Lion" }
-5257.3 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
-5259.9 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
-5259.9 "Sand Surge" #Ability { id: "A150", source: "Holy Sphere" }
-5261.3 "Ancient Stone III" Ability { id: "A14D", source: "Repaired Lion" }
-5261.3 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
-5263.9 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
-5263.9 "Sand Surge" #Ability { id: "A150", source: "Holy Sphere" }
+5429.8 "Double Cast" Ability { id: ["A14B", "A14A"], source: "Repaired Lion" }
+5430.2 "Ancient Stone III" Ability { id: "A14D", source: "Repaired Lion" }
+5430.2 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
+5432.8 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
+5432.8 "Sand Surge" #Ability { id: "A150", source: "Holy Sphere" }
+5434.2 "Ancient Stone III" Ability { id: "A14D", source: "Repaired Lion" }
+5434.2 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
+5436.8 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
+5436.8 "Sand Surge" #Ability { id: "A150", source: "Holy Sphere" }
+5438.2 "Ancient Stone III" Ability { id: "A14D", source: "Repaired Lion" }
+5438.2 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
+5440.9 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
+5440.9 "Sand Surge" #Ability { id: "A150", source: "Holy Sphere" }
+5452.9 "Double Cast" Ability { id: ["A14A", "A14B"], source: "Repaired Lion" }
+5453.3 "Ancient Stone III" Ability { id: "A14D", source: "Repaired Lion" }
+5453.3 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
+5455.9 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
+5455.9 "Sand Surge" #Ability { id: "A150", source: "Holy Sphere" }
+5457.3 "Ancient Stone III" Ability { id: "A14D", source: "Repaired Lion" }
+5457.3 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
+5459.9 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
+5459.9 "Sand Surge" #Ability { id: "A150", source: "Holy Sphere" }
+5461.3 "Ancient Stone III" Ability { id: "A14D", source: "Repaired Lion" }
+5461.3 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
+5463.9 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
+5463.9 "Sand Surge" #Ability { id: "A150", source: "Holy Sphere" }
 
-5268.8 "Holy Blaze" Ability { id: "A151", source: "Repaired Lion" }
-5278.6 "Scratch" Ability { id: "A155", source: "Repaired Lion" }
-5291.5 "Radiant Wave" Ability { id: "A13F", source: "Repaired Lion" }
-5293.6 "Ancient Holy" Ability { id: "A142", source: "Repaired Lion" }
-5298.6 "Aetherial Exchange" Ability { id: "A140", source: "Repaired Lion" }
-5299.6 "--wind spheres x2--" #Ability { id: "A13C", source: "Repaired Lion" }
-5299.6 "--sand spheres x2--" #Ability { id: "A141", source: "Repaired Lion" }
-5304.5 "--holy spheres x4--" #Ability { id: ["A1B3", "A144"], source: "Repaired Lion" }
-5306.8 "--sync--" StartsUsing { id: "A148", source: "Repaired Lion" } forcejump "oc-eternal-watch-stone"
-5306.8 "--sync--" StartsUsing { id: "A146", source: "Repaired Lion" } forcejump "oc-eternal-watch-aero"
-5307.8 "Light Surge" #Ability { id: "A14E", source: "Holy Sphere" }
-5310.8 "Ancient Stone III/Ancient Aero III?" #Ability { id: ["A148", "A146"], source: "Repaired Lion" }
+5468.8 "Holy Blaze" Ability { id: "A151", source: "Repaired Lion" }
+5478.6 "Scratch" Ability { id: "A155", source: "Repaired Lion" }
+5491.5 "Radiant Wave" Ability { id: "A13F", source: "Repaired Lion" }
+5493.6 "Ancient Holy" Ability { id: "A142", source: "Repaired Lion" }
+5498.6 "Aetherial Exchange" Ability { id: "A140", source: "Repaired Lion" }
+5499.6 "--wind spheres x2--" #Ability { id: "A13C", source: "Repaired Lion" }
+5499.6 "--sand spheres x2--" #Ability { id: "A141", source: "Repaired Lion" }
+5504.5 "--holy spheres x4--" #Ability { id: ["A1B3", "A144"], source: "Repaired Lion" }
+5506.8 "--sync--" StartsUsing { id: "A148", source: "Repaired Lion" } jump 5606.8
+5506.8 "--sync--" StartsUsing { id: "A146", source: "Repaired Lion" } forcejump "oc-eternal-watch-aero"
+5507.8 "Light Surge" Ability { id: "A14E", source: "Holy Sphere" }
+5510.8 "Ancient Stone III/Ancient Aero III?" #Ability { id: ["A148", "A146"], source: "Repaired Lion" }
 
-# Pattern 2 - Stone First
-5406.8 label "oc-eternal-watch-stone"
-5407.8 "Light Surge" Ability { id: "A14E", source: "Holy Sphere" }
-5410.8 "Ancient Stone III" Ability { id: "A148", source: "Repaired Lion" } duration 1
-5414.4 "Sand Surge" Ability { id: "A150", source: "Holy Sphere" }
-5418.0 "Ancient Aero III" Ability { id: "A146", source: "Repaired Lion" } duration 1
-5421.7 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
-5422.4 "--sync--" StartsUsing { id: "A151", source: "Repaired Lion" } forcejump "oc-eternal-watch-p1-end"
-5426.4 "Holy Blaze" #Ability { id: "A151", source: "Repaired Lion" }
+# Pattern 3 - Stone First
+5606.8 label "oc-eternal-watch-stone"
+5607.8 "Light Surge" Ability { id: "A14E", source: "Holy Sphere" }
+5610.8 "Ancient Stone III" Ability { id: "A148", source: "Repaired Lion" } duration 1
+5614.4 "Sand Surge" Ability { id: "A150", source: "Holy Sphere" }
+5618.0 "Ancient Aero III" Ability { id: "A146", source: "Repaired Lion" } duration 1
+5621.7 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
+5622.4 "--sync--" StartsUsing { id: "A151", source: "Repaired Lion" } forcejump "oc-eternal-watch-p1-end"
+5626.4 "Holy Blaze" #Ability { id: "A151", source: "Repaired Lion" }
 
-# Pattern 2 - Aero First
-5505.9 label "oc-eternal-watch-aero"
-5507.1 "Light Surge" Ability { id: "A14E", source: "Holy Sphere" }
-5509.9 "Ancient Aero III" Ability { id: "A146", source: "Repaired Lion" } duration 1
-5513.5 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
-5517.1 "Ancient Stone III" Ability { id: "A148", source: "Repaired Lion" } duration 1
-5520.8 "Sand Surge" Ability { id: "A150", source: "Holy Sphere" }
+# Pattern 3 - Aero First
+5705.9 label "oc-eternal-watch-aero"
+5707.1 "Light Surge" Ability { id: "A14E", source: "Holy Sphere" }
+5709.9 "Ancient Aero III" Ability { id: "A146", source: "Repaired Lion" } duration 1
+5713.5 "Wind Surge" Ability { id: "A14F", source: "Holy Sphere" }
+5717.1 "Ancient Stone III" Ability { id: "A148", source: "Repaired Lion" } duration 1
+5720.8 "Sand Surge" Ability { id: "A150", source: "Holy Sphere" }
 
-5521.4 label "oc-eternal-watch-p1-end"
-5525.4 "Holy Blaze" Ability { id: "A151", source: "Repaired Lion" }
-5535.2 "Scratch" Ability { id: "A155", source: "Repaired Lion" }
+5721.4 label "oc-eternal-watch-p1-end"
+5725.4 "Holy Blaze" Ability { id: "A151", source: "Repaired Lion" }
+5735.2 "Scratch" Ability { id: "A155", source: "Repaired Lion" }
 
 # Loop
-5542.5 "--sync--" StartsUsing { id: "A13F", source: "Repaired Lion" } forcejump "oc-eternal-watch-loop"
-5547.5 "Radiant Wave" #Ability { id: "A13F", source: "Repaired Lion" }
-5552.6 "--wind spheres x4--" #Ability { id: "A13C", source: "Repaired Lion" }
-5553.6 "--sand spheres x4--" #Ability { id: "A141", source: "Repaired Lion" }
-5566.2 "Double Cast" #Ability { id: "A14B", source: "Repaired Lion" }
-5566.6 "Ancient Stone III" #Ability { id: "A14D", source: "Repaired Lion" }
-5566.6 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
+5742.5 "--sync--" StartsUsing { id: "A13F", source: "Repaired Lion" } forcejump "oc-eternal-watch-loop"
+5747.5 "Radiant Wave" #Ability { id: "A13F", source: "Repaired Lion" }
+5752.6 "--wind spheres x4--" #Ability { id: "A13C", source: "Repaired Lion" }
+5753.6 "--sand spheres x4--" #Ability { id: "A141", source: "Repaired Lion" }
+5766.2 "Double Cast" #Ability { id: "A14B", source: "Repaired Lion" }
+5766.6 "Ancient Stone III" #Ability { id: "A14D", source: "Repaired Lion" }
+5766.6 "Ancient Aero III" #Ability { id: "A14C", source: "Repaired Lion" }
 
 ### Flame Of Dusk
 6000.0 "--sync--" ActorControl { command: "80000014", data0: "32A" } window 100000,0
@@ -465,7 +489,7 @@ hideall "--sync--"
 7230.3 "--sync--" Ability { id: "A0A7", source: "Mythic Idol" }
 7231.0 "--Mythic Mirror x2--" Ability { id: "A0A9", source: "Mythic Mirror" }
 
-7232.6 "--sync--" StartsUsing { id: "A0AA", source: "Mythic Mirror" } forcejump "oc-from-times-bygone-burst1"
+7232.6 "--sync--" StartsUsing { id: "A0AA", source: "Mythic Mirror" } jump 7632.6
 7232.6 "--sync--" StartsUsing { id: "A0AD", source: "Mythic Mirror" } forcejump "oc-from-times-bygone-death1"
 7236.9 "--sync--" #Ability { id: "A0A7", source: "Mythic Idol" }
 7237.6 "--Mythic Mirror x2--" #Ability { id: "A0A9", source: "Mythic Mirror" }
@@ -487,7 +511,7 @@ hideall "--sync--"
 7356.3 "--sync--" Ability { id: "A0A7", source: "Mythic Idol" }
 7357.0 "--Mythic Mirror x2--" Ability { id: "A0A9", source: "Mythic Mirror" }
 
-7358.6 "--sync--" StartsUsing { id: "A0AA", source: "Mythic Mirror" } forcejump "oc-from-times-bygone-burst2"
+7358.6 "--sync--" StartsUsing { id: "A0AA", source: "Mythic Mirror" } forcejump 7558.6
 7358.6 "--sync--" StartsUsing { id: "A0AD", source: "Mythic Mirror" } forcejump "oc-from-times-bygone-death2"
 7360.0 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
 7360.0 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
@@ -543,7 +567,7 @@ hideall "--sync--"
 7643.5 "--sync--" Ability { id: "A0A7", source: "Mythic Idol" }
 7644.2 "--Mythic Mirror x2--" Ability { id: "A0A9", source: "Mythic Mirror" }
 
-7645.8 "--sync--" StartsUsing { id: "A0AA", source: "Mythic Mirror" } forcejump "oc-from-times-bygone-burst2"
+7645.8 "--sync--" StartsUsing { id: "A0AA", source: "Mythic Mirror" } jump 7558.6
 7645.8 "--sync--" StartsUsing { id: "A0AD", source: "Mythic Mirror" } forcejump "oc-from-times-bygone-death2"
 7647.2 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
 7647.2 "Death Ray/Big Burst" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
@@ -584,7 +608,7 @@ hideall "--sync--"
 
 # Check for Steelstrike, else assume Death Ray + Big Burst
 # This can be Steelstrike + Death Ray, Steelstrike + Big Burst, or Big Burst + Death Ray
-7708.9 "--sync--" StartsUsing { id: "A0AB", source: "Mythic Mirror" } forcejump "oc-from-times-bygone-steelstrike"
+7708.9 "--sync--" StartsUsing { id: "A0AB", source: "Mythic Mirror" } jump 7908.9
 7709.2 "--sync--" Ability { id: "A0A8", source: "Mythic Idol" } forcejump "oc-from-times-bygone-no-steelstrike"
 7716.9 "Death Ray + Big Burst?" #Ability { id: ["A0AD", "A0AA"], source: "Mythic Mirror" }
 7716.9 "Steelstrike + Death Ray?" #Ability { id: "A0AB", source: "Mythic Mirror" }
@@ -1013,38 +1037,44 @@ hideall "--sync--"
 15262.4 label "oc-extreme-prejudice-loop"
 15262.4 "Assail" Ability { id: "A1C9", source: "Command Urn" }
 15269.3 "Rockslide/Stone Swell?" #Ability { id: ["9A2F", "9A2E"], source: "Vassal Vessel" }
-15269.3 "--sync--" Ability { id: "9A2F", source: "Vassal Vessel" } forcejump "oc-extreme-prejudice-rockslide"
+15269.3 "--sync--" Ability { id: "9A2F", source: "Vassal Vessel" } jump 15269.3
 15269.3 "--sync--" Ability { id: "9A2E", source: "Vassal Vessel" } forcejump "oc-extreme-prejudice-stoneswell"
+15269.3 "Rockslide/Stone Swell?" #Ability { id: ["9A2F", "92AE"], source: "Vassal Vessel" }
+15274.3 "Stone Swell/Rockslide?" #Ability { id: ["9A2E", "9A2F"], source: "Vassal Vessel" }
+15279.4 "Rockslide/Stone Swell?" #Ability { id: ["9A2F", "92AE"], source: "Vassal Vessel" }
+15284.4 "Stone Swell/Rockslide?" #Ability { id: ["9A2E", "9A2F"], source: "Vassal Vessel" }
+15289.5 "Rockslide/Stone Swell?" #Ability { id: ["9A2F", "92AE"], source: "Vassal Vessel" }
+15294.5 "Stone Swell/Rockslide?" #Ability { id: ["9A2E", "9A2F"], source: "Vassal Vessel" }
 
 # Pattern 1 - Rockslide first
-15269.3 label "oc-extreme-prejudice-rockslide"
-15269.3 "Rockslide" #Ability { id: "9A2F", source: "Vassal Vessel" }
-15274.3 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
-15279.4 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
-15284.4 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
-15289.5 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
-15294.5 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
-15299.6 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
-15304.6 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
-15309.7 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
-15314.7 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
-15321.4 "Aetheric Burst" Ability { id: "A1D0", source: "Command Urn" }
-15337.5 "Assail" Ability { id: "A1C9", source: "Command Urn" } forcejump "oc-extreme-prejudice-loop"
-15344.4 "Rockslide/Stone Swell?" #Ability { id: ["9A2F", "9A2E"], source: "Vassal Vessel" }
+15369.3 label "oc-extreme-prejudice-rockslide"
+15369.3 "Rockslide" #Ability { id: "9A2F", source: "Vassal Vessel" }
+15374.3 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
+15379.4 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
+15384.4 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
+15389.5 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
+15394.5 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
+15399.6 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
+15404.6 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
+15409.7 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
+15414.7 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
+15421.4 "Aetheric Burst" Ability { id: "A1D0", source: "Command Urn" }
+15437.5 "Assail" Ability { id: "A1C9", source: "Command Urn" } forcejump "oc-extreme-prejudice-loop"
+15444.4 "Rockslide/Stone Swell?" #Ability { id: ["9A2F", "9A2E"], source: "Vassal Vessel" }
 
 # Pattern 2 - Stone Well first
-15494.6 label "oc-extreme-prejudice-stoneswell"
-15494.6 "Stone Swell" #Ability { id: "9A2E", source: "Vassal Vessel" }
-15499.6 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
-15504.7 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
-15509.7 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
-15514.8 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
-15519.8 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
-15524.9 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
-15529.9 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
-15535.0 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
-15540.0 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
-15546.7 "Aetheric Burst" Ability { id: "A1D0", source: "Command Urn" }
-15562.8 "Assail" Ability { id: "A1C9", source: "Command Urn" } forcejump "oc-extreme-prejudice-loop"
-15569.1 "Rockslide/Stone Swell?" #Ability { id: ["9A2F", "9A2E"], source: "Vassal Vessel" }
+15594.6 label "oc-extreme-prejudice-stoneswell"
+15594.6 "Stone Swell" #Ability { id: "9A2E", source: "Vassal Vessel" }
+15599.6 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
+15604.7 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
+15609.7 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
+15614.8 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
+15619.8 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
+15624.9 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
+15629.9 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
+15635.0 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
+15640.0 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
+15646.7 "Aetheric Burst" Ability { id: "A1D0", source: "Command Urn" }
+15662.8 "Assail" Ability { id: "A1C9", source: "Command Urn" } forcejump "oc-extreme-prejudice-loop"
+15669.1 "Rockslide/Stone Swell?" #Ability { id: ["9A2F", "9A2E"], source: "Vassal Vessel" }
 

--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
@@ -210,7 +210,7 @@ hideall "--sync--"
 4267.1 "Twopenny Inflation / Onepenny Inflation / Fourpenny Inflation" Ability { id: ["A915", "A231", "A230"], source: "Trade Tortoise" }
 4267.1 "Cost of Living" Ability { id: "A232", source: "Trade Tortoise" }
 
-# Loop Begins
+# Loop Block
 4275.4 label "oc-cursed-concern-loop"
 4279.4 "Recommended for You" Ability { id: "A409", source: "Trade Tortoise" }
 4307.5 "What're You Buying?" Ability { id: "A9BC", source: "Trade Tortoise" }
@@ -231,6 +231,7 @@ hideall "--sync--"
 4356.1 "Hoard Wealth 2" Ability { id: "A96C", source: "Trade Tortoise" }
 4368.8 "Earthquake" Ability { id: "A238", source: "Trade Tortoise" } duration 1
 
+# Loop
 4379.2 "--sync--" StartsUsing { id: "A409", source: "Trade Tortoise" } forcejump "oc-cursed-concern-loop"
 4383.2 "Recommended for You" #Ability { id: "A409", source: "Trade Tortoise" }
 4411.3 "What're You Buying?" #Ability { id: "A9BC", source: "Trade Tortoise" }

--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
@@ -171,7 +171,7 @@ hideall "--sync--"
 3344.5 "Threefold Marks" Ability { id: "A15E", source: "Death Claw" } forcejump "crosshatch-loop"
 
 ### Cursed Concern
-# -ii 368 A2EF A239 A2CC
+# -ii 368 A23F A239 A2CC
 # -p A22E:4131.8
 # -it "Trade Tortoise"
 # IGNORED ABILITIES
@@ -208,7 +208,7 @@ hideall "--sync--"
 4235.8 "What're You Buying?" Ability { id: "A22B", source: "Trade Tortoise" }
 4242.8 "Material World" Ability { id: "A22D", source: "Trade Tortoise" }
 4267.1 "Twopenny Inflation / Onepenny Inflation / Fourpenny Inflation" Ability { id: ["A915", "A231", "A230"], source: "Trade Tortoise" }
-4267.1 "Cost of Living" Ability { id: "A232", source: "Trade Tortoise" }
+4267.1 "Cost of Living" #Ability { id: "A232", source: "Trade Tortoise" }
 
 # Loop Block
 4275.4 label "oc-cursed-concern-loop"
@@ -226,7 +226,7 @@ hideall "--sync--"
 4336.4 "Waterspout 8" #Ability { id: "A237", source: "Trade Tortoise" }
 4337.3 "Waterspout (middle)" #Ability { id: "A237", source: "Trade Tortoise" }
 4351.1 "Twopenny Inflation / Onepenny Inflation / Fourpenny Inflation" Ability { id: ["A915", "A231", "A230"], source: "Trade Tortoise" }
-4351.1 "Cost of Living" Ability { id: "A232", source: "Trade Tortoise" }
+4351.1 "Cost of Living" #Ability { id: "A232", source: "Trade Tortoise" }
 4353.1 "Hoard Wealth 1" Ability { id: "A96C", source: "Trade Tortoise" }
 4356.1 "Hoard Wealth 2" Ability { id: "A96C", source: "Trade Tortoise" }
 4368.8 "Earthquake" Ability { id: "A238", source: "Trade Tortoise" } duration 1

--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
@@ -245,7 +245,7 @@ hideall "--sync--"
 12402.6 "Choco Maelfeather" Ability { id: "A0CC", source: "Black Chocobo" }
 12414.8 "Choco Maelfeather" #Ability { id: "A0CC", source: "Black Chocobo" } forcejump "black-regiment-malefeather-loop"
 12427.0 "Choco Maelfeather" #Ability { id: "A0CC", source: "Black Chocobo" }
-12439.2 "Choco Maelfeather" #Ability { id: "A0CC", source: "Black Chocobo" } 
+12439.2 "Choco Maelfeather" #Ability { id: "A0CC", source: "Black Chocobo" }
 
 # Boss + Windstorm and Cyclone Tutorial
 12544.0 "--sync--" AddedCombatant { name: "Black Star" } window 445,2

--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
@@ -515,7 +515,91 @@ hideall "--sync--"
 14442 "Made Magic" Ability { id: "A71[01]", source: "Draconic Double" }
 14443.9 "--sync--" StartsUsing { id: "A31C", source: "Crystal Dragon" } forcejump "crystallized-chaos-loop"
 
-### With Extreme Predjudice
+### With Extreme Prejudice
+# -ii 93BD A1D1 A86C
+# -p A1C8:15120.0
+# -it "Command Urn" "Vassal Vessel"
+# IGNORED ABILITIES
+# 93BD Attack
+# A1D1 Aetheric Burst (Secondary cast)
+# A86C --sync--
+#
+# ALL ENCOUNTER ABILITIES
+# 9A2E Stone Swell
+# 9A2F Rockslide
+# A1C8 Summon
+# A1C9 Assail
+# A1CC Stone Swell
+# A1CD Rockslide
+# A1CE Destruct
+# A1D0 Aetheric Burst
+#
 15000.0 "--sync--" ActorControl { command: "80000014", data0: "339" } window 100000,0
 15100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
+15117.0 "--sync--" StartsUsing { id: "A1C8", source: "Command Urn" } window 20,5
+15120.0 "Summon" Ability { id: "A1C8", source: "Command Urn" }
+# Stone Swell Tutorial
+15126.1 "Assail" Ability { id: "A1C9", source: "Command Urn" }
+15133.0 "Stone Swell" Ability { id: "A1CC", source: "Vassal Vessel" }
+15141.1 "Stone Swell" Ability { id: "A1CC", source: "Vassal Vessel" }
+15149.2 "Stone Swell" Ability { id: "A1CC", source: "Vassal Vessel" }
+# Rockslide Tutorial
+15149.2 "Assail" Ability { id: "A1C9", source: "Command Urn" }
+15156.1 "Rockslide" Ability { id: "A1CD", source: "Vassal Vessel" }
+15164.2 "Rockslide" Ability { id: "A1CD", source: "Vassal Vessel" }
+15172.3 "Rockslide" Ability { id: "A1CD", source: "Vassal Vessel" }
+15176.3 "Aetheric Burst" Ability { id: "A1D0", source: "Command Urn" }
+15192.5 "Summon" Ability { id: "A1C8", source: "Command Urn" }
+15197.7 "Assail" Ability { id: "A1C9", source: "Command Urn" }
+15204.5 "Stone Swell" #Ability { id: "A1CC", source: "Vassal Vessel" }
+15206.1 "Stone Swell" #Ability { id: "A1CC", source: "Vassal Vessel" }
+15207.5 "Stone Swell" #Ability { id: "A1CC", source: "Vassal Vessel" }
+15209.1 "Stone Swell" #Ability { id: "A1CC", source: "Vassal Vessel" }
+15210.7 "Stone Swell" #Ability { id: "A1CC", source: "Vassal Vessel" }
+15212.3 "Stone Swell" #Ability { id: "A1CC", source: "Vassal Vessel" }
+
+# Adds
+15215.2 "Destruct" Ability { id: "A1CE", source: "Command Urn" }
+15215.2 "--adds-targetable--"
+# TODO: Add enrage timings (there are 2 sets?)
+15257.3 "Summon" Ability { id: "A1C8", source: "Command Urn" }
+
+# Loop Begins
+15262.4 label "oc-extreme-prejudice-loop"
+15262.4 "Assail" Ability { id: "A1C9", source: "Command Urn" }
+15269.3 "Rockslide/Stone Swell?" #Ability { id: ["9A2F", "9A2E"], source: "Vassal Vessel" }
+15269.3 "--sync--" Ability { id: "9A2F", source: "Vassal Vessel" } forcejump "oc-extreme-prejudice-rockslide"
+15269.3 "--sync--" Ability { id: "9A2E", source: "Vassal Vessel" } forcejump "oc-extreme-prejudice-stoneswell"
+
+# Pattern 1 - Rockslide first
+15269.3 label "oc-extreme-prejudice-rockslide"
+15269.3 "Rockslide" #Ability { id: "9A2F", source: "Vassal Vessel" }
+15274.3 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
+15279.4 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
+15284.4 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
+15289.5 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
+15294.5 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
+15299.6 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
+15304.6 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
+15309.7 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
+15314.7 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
+15321.4 "Aetheric Burst" Ability { id: "A1D0", source: "Command Urn" }
+15337.5 "Assail" Ability { id: "A1C9", source: "Command Urn" } forcejump "oc-extreme-prejudice-loop"
+15344.4 "Rockslide/Stone Swell?" #Ability { id: ["9A2F", "9A2E"], source: "Vassal Vessel" }
+
+# Pattern 2 - Stone Well first
+15494.6 label "oc-extreme-prejudice-stoneswell"
+15494.6 "Stone Swell" #Ability { id: "9A2E", source: "Vassal Vessel" }
+15499.6 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
+15504.7 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
+15509.7 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
+15514.8 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
+15519.8 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
+15524.9 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
+15529.9 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
+15535.0 "Stone Swell" Ability { id: "9A2E", source: "Vassal Vessel" }
+15540.0 "Rockslide" Ability { id: "9A2F", source: "Vassal Vessel" }
+15546.7 "Aetheric Burst" Ability { id: "A1D0", source: "Command Urn" }
+15562.8 "Assail" Ability { id: "A1C9", source: "Command Urn" } forcejump "oc-extreme-prejudice-loop"
+15569.1 "Rockslide/Stone Swell?" #Ability { id: ["9A2F", "9A2E"], source: "Vassal Vessel" }
 

--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
@@ -477,7 +477,6 @@ hideall "--sync--"
 
 # Pattern 1 - Steelstrike + Death Ray first
 7345.4 label "oc-from-times-bygone-death1"
-7343.8 "--Mythic Mirror x2--" Ability { id: "A0A9", source: "Mythic Mirror" }
 7349.7 "--sync--" Ability { id: "A0A7", source: "Mythic Idol" }
 7350.4 "--Mythic Mirror x2--" Ability { id: "A0A9", source: "Mythic Mirror" }
 7353.4 "Steelstrike" Ability { id: "A0AB", source: "Mythic Mirror" }
@@ -534,6 +533,7 @@ hideall "--sync--"
 
 # Pattern 1 - Steelstrike + Big Burst first
 7632.6 label "oc-from-times-bygone-burst1"
+7636.9 "--sync--" Ability { id: "A0A7", source: "Mythic Idol" }
 7637.6 "--Mythic Mirror x2--" Ability { id: "A0A9", source: "Mythic Mirror" }
 7640.6 "Steelstrike" Ability { id: "A0AB", source: "Mythic Mirror" }
 7640.6 "Big Burst" #Ability { id: "A0AA", source: "Mythic Mirror" }

--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
@@ -1037,7 +1037,7 @@ hideall "--sync--"
 15262.4 label "oc-extreme-prejudice-loop"
 15262.4 "Assail" Ability { id: "A1C9", source: "Command Urn" }
 15269.3 "Rockslide/Stone Swell?" #Ability { id: ["9A2F", "9A2E"], source: "Vassal Vessel" }
-15269.3 "--sync--" Ability { id: "9A2F", source: "Vassal Vessel" } jump 15269.3
+15269.3 "--sync--" Ability { id: "9A2F", source: "Vassal Vessel" } jump 15369.3
 15269.3 "--sync--" Ability { id: "9A2E", source: "Vassal Vessel" } forcejump "oc-extreme-prejudice-stoneswell"
 15269.3 "Rockslide/Stone Swell?" #Ability { id: ["9A2F", "92AE"], source: "Vassal Vessel" }
 15274.3 "Stone Swell/Rockslide?" #Ability { id: ["9A2E", "9A2F"], source: "Vassal Vessel" }


### PR DESCRIPTION
Adds The Black Regiment:
Unsure if there is a loop with the Choco Beak tutorial (would probably need to get in a dying/pre-made instance to confirm that one).

I don't know that it is feasible to get accurate '--targetable--' lines given progression is based on killing all the Black Chocobos. AddedCombatant lines are used to differentiate how far the encounter has progressed.

Adds With Extreme Prejudice
Adds Cursed Concern
Adds Eternal Watch
Adds From Times Bygone
Adds Noise Complaint