### PR TITLE
resources: fix example tankBuster() response code

### DIFF
--- a/resources/responses.ts
+++ b/resources/responses.ts
@@ -3,7 +3,7 @@
 //   id: 'Some tankbuster',
 //   regex: Regexes.startsUsing({source: 'Ye Olde Bosse', id: '666'}),
 //   condition: Conditions.caresAboutMagical(data),
-//   response: Responses.tankbuster(),
+//   response: Responses.tankBuster(),
 // },
 //
 // Note: Breaking out the condition like this lets people override it if they


### PR DESCRIPTION
The example code for the tank buster response does not match the name
actually used in the file. Fix the capitalization to match the expected
camelCase.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
