### PR TITLE
resources: add Korean font stack

### DIFF
--- a/resources/defaults.css
+++ b/resources/defaults.css
@@ -45,6 +45,17 @@ body {
     sans-serif;
 }
 
+:lang(ko) .text {
+  font-family:
+    "나눔바른고딕",
+    "Noto Sans KR",
+    "Noto Sans CJK KR",
+    "맑은 고딕",
+    Arial,
+    Helvetica,
+    sans-serif;
+}
+
 .hide {
   display: none !important;
 }


### PR DESCRIPTION
I came across this by chance.

- "나눔바른고딕": Popular Korean font, need install
- "Noto Sans KR"
<img width="774" height="146" alt="image" src="https://github.com/user-attachments/assets/8020a70d-a349-4e29-9c54-2d88cc00e598" />

The latest Windows 11 includes this font series.
https://support.microsoft.com/en-us/topic/march-25-2025-kb5053643-os-build-19045-5679-preview-3fd3cc5d-2757-4092-ac0e-bb0e9c295861#id0eddj=highlights
- "Noto Sans CJK KR": Alias when Noto fonts are installed via another route
- "맑은 고딕": Default Korean fonts starting from Windows Vista

