### PR TITLE
raidboss: Add missing Bio II AoE trigger to mistwake

### DIFF
--- a/ui/raidboss/data/07-dt/dungeon/mistwake.ts
+++ b/ui/raidboss/data/07-dt/dungeon/mistwake.ts
@@ -98,6 +98,13 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.aoe(),
     },
     {
+      id: 'Mistwake Treno Amdusias Bio II',
+      type: 'StartsUsing',
+      // Paired with B121, which is the actual damage hit, but no cast bar
+      netRegex: { source: 'Amdusias', id: 'B120', capture: false },
+      response: Responses.aoe(),
+    },
+    {
       id: 'Mistwake Treno Amdusias Shockbolt',
       type: 'StartsUsing',
       // Paired with B12B, which happens first, but does not target


### PR DESCRIPTION
Noticed while spamming expert roulette to grind tomes...