### PR TITLE
raidboss: fixes and improvements for OC triggers

### DIFF
--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.ts
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.ts
@@ -1083,7 +1083,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Occult Crescent Lifereaper Soul Sweep',
       type: 'StartsUsing',
-      netRegex: { source: 'Lifereaper', id: 'A4C1', capture: false },
+      netRegex: { source: 'Lifereaper', id: ['A4C1', 'A4C5'], capture: false },
       response: Responses.getBehind(),
     },
     {
@@ -1102,7 +1102,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Occult Crescent Lifereaper Sweeping Charge',
       type: 'StartsUsing',
-      netRegex: { source: 'Lifereaper', id: 'A4C[25]', capture: false },
+      netRegex: { source: 'Lifereaper', id: 'A4C2', capture: false },
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {


### PR DESCRIPTION
An accumulation of fixes I've been testing for the Occult Crescent: South
Horn. First, the callouts for Hinkypunk are improved to reflect whether the
attack is coming from a clone or from the boss. Second, an erroneous "Follow
Dash" trigger is fixed to only report Get Behind.

- **raidboss: improve callouts for Hinkypunk**
- **raidboss: fix incorrect "Follow Dash => Get Behind" trigger**
