### PR TITLE
raidboss: add support for timeline blocks

### DIFF
--- a/test/helper/test_timeline.ts
+++ b/test/helper/test_timeline.ts
@@ -126,6 +126,12 @@ class TimelineParserLint extends TimelineParser {
       return;
     }
 
+    // Blocks track sync times separately
+    if (first === 'blockbegin' || first === `blockend`) {
+      this.lastSyncTime = 0;
+      return;
+    }
+
     // At this point, if `first` is not a time, it's not a valid timeline entry
     const time = parseFloat(first);
     if (isNaN(time)) {


### PR DESCRIPTION
Add new `blockbegin` and `blockend` keywords for the timeline file.
These implement basic "block" support by allowing a timeline to identify
collections of entries that belong together.

To start a block, the timeline should use `blockbegin "name"` where
"name" is a unique block name. This also creates an implicit label for
the start of the block.

To end a block the `blockend` keyword on its own line should be used.

To avoid complexity with making the actual timeline logic handle blocks,
implement support via a clever hack in the timeline parser to offset all
entries.

Keep track of the current block, and the largest time offset found so
far. When a `blockbegin` keyword is found, use the largest known offset
to generate a new "offset". To ensure a decent gap, add 500 seconds to
that time then round up to the next multiple of 1000.

For all entries until the next `blockend`, add this offset to their
encoded time. This essentially automatically offsets blocks in the
timeline instead of requiring manual offset configuration. Entries
outside of blocks do not get modified.

For jumps by label, add "block scoping" where a label is prefixed by the
blockname separated by a ':'. Currently no timelines actually use ':' in
their label name so this should be safe.

A jump with a ':' in its name will always jump to the block label
without implicit handling. Labels without ':' will get implicit handling
in the following priority, with the first existing option being chosen

1) A label within the same block
2) A label outside any block
3) The start of a block by name

This means that timeline files can re-use labels across blocks, and that
blocks get implicit labels that do not override explicit ones.

This solution is very much a hack, but it avoids a massive refactor that
would be required for explicit block handling within many parts of the
codebase.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
