### PR TITLE
raidboss: fix incorrect "Follow Dash => Get Behind" trigger

### DIFF
--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.ts
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.ts
@@ -1051,7 +1051,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Occult Crescent Lifereaper Soul Sweep',
       type: 'StartsUsing',
-      netRegex: { source: 'Lifereaper', id: 'A4C1', capture: false },
+      netRegex: { source: 'Lifereaper', id: ['A4C1', 'A4C5'], capture: false },
       response: Responses.getBehind(),
     },
     {
@@ -1070,7 +1070,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Occult Crescent Lifereaper Sweeping Charge',
       type: 'StartsUsing',
-      netRegex: { source: 'Lifereaper', id: 'A4C[25]', capture: false },
+      netRegex: { source: 'Lifereaper', id: 'A4C2', capture: false },
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {


### PR DESCRIPTION
The trigger for sweeping charge was incorrectly placed on both the start
attack with the dash, *and* the followup sweep, causing cactbot to
trigger twice with the same text. Fix this by moving the later A4C5
trigger to just be the getBehind callout for Soul Sweep. This is the
same as how Menacing Charge is handled.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
