### PR TITLE
config: fix missing zoneId when user setting zoneLabel.

### DIFF
--- a/ui/config/config.ts
+++ b/ui/config/config.ts
@@ -1079,6 +1079,9 @@ export class CactbotConfigurator {
       if (triggerSet.zoneLabel) {
         zoneLabel = triggerSet.zoneLabel;
         title = this.translate(zoneLabel);
+        if (typeof triggerSet.zoneId === 'number') {
+          zoneId = triggerSet.zoneId;
+        }
       } else if (typeof triggerSet.zoneId === 'number') {
         zoneId = triggerSet.zoneId;
         // Use the translatable zone info name, if possible.


### PR DESCRIPTION
This issue previously prevented the Config page from correctly showing the “Edit Timeline” interface when zoneLabel was defined in a user JS file, due to a missing zoneId. This change fixes that.

before:
<img width="996" height="290" alt="image" src="https://github.com/user-attachments/assets/73e1678e-7ae3-4750-a4b3-d79f58cf64d7" />


after:
<img width="1001" height="470" alt="image" src="https://github.com/user-attachments/assets/a9acf8b9-8d5e-4ae5-ba26-1bb5471490e3" />
