### PR TITLE
raidboss: add simple triggers for some FATE monsters

### DIFF
--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.ts
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.ts
@@ -615,6 +615,7 @@ const triggerSet: TriggerSet<Data> = {
     },
   ],
   triggers: [
+    // ---------------------- Setup --------------------------
     {
       id: 'Occult Crescent Critical Encounter',
       type: 'ActorControl',
@@ -702,7 +703,7 @@ const triggerSet: TriggerSet<Data> = {
         data.magitaurLancelightCount = 0;
       },
     },
-    // CE Triggers
+    // ---------------------- CEs --------------------------
     {
       id: 'Occult Crescent Cloister Demon Tidal Breath',
       type: 'StartsUsing',
@@ -812,7 +813,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { source: 'Nymian Petalodus', id: 'A88D', capture: false },
       response: Responses.awayFromFront(),
     },
-    // FATE triggers
+    // ------------------- FATEs -----------------------
     {
       id: 'Occult Crescent Giant Bird Gale Cannon',
       type: 'StartsUsing',
@@ -1127,8 +1128,7 @@ const triggerSet: TriggerSet<Data> = {
       suppressSeconds: 1,
       response: Responses.aoe(),
     },
-
-    // Forked Tower Triggers
+    // ------------------- Forked Tower: Blood -----------------------
     {
       id: 'Occult Crescent Demon Tablet Demonic Dark II',
       type: 'StartsUsing',


### PR DESCRIPTION
This covers the majority of the fates, and I've tested them live in
game. Things appear to work pretty well. Testing is tricky unless you
find a low population instance, as most fates die well before anything
important happens. However, the triggers are quite valuable when
soloing.

There are a few mechanics I haven't figured out good solutions for yet,
including:

1) a trigger for the baited lines from the adds during Dehumidifier.
   This could be helpful while soloing to remind players to bait since
   you don't have much time to dodge after the lines appear if you're
   alone.

2) better logic for handling the many look away / look towards from the
   guardian eye.

I was able to decode how the memory mechanic from sisyphus works, and it
should be accurate even if you arrive relatively late, as all the info
you need is from recent casts.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
