### PR TITLE
plugin: update signatures and memory for KO 7.3

### DIFF
--- a/plugin/CactbotEventSource/FFXIVProcessKo.cs
+++ b/plugin/CactbotEventSource/FFXIVProcessKo.cs
@@ -8,7 +8,7 @@ using RainbowMage.OverlayPlugin;
 
 namespace Cactbot {
   public class FFXIVProcessKo : FFXIVProcess {
-    // Last updated for FFXIV 7.2
+    // Last updated for FFXIV 7.3
     // Per aers/FFXIVClientStructs, what we call EntityMemory is actually:
     // Client::Game::Character::Character (0x22E0)
     //   Client::Game::Object::GameObject (0x190)
@@ -25,28 +25,28 @@ namespace Cactbot {
       [FieldOffset(0x30)]
       public fixed byte Name[nameBytes];
 
-      [FieldOffset(0x74)]
+      [FieldOffset(0x78)]
       public uint id;
 
-      [FieldOffset(0x8C)]
+      [FieldOffset(0x90)]
       public EntityType type;
 
-      [FieldOffset(0x92)]
+      [FieldOffset(0x96)]
       public ushort distance;
 
-      [FieldOffset(0xA0)]
+      [FieldOffset(0xB0)]
       public Single pos_x;
 
-      [FieldOffset(0xA4)]
+      [FieldOffset(0xB4)]
       public Single pos_z;
 
-      [FieldOffset(0xA8)]
+      [FieldOffset(0xB8)]
       public Single pos_y;
 
-      [FieldOffset(0xB0)]
+      [FieldOffset(0xC0)]
       public Single rotation;
 
-      [FieldOffset(0x190)]
+      [FieldOffset(0x1A0)]
       public CharacterDetails charDetails;
     }
 
@@ -106,7 +106,8 @@ namespace Cactbot {
     // In combat boolean.
     // This address is written to by "mov [rax+rcx],bl" and has three readers.
     // This reader is "cmp byte ptr [ffxiv_dx11.exe+????????],00 { (0),0 }"
-    private static String kInCombatSignature = "803D??????????74??488B03488BCBFF50";
+    // Updated in 7.3, signature was no longer unique, include the preceeding "jz LAB_?????????"
+    private static String kInCombatSignature = "74??803D??????????74??488B03488BCBFF50";
     private static int kInCombatSignatureOffset = -15;
     private static bool kInCombatSignatureRIP = true;
     // Because this line is a cmp byte line, the signature is not at the end of the line.


### PR DESCRIPTION
just copy of cn 7.3

```
[2025-10-28 오후 8:25:08] Info: AssemblyResolver: Loaded: HtmlRenderer, Version=0.19.70.0, Culture=neutral, PublicKeyToken=null
[2025-10-28 오후 8:25:08] Info: AssemblyResolver: Loaded: CefSharp, Version=95.7.141.0, Culture=neutral, PublicKeyToken=40c4b6fc221f4138
[2025-10-28 오후 8:25:08] Info: InitPlugin: PluginDirectory = C:\Advanced Combat Tracker\Plugins\OverlayPlugin
[2025-10-28 오후 8:25:08] Info: AssemblyResolver: Loaded: CefSharp.OffScreen, Version=95.7.141.0, Culture=neutral, PublicKeyToken=40c4b6fc221f4138
[2025-10-28 오후 8:25:08] Info: AssemblyResolver: Loaded: CefSharp.Core, Version=95.7.141.0, Culture=neutral, PublicKeyToken=40c4b6fc221f4138
[2025-10-28 오후 8:25:08] Info: AssemblyResolver: Loaded: CefSharp.Core.Runtime, Version=95.7.141.0, Culture=neutral, PublicKeyToken=40c4b6fc221f4138
[2025-10-28 오후 8:25:08] Info: AssemblyResolver: Loaded: System.Resources.Extensions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
[2025-10-28 오후 8:25:08] Info: AssemblyResolver: Loaded: System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
[2025-10-28 오후 8:25:08] Info: AssemblyResolver: Loaded: System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
[2025-10-28 오후 8:25:08] Info: AssemblyResolver: Loaded: System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
[2025-10-28 오후 8:25:08] Info: AssemblyResolver: Loaded: OverlayPlugin.Core.resources, Version=0.19.70.0, Culture=ko-KR, PublicKeyToken=null
[2025-10-28 오후 8:25:09] Info: AssemblyResolver: Loaded: Fleck, Version=1.2.0.0, Culture=neutral, PublicKeyToken=null
[2025-10-28 오후 8:25:09] Info: InitPlugin: Initialised.
[2025-10-28 오후 8:25:12] Error: Could not detect game version from FFXIV_ACT_Plugin, defaulting to latest version for region Global
[2025-10-28 오후 8:25:12] Error: Detected most recent version for Global = 2025.10.13.0000.0000
[2025-10-28 오후 8:25:12] Error: Could not detect game version from FFXIV_ACT_Plugin, defaulting to latest version for region Chinese
[2025-10-28 오후 8:25:13] Info: cactbot: 0.35.3.0 C:\Advanced Combat Tracker\Plugins\cactbot\CactbotOverlay.dll (dir: C:\Advanced Combat Tracker\Plugins\cactbot)
[2025-10-28 오후 8:25:13] Info: OverlayPlugin: 0.19.70.0 C:\Advanced Combat Tracker\Plugins\OverlayPlugin\OverlayPlugin.dll
[2025-10-28 오후 8:25:13] Info: FFXIV Plugin: 2.4.5.0 C:\Advanced Combat Tracker\Plugins\FFXIV_ACT_Plugin_KR\FFXIV_ACT_Plugin.dll
[2025-10-28 오후 8:25:13] Info: ACT: 3.8.4.287 C:\Advanced Combat Tracker\Advanced Combat Tracker.exe
[2025-10-28 오후 8:25:13] Info: Parsing Plugin Language: ko
[2025-10-28 오후 8:25:13] Info: System Locale: ko-KR
[2025-10-28 오후 8:25:13] Info: cactbot user directory: C:\Advanced Combat Tracker\FileResources\user
[2025-10-28 오후 8:25:13] Info: Version: ko
[2025-10-28 오후 8:25:13] Error: In combat signature found 5 matches
[2025-10-28 오후 8:25:15] Info: Found in combat memory via InCombatMemory70.
[2025-10-28 오후 8:25:15] Info: LoadAddons: CactbotOverlay.dll: Initialized Cactbot.PluginLoader
[2025-10-28 오후 8:25:15] Info: Found combatant memory via CombatantMemory72.
[2025-10-28 오후 8:25:16] Info: Found content finder settings memory via ContentFinderSettingsMemory71.
[2025-10-28 오후 8:25:16] Info: [Cactbot] Oopsyraidsy: BrowserConsole: local user file: C:\Advanced Combat Tracker\FileResources\user\oopsyraidsy.css (Source: https://overlayplugin.github.io/cactbot/ui/oopsyraidsy/oopsy_live.bundle.js, Line: 5053)
[2025-10-28 오후 8:25:16] Info: [Cactbot] Oopsyraidsy: BrowserConsole: RequestSync: 1761650716669 (Source: https://overlayplugin.github.io/cactbot/ui/oopsyraidsy/oopsy_live.bundle.js, Line: 21154)
[2025-10-28 오후 8:25:16] Info: Found job Gauge memory via JobGaugeMemory655.
[2025-10-28 오후 8:25:17] Info: Found target memory via TargetMemory70.
[2025-10-28 오후 8:25:17] Info: Skyline Overlay: BrowserConsole: [ffxiv-overlay-api] initializing api in callback mode... (Source: https://skyline.dsrkafuu.net/assets/index-B3Tvrxpw.js, Line: 57)
[2025-10-28 오후 8:25:17] Info: Skyline Overlay: BrowserConsole: [ffxiv-overlay-api] callback mode api ready (Source: https://skyline.dsrkafuu.net/assets/index-B3Tvrxpw.js, Line: 57)
[2025-10-28 오후 8:25:17] Info: Skyline Overlay: BrowserConsole: [ffxiv-overlay-api] listener for `CombatData` added (Source: https://skyline.dsrkafuu.net/assets/index-B3Tvrxpw.js, Line: 57)
[2025-10-28 오후 8:25:17] Info: Skyline Overlay: BrowserConsole: [ffxiv-overlay-api] 1 types of event transmission started (Source: https://skyline.dsrkafuu.net/assets/index-B3Tvrxpw.js, Line: 57)
[2025-10-28 오후 8:25:17] Info: Found enmity memory via EnmityMemory60.
[2025-10-28 오후 8:25:17] Info: Skyline Overlay: BrowserConsole: [skyline-overlay] service worker registered [object ServiceWorkerRegistration] (Source: https://skyline.dsrkafuu.net/assets/index-B3Tvrxpw.js, Line: 57)
[2025-10-28 오후 8:25:17] Info: Found aggro memory via AggroMemory60.
[2025-10-28 오후 8:25:17] Info: [Cactbot] Raidboss: BrowserConsole: local user file: C:\Advanced Combat Tracker\FileResources\user\raidboss.css (Source: https://overlayplugin.github.io/cactbot/ui/raidboss/raidboss.bundle.js, Line: 5066)
[2025-10-28 오후 8:25:17] Error: Failed to find enmity HUD memory via EnmityHudMemory70: enmityHudAddress, sigscan failed, count: 0.
[2025-10-28 오후 8:25:17] Info: Found enmity HUD memory via EnmityHudMemory73.
[2025-10-28 오후 8:25:17] Info: AssemblyResolver: Loaded: YamlDotNet, Version=12.0.0.0, Culture=neutral, PublicKeyToken=ec19458f3c15af5e
[2025-10-28 오후 8:25:18] Info: Found atkStage memory via AtkStageMemory62.
```

Should I wait for the Korean Plugin 7.3 update? Or please help me with what actions I can take.
