### PR TITLE
util: Catch bundle compile exceptions in test_timeline

### DIFF
--- a/util/logtools/test_timeline.ts
+++ b/util/logtools/test_timeline.ts
@@ -513,4 +513,4 @@ class TestTimelineUI extends TimelineUI {
   }
 }
 
-void main();
+await main().catch((e) => console.log(e));


### PR DESCRIPTION
Due to the way we load timelines (by loading the raidboss data bundle), if there's a compile-time exception in a triggers file when running `test_timeline`, it will fail with this unbelievably unhelpful exception:

```
(node:9429) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:
--import 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("ts-node/esm", pathToFileURL("./"));'
(Use `node --trace-warnings ...` to show where the warning was created)
node:internal/process/promises:289
            triggerUncaughtException(err, true /* fromPromise */);
            ^

[UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "[object Object]".] {
  code: 'ERR_UNHANDLED_REJECTION'
}
```

Add an await/catch to the call to `main` and log any exceptions, so we actually get back useful information such as:

```
$ node --loader=ts-node/esm ./util/logtools/test_timeline.ts -f .../Network_27408_20251216.log -lf 5 -t r9n
(node:10068) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:
--import 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("ts-node/esm", pathToFileURL("./"));'
(Use `node --trace-warnings ...` to show where the warning was created)
ui/raidboss/data/07-dt/raid/r9n.ts(366,36): error TS18048: 'flail1Match' is possibly 'undefined'.
ui/raidboss/data/07-dt/raid/r9n.ts(367,36): error TS18048: 'flail1Match' is possibly 'undefined'.
ui/raidboss/data/07-dt/raid/r9n.ts(368,36): error TS18048: 'flail2Match' is possibly 'undefined'.
ui/raidboss/data/07-dt/raid/r9n.ts(369,36): error TS18048: 'flail2Match' is possibly 'undefined'.
```

Probably some of these other utils could also use this adjustment, but it's 1:30am and I'm out of brainpower to dig through the logic to see if they also load the bundle.

<img width="232" height="399" alt="image" src="https://github.com/user-attachments/assets/62bb3d9d-977a-4363-b908-518555e70b30" />
