### PR TITLE
lint: revert comments moved

### DIFF
--- a/ui/eureka/zone_bozja_southern.ts
+++ b/ui/eureka/zone_bozja_southern.ts
@@ -402,8 +402,7 @@ export const zoneInfoBozjaSouthern: EurekaZoneInfo = {
         tc: '梅內紐斯·薩斯·拉那圖斯',
       },
       shortName: {
-        en: 'Menenius',
-        // FIX-ME
+        en: 'Menenius', // FIX-ME
         de: 'Menenius',
         fr: 'Menenius',
         ja: 'メネニウス',
@@ -425,8 +424,7 @@ export const zoneInfoBozjaSouthern: EurekaZoneInfo = {
         tc: '米希亞·博特雅失',
       },
       shortName: {
-        en: 'Misija',
-        // FIX-ME
+        en: 'Misija', // FIX-ME
         de: 'Misija',
         fr: 'Misija',
         ja: 'ミーシィヤ',
@@ -470,8 +468,7 @@ export const zoneInfoBozjaSouthern: EurekaZoneInfo = {
         tc: '莉莉婭·希雅薩里斯',
       },
       shortName: {
-        en: 'Lilja Sjasaris',
-        // FIX-ME
+        en: 'Lilja Sjasaris', // FIX-ME
         de: 'Lilja',
         fr: 'Lilja',
         ja: 'リリヤ',
@@ -493,8 +490,7 @@ export const zoneInfoBozjaSouthern: EurekaZoneInfo = {
         tc: '布瓦基·恩澤·潘卡',
       },
       shortName: {
-        en: 'Bwagi Ennze Panca',
-        // FIX-ME
+        en: 'Bwagi Ennze Panca', // FIX-ME
         de: 'Bwagi',
         fr: 'Bwagi',
         ja: 'ブワジ',
@@ -516,8 +512,7 @@ export const zoneInfoBozjaSouthern: EurekaZoneInfo = {
         tc: '羅斯提克·琉芭失',
       },
       shortName: {
-        en: 'Rostik Liubasch',
-        // FIX-ME
+        en: 'Rostik Liubasch', // FIX-ME
         de: 'Rostik',
         fr: 'Rostik',
         ja: 'ロスティック',
@@ -539,8 +534,7 @@ export const zoneInfoBozjaSouthern: EurekaZoneInfo = {
         tc: '神庭水琴',
       },
       shortName: {
-        en: 'Mikoto Jinba',
-        // FIX-ME
+        en: 'Mikoto Jinba', // FIX-ME
         de: 'Mikoto',
         fr: 'Mikoto',
         ja: 'ミコト',
@@ -562,8 +556,7 @@ export const zoneInfoBozjaSouthern: EurekaZoneInfo = {
         tc: '米希亞·博特雅失',
       },
       shortName: {
-        en: 'Misija Votyasch',
-        // FIX-ME
+        en: 'Misija Votyasch', // FIX-ME
         de: 'Misija',
         fr: 'Misija',
         ja: 'ミーシィヤ',
@@ -607,8 +600,7 @@ export const zoneInfoBozjaSouthern: EurekaZoneInfo = {
         tc: '求道之三位一體',
       },
       shortName: {
-        en: 'Seeker',
-        // FIX-ME
+        en: 'Seeker', // FIX-ME
         de: 'Sucher',
         fr: 'Soudée',
         ja: 'シーカー',
@@ -630,8 +622,7 @@ export const zoneInfoBozjaSouthern: EurekaZoneInfo = {
         tc: '女王護衛',
       },
       shortName: {
-        en: 'Guard',
-        // FIX-ME
+        en: 'Guard', // FIX-ME
         de: 'Königinnenwache',
         fr: 'Garde',
         ja: 'ガード',
@@ -653,8 +644,7 @@ export const zoneInfoBozjaSouthern: EurekaZoneInfo = {
         tc: '誓約之三位一體',
       },
       shortName: {
-        en: 'Trinity Avowed',
-        // FIX-ME
+        en: 'Trinity Avowed', // FIX-ME
         de: 'Eingeschworene',
         fr: 'Féale',
         ja: 'アヴァウド',
@@ -676,8 +666,7 @@ export const zoneInfoBozjaSouthern: EurekaZoneInfo = {
         tc: '天佑女王',
       },
       shortName: {
-        en: 'Save the Queen',
-        // FIX-ME
+        en: 'Save the Queen', // FIX-ME
         de: 'Heilige Klinge',
         fr: 'Sauver',
         ja: 'セイブ・ザ・クイーン',

--- a/ui/raidboss/data/03-hw/trial/sephirot-ex.ts
+++ b/ui/raidboss/data/03-hw/trial/sephirot-ex.ts
@@ -197,8 +197,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Orange (${force})',
           de: 'Orange (${force})',
           fr: '${force} Orange',
-          ja: '自分に${force}',
-          // FIXME
+          ja: '自分に${force}', // FIXME
           cn: '橙点名 ${force}',
           ko: '노랑 (${force})',
           tc: '橙點名 ${force}',
@@ -217,8 +216,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Green (${force})',
           de: 'Grün (${force})',
           fr: '${force} Vert',
-          ja: '自分に${force}',
-          // FIXME
+          ja: '自分に${force}', // FIXME
           cn: '绿点名 ${force}',
           ko: '초록 (${force})',
           tc: '綠點名 ${force}',

--- a/ui/raidboss/data/03-hw/trial/zurvan-ex.ts
+++ b/ui/raidboss/data/03-hw/trial/zurvan-ex.ts
@@ -192,8 +192,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Stay outside hitbox',
           de: 'Auserhalb der Hitbox stehen',
           fr: 'Restez à l\'extérieur de la hitbox',
-          ja: '範囲攻撃を避ける',
-          // FIXME
+          ja: '範囲攻撃を避ける', // FIXME
           cn: '站在目标圈外',
           ko: '히트박스 밖으로',
           tc: '站在目標圈外',

--- a/ui/raidboss/data/04-sb/raid/o3s.ts
+++ b/ui/raidboss/data/04-sb/raid/o3s.ts
@@ -352,8 +352,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Books (One Per Square)',
           de: 'Bücher (Eins pro Feld)',
           fr: 'Livres (Un par carré)',
-          ja: '女王の舞い: 本',
-          // FIXME
+          ja: '女王の舞い: 本', // FIXME
           cn: '中间两排分格站位',
           ko: '책 (칸마다 한명)',
           tc: '中間兩排分格站位',
@@ -378,8 +377,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Clock',
           de: 'Himmelsrichtungen',
           fr: 'Positions',
-          ja: '女王の舞い: 散開',
-          // FIXME
+          ja: '女王の舞い: 散開', // FIXME
           cn: '八方站位',
           ko: '산개',
           tc: '八方站位',
@@ -396,8 +394,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Be On Blue Square',
           de: 'Stehe auf einem blauem Feld',
           fr: 'Placez-vous sur un carré bleu',
-          ja: '女王の舞い: 床',
-          // FIXME
+          ja: '女王の舞い: 床', // FIXME
           cn: '站在蓝地板',
           ko: '파란 바닥 위로',
           tc: '站在藍地板',
@@ -414,8 +411,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Tethers',
           de: 'Dornenranken-Verbindungen',
           fr: 'Liens',
-          ja: '女王の舞い: 茨',
-          // FIXME
+          ja: '女王の舞い: 茨', // FIXME
           cn: '先集中后扯线',
           ko: '가시줄 끊기',
           tc: '先集中後扯線',

--- a/ui/raidboss/data/04-sb/raid/o5n.ts
+++ b/ui/raidboss/data/04-sb/raid/o5n.ts
@@ -71,8 +71,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Drop Marker Away',
           de: 'Licht am Rand ablegen',
           fr: 'Déposez la marque au loin',
-          ja: '魔界の光',
-          // FIXME
+          ja: '魔界の光', // FIXME
           cn: '远离放置光点名',
           ko: '빛장판 유도',
           tc: '遠離放置光點名',

--- a/ui/raidboss/data/04-sb/raid/o6n.ts
+++ b/ui/raidboss/data/04-sb/raid/o6n.ts
@@ -56,8 +56,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Drop Chasing AOE Away',
           de: 'AoEs weglocken',
           fr: 'Déposez les AoEs au loin',
-          ja: '離れてAoEを置く',
-          // FIXME
+          ja: '離れてAoEを置く', // FIXME
           cn: '远离放置追踪AOE',
           ko: '연속장판 멀리빼기',
           tc: '遠離放置追蹤AOE',

--- a/ui/raidboss/data/05-shb/raid/e10n.ts
+++ b/ui/raidboss/data/05-shb/raid/e10n.ts
@@ -147,8 +147,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Stand behind tethered dog',
           de: 'Achte auf den verbundenen Hund',
           fr: 'Allez derrière le chien lié',
-          ja: '線で繋がった分身を注視',
-          // FIXME
+          ja: '線で繋がった分身を注視', // FIXME
           cn: '站在连线狗后',
           ko: '연결된 쫄 뒤로가기',
           tc: '站在連線狗後',

--- a/ui/raidboss/data/05-shb/raid/e12s.ts
+++ b/ui/raidboss/data/05-shb/raid/e12s.ts
@@ -1351,8 +1351,7 @@ const triggerSet: TriggerSet<Data> = {
             en: 'Eye (w/${player})',
             de: 'Auge (mit ${player})',
             fr: 'Œil (avec ${player})',
-            ja: '自分に目 (w/${player})',
-            // FIXME
+            ja: '自分に目 (w/${player})', // FIXME
             cn: '石化眼点名 (与${player})',
             ko: '시선징 (+${player})',
             tc: '石化眼點名 (與${player})',
@@ -1369,8 +1368,7 @@ const triggerSet: TriggerSet<Data> = {
             en: 'Long Fire (w/${player})',
             de: 'langes Feuer (w/${player})',
             fr: 'Feu long (avec ${player})',
-            ja: 'ファイガ(遅い) (w/${player})',
-            // FIXME
+            ja: 'ファイガ(遅い) (w/${player})', // FIXME
             cn: '长火 (与${player})',
             ko: '느린 파이가 (+${player})',
             tc: '長火 (與${player})',
@@ -1379,8 +1377,7 @@ const triggerSet: TriggerSet<Data> = {
             en: 'Short Fire (w/${player})',
             de: 'kurzes Feuer (w/${player})',
             fr: 'Feu court (avec ${player})',
-            ja: 'ファイガ(早い) (w/${player})',
-            // FIXME
+            ja: 'ファイガ(早い) (w/${player})', // FIXME
             cn: '短火 (与${player})',
             ko: '빠른 파이가 (+${player})',
             tc: '短火 (與${player})',
@@ -1389,8 +1386,7 @@ const triggerSet: TriggerSet<Data> = {
             en: 'Long Ice (w/${player})',
             de: 'langes Eis (w/${player})',
             fr: 'Glace longue (avec ${player})',
-            ja: 'ブリザガ(遅い) (w/${player})',
-            // FIXME
+            ja: 'ブリザガ(遅い) (w/${player})', // FIXME
             cn: '长冰 (与${player})',
             ko: '느린 블리자가 (+${player})',
             tc: '長冰 (與${player})',
@@ -1399,8 +1395,7 @@ const triggerSet: TriggerSet<Data> = {
             en: 'Short Ice (w/${player})',
             de: 'kurzes Eis (w/${player})',
             fr: 'Glace courte (avec ${player})',
-            ja: 'ブリザガ(早い) (w/${player})',
-            // FIXME
+            ja: 'ブリザガ(早い) (w/${player})', // FIXME
             cn: '短冰 (与${player})',
             ko: '빠른 블리자가 (+${player})',
             tc: '短冰 (與${player})',
@@ -1856,8 +1851,7 @@ const triggerSet: TriggerSet<Data> = {
             en: 'Double Aero (w/${player})',
             de: 'Doppel Windga (mit ${player})',
             fr: 'Double Vent(avec ${player})',
-            ja: '自分にエアロガ×2 (w/${player})',
-            // FIXME
+            ja: '自分にエアロガ×2 (w/${player})', // FIXME
             cn: '双风点名 (与${player})',
             ko: '더블 에어로가 (+${player})',
             tc: '雙風點名 (與${player})',
@@ -1866,8 +1860,7 @@ const triggerSet: TriggerSet<Data> = {
             en: 'Spread (w/${player1}, ${player2}, ${player3})',
             de: 'Verteilen (mit ${player1}, ${player2}, ${player3})',
             fr: 'Dispersion (avec ${player1}, ${player2}, ${player3})',
-            ja: '自分に散開 (w/${player1}, ${player2}, ${player3})',
-            // FIXME
+            ja: '自分に散開 (w/${player1}, ${player2}, ${player3})', // FIXME
             cn: '分散点名 (与${player1}, ${player2}, ${player3})',
             ko: '산개징 (+${player1}, ${player2}, ${player3})',
             tc: '分散點名 (與${player1}, ${player2}, ${player3})',

--- a/ui/raidboss/data/05-shb/raid/e4s.ts
+++ b/ui/raidboss/data/05-shb/raid/e4s.ts
@@ -456,8 +456,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Left (or Back)',
           de: 'Links (oder Hinten)',
           fr: 'Gauche (ou Arrière)',
-          ja: '右前壊れるよ',
-          // FIXME
+          ja: '右前壊れるよ', // FIXME
           cn: '左 (或 后)',
           ko: '왼쪽 (또는 뒤)',
           tc: '左 (或 後)',
@@ -485,8 +484,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Left (or Front)',
           de: 'Links (oder Vorne)',
           fr: 'Gauche (ou Devant)',
-          ja: '右後ろ壊れるよ',
-          // FIXME
+          ja: '右後ろ壊れるよ', // FIXME
           cn: '左 (或 前)',
           ko: '왼쪽 (또는 앞)',
           tc: '左 (或 前)',
@@ -514,8 +512,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Right (or Front)',
           de: 'Rechts (oder Vorne)',
           fr: 'Droite (ou Devant)',
-          ja: '左後ろ壊れるよ',
-          // FIXME
+          ja: '左後ろ壊れるよ', // FIXME
           cn: '右 (或 前)',
           ko: '오른쪽 (또는 앞)',
           tc: '右 (或 前)',
@@ -543,8 +540,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Right (or Back)',
           de: 'Rechts (oder Hinten)',
           fr: 'Droite (ou Arrière)',
-          ja: '左前壊れるよ',
-          // FIXME
+          ja: '左前壊れるよ', // FIXME
           cn: '右 (或 后)',
           ko: '오른쪽 (또는 뒤)',
           tc: '右 (或 後)',

--- a/ui/raidboss/data/05-shb/raid/e8s.ts
+++ b/ui/raidboss/data/05-shb/raid/e8s.ts
@@ -90,8 +90,7 @@ const triggerSet: TriggerSet<Data> = {
         en: 'Enable uptime knockback strat',
         de: 'Aktiviere Uptime Rückstoß Strategie',
         fr: 'Activer la strat Poussée-Uptime',
-        ja: 'エデン零式共鳴編４層：cactbot「ヘヴンリーストライク (ノックバック)」ギミック',
-        // FIXME
+        ja: 'エデン零式共鳴編４層：cactbot「ヘヴンリーストライク (ノックバック)」ギミック', // FIXME
         cn: '启用击退镜 uptime 策略',
         ko: '정확한 타이밍 넉백방지 공략 사용',
         tc: '啟用擊退鏡 uptime 策略',
@@ -407,8 +406,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Biting Next (face outward)',
           de: 'Frosthieb als nächstes (nach außen drehen)',
           fr: 'Taillade de givre (pointez vers l\'extérieur)',
-          ja: '次はフロストスラッシュ',
-          // FIXME
+          ja: '次はフロストスラッシュ', // FIXME
           cn: '即将冰霜斩 (拉背对人群)',
           ko: '서리 참격 (뒤로)',
           tc: '即將冰霜斬 (拉背對人群)',
@@ -417,8 +415,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Driving Next (face inward)',
           de: 'Froststoß als nächstes (nach innen drehen)',
           fr: 'Percée de givre (pointez vers l\'intérieur)',
-          ja: '次はフロストスラスト',
-          // FIXME
+          ja: '次はフロストスラスト', // FIXME
           cn: '即将冰霜刺 (拉面对人群)',
           ko: '서리 일격 (앞으로)',
           tc: '即將冰霜刺 (拉麵對人群)',

--- a/ui/raidboss/data/05-shb/trial/emerald_weapon-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/emerald_weapon-ex.ts
@@ -474,8 +474,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Go North; Dodge Soldiers/Divebombs',
           de: 'Geh nach Norden; Achte auf die Lücken zwischen den Soldaten',
           fr: 'Allez au Nord, esquivez les soldats et les bombes plongeantes',
-          ja: '飛行部隊と射撃部隊を見覚える',
-          // FIXME
+          ja: '飛行部隊と射撃部隊を見覚える', // FIXME
           cn: '去上边缘；躲避士兵射击/飞机轰炸',
           ko: '북쪽으로 이동, 엑사플레어, 병사 사격 확인',
           tc: '去上邊緣；躲避士兵射擊/飛機轟炸',

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.ts
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.ts
@@ -378,8 +378,7 @@ const triggerSet: TriggerSet<Data> = {
           'Aktiviere Cactbot Wormhole Strategie: https://ff14.toolboxgaming.space/?id=17050133675751&preview=1',
         fr:
           'Activer cactbot pour la strat Wormhole : https://ff14.toolboxgaming.space/?id=17050133675751&preview=1',
-        ja: '絶アレキサンダー討滅戦：cactbot「次元断絶のマーチ」ギミック',
-        // FIXME
+        ja: '絶アレキサンダー討滅戦：cactbot「次元断絶のマーチ」ギミック', // FIXME
         cn: '启用 cactbot 次元断绝策略: https://ff14.toolboxgaming.space/?id=17050133675751&preview=1',
         ko: 'cactbot 웜홀 공략방식 사용: https://ff14.toolboxgaming.space/?id=17050133675751&preview=1',
         tc: '啟用 cactbot 次元斷絕策略: https://ff14.toolboxgaming.space/?id=17050133675751&preview=1',

--- a/ui/raidboss/data/06-ew/alliance/thaleia.ts
+++ b/ui/raidboss/data/06-ew/alliance/thaleia.ts
@@ -177,8 +177,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Go to rotated safe zone',
           de: 'Geh zum rotierten sicheren Feld',
           fr: 'Allez dans une zone sûre après rotation',
-          ja: '安置へ移動',
-          // FIXME
+          ja: '安置へ移動', // FIXME
           cn: '去旋转后的安全区',
           ko: '회전한 뒤의 안전 지대로 가기',
           tc: '去旋轉後的安全區',
@@ -648,8 +647,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Go to rotated safe zone',
           de: 'Geh in den sicheren Bereich',
           fr: 'Allez dans une zone sûre après rotation',
-          ja: '安置へ移動',
-          // FIXME
+          ja: '安置へ移動', // FIXME
           cn: '去旋转后的安全区',
           ko: '회전한 뒤의 안전 지대로 가기',
           tc: '去旋轉後的安全區',

--- a/ui/raidboss/data/06-ew/dungeon/aloalo_island.ts
+++ b/ui/raidboss/data/06-ew/dungeon/aloalo_island.ts
@@ -540,8 +540,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Forward March (1 square)',
           de: 'Geistlenkung: Vorwärts',
           fr: 'Vers l\'avant (1 carreau)',
-          ja: '強制移動 : 前',
-          // FIXME
+          ja: '強制移動 : 前', // FIXME
           cn: '强制移动 : 前',
           ko: '강제이동: 앞 (1칸)',
           tc: '強制移動 : 前',
@@ -550,8 +549,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Backwards March (1 square)',
           de: 'Geistlenkung: Rückwärts',
           fr: 'Vers l\'arrière (1 carreau)',
-          ja: '強制移動 : 後ろ',
-          // FIXME
+          ja: '強制移動 : 後ろ', // FIXME
           cn: '强制移动 : 后',
           ko: '강제이동: 뒤 (1칸)',
           tc: '強制移動 : 後',
@@ -560,8 +558,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Left March (1 square)',
           de: 'Geistlenkung: Links',
           fr: 'Vers la gauche (1 carreau)',
-          ja: '強制移動 : 左',
-          // FIXME
+          ja: '強制移動 : 左', // FIXME
           cn: '强制移动 : 左',
           ko: '강제이동: 왼쪽 (1칸)',
           tc: '強制移動 : 左',
@@ -570,8 +567,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Right March (1 square)',
           de: 'Geistlenkung: Rechts',
           fr: 'Vers la droite (1 carreau)',
-          ja: '強制移動 : 右',
-          // FIXME
+          ja: '強制移動 : 右', // FIXME
           cn: '强制移动 : 右',
           ko: '강제이동: 오른쪽 (1칸)',
           tc: '強制移動 : 右',

--- a/ui/raidboss/data/06-ew/raid/p10s.ts
+++ b/ui/raidboss/data/06-ew/raid/p10s.ts
@@ -486,8 +486,7 @@ const triggerSet: TriggerSet<Data> = {
           en: '(spread => role stack (${player1}, ${player2}), for later)',
           de: '(Verteilen => Rollengruppe (${player1}, ${player2}), für später)',
           fr: '(Écartez-vous => Package par rôle (${player1}, ${player2}), pour après)',
-          ja: '(散会 => 4:4あたまわり (${player1}, ${player2}))',
-          // FIXME
+          ja: '(散会 => 4:4あたまわり (${player1}, ${player2}))', // FIXME
           cn: '(稍后 分散 => 四人分摊 (${player1}, ${player2}))',
           ko: '(곧 산개 => 직업군별 쉐어 (${player1}, ${player2}))',
           tc: '(稍後 分散 => 四人分攤 (${player1}, ${player2}))',
@@ -496,8 +495,7 @@ const triggerSet: TriggerSet<Data> = {
           en: '(role stack (${player1}, ${player2}) => spread, for later)',
           de: '(Rollengruppe (${player1}, ${player2}) => Verteilen, für später)',
           fr: '(Package par rôle (${player1}, ${player2}) => Écartez-vous, pour après)',
-          ja: '(4:4あたまわり (${player1}, ${player2}) => 散会)',
-          // FIXME
+          ja: '(4:4あたまわり (${player1}, ${player2}) => 散会)', // FIXME
           cn: '(稍后 四人分摊 (${player1}, ${player2}) => 分散)',
           ko: '(곧 직업군별 쉐어 (${player1}, ${player2}) => 산개)',
           tc: '(稍後 四人分攤 (${player1}, ${player2}) => 分散)',
@@ -527,8 +525,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Spread => Role Stack (${player1}, ${player2})',
           de: 'Verteilen => Rollengruppe (${player1}, ${player2})',
           fr: 'Écartez-vous => Package par rôle (${player1}, ${player2})',
-          ja: '散会 => 4:4あたまわり (${player1}, ${player2})',
-          // FIXME
+          ja: '散会 => 4:4あたまわり (${player1}, ${player2})', // FIXME
           cn: '分散 => 四人分摊 (${player1}, ${player2})',
           ko: '산개 => 직업군별 쉐어 (${player1}, ${player2})',
           tc: '分散 => 四人分攤 (${player1}, ${player2})',
@@ -588,8 +585,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Role Stack (${player1}, ${player2}) => Spread',
           de: 'Rollengruppe (${player1}, ${player2}) => Verteilen',
           fr: 'Package par rôle (${player1}, ${player2}) => Écartez-vous',
-          ja: '4:4あたまわり (${player1}, ${player2}) => 散会',
-          // FIXME
+          ja: '4:4あたまわり (${player1}, ${player2}) => 散会', // FIXME
           cn: '四人分摊 (${player1}, ${player2}) => 分散',
           ko: '직업군별 쉐어 (${player1}, ${player2}) => 산개',
           tc: '四人分攤 (${player1}, ${player2}) => 分散',
@@ -632,8 +628,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Role Stack (${player1}, ${player2})',
           de: 'Rollengruppe (${player1}, ${player2})',
           fr: 'Package par rôle (${player1}, ${player2})',
-          ja: '4:4あたまわり (${player1}, ${player2})',
-          // FIXME
+          ja: '4:4あたまわり (${player1}, ${player2})', // FIXME
           cn: '四人分摊 (${player1}, ${player2})',
           ko: '직업군별 쉐어 (${player1}, ${player2})',
           tc: '四人分攤 (${player1}, ${player2})',

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -2221,8 +2221,7 @@ const triggerSet: TriggerSet<Data> = {
             en: 'Bait (${delay})',
             de: 'Laser Ködern (${delay})',
             fr: 'Bait (${delay})',
-            ja: 'レーザー誘導 (${delay})',
-            // FIXME
+            ja: 'レーザー誘導 (${delay})', // FIXME
             cn: '引导激光 (${delay})',
             ko: '레이저 유도 (${delay})',
             tc: '引導雷射 (${delay})',
@@ -2231,8 +2230,7 @@ const triggerSet: TriggerSet<Data> = {
             en: '(5 and 7 ${delay})',
             de: '(5 und 7 ködern ${delay})',
             fr: '(5 et 7 ${delay})',
-            ja: '(5と7誘導 ${delay})',
-            // FIXME
+            ja: '(5と7誘導 ${delay})', // FIXME
             cn: '(5 和 7 引导 ${delay})',
             ko: '(5, 7 레이저 ${delay})',
             tc: '(5 和 7 引導 ${delay})',
@@ -2271,8 +2269,7 @@ const triggerSet: TriggerSet<Data> = {
             en: 'Bait (${delay})',
             de: 'Laser Ködern (${delay})',
             fr: 'Bait (${delay})',
-            ja: 'レーザー誘導 (${delay})',
-            // FIXME
+            ja: 'レーザー誘導 (${delay})', // FIXME
             cn: '引导激光 (${delay})',
             ko: '레이저 유도 (${delay})',
             tc: '引導雷射 (${delay})',
@@ -2281,8 +2278,7 @@ const triggerSet: TriggerSet<Data> = {
             en: '(6 and 8 ${delay})',
             de: '(6 und 8 ködern ${delay})',
             fr: '(6 et 8 ${delay})',
-            ja: '(6と8誘導 ${delay})',
-            // FIXME
+            ja: '(6と8誘導 ${delay})', // FIXME
             cn: '(6 和 8 引导 ${delay})',
             ko: '(6, 8 레이저 ${delay})',
             tc: '(6 和 8 引導 ${delay})',
@@ -2291,8 +2287,7 @@ const triggerSet: TriggerSet<Data> = {
             en: '(1 and 3 ${delay})',
             de: '(1 und 3 ködern ${delay})',
             fr: '(1 et 3 ${delay})',
-            ja: '(1と3誘導 ${delay})',
-            // FIXME
+            ja: '(1と3誘導 ${delay})', // FIXME
             cn: '(1 和 3 引导 ${delay})',
             ko: '(1, 3 레이저 ${delay})',
             tc: '(1 和 3 引導 ${delay})',
@@ -2301,8 +2296,7 @@ const triggerSet: TriggerSet<Data> = {
             en: '(2 and 4 ${delay})',
             de: '(2 und 6 ködern ${delay})',
             fr: '(2 et 4 ${delay})',
-            ja: '(2と4誘導 ${delay})',
-            // FIXME
+            ja: '(2と4誘導 ${delay})', // FIXME
             cn: '(2 和 4 引导 ${delay})',
             ko: '(2, 4 레이저 ${delay})',
             tc: '(2 和 4 引導 ${delay})',
@@ -4335,8 +4329,7 @@ const triggerSet: TriggerSet<Data> = {
             en: 'Initial Fire (w/ ${partner})',
             de: 'Initiales Feuer (mit ${partner})',
             fr: 'Feu initial (avec ${partner})',
-            ja: '自分に初炎 (${partner})',
-            // FIXME
+            ja: '自分に初炎 (${partner})', // FIXME
             cn: '火点名 (和 ${partner})',
             ko: '첫 불 대상자 (+ ${partner})',
             tc: '火點名 (和 ${partner})',
@@ -4406,8 +4399,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Stack with Fire',
           de: 'Mit Feuer sammeln',
           fr: 'Package avec le Feu',
-          ja: '無職！炎とあたまわり',
-          // FIXME
+          ja: '無職！炎とあたまわり', // FIXME
           cn: '与火分摊',
           ko: '불 쉐어',
           tc: '與火分攤',
@@ -4456,8 +4448,7 @@ const triggerSet: TriggerSet<Data> = {
             en: 'Initial Wind',
             de: 'Initial Wind',
             fr: 'Vent inital',
-            ja: '自分に初風',
-            // FIXME
+            ja: '自分に初風', // FIXME
             cn: '风点名',
             ko: '첫 바람 대상자',
             tc: '風點名',
@@ -4510,8 +4501,7 @@ const triggerSet: TriggerSet<Data> = {
             en: 'Fire Marker',
             de: 'Feuer Markierung',
             fr: 'Marqueur de feu',
-            ja: '自分に初炎!',
-            // FIXME
+            ja: '自分に初炎!', // FIXME
             cn: '传火点名',
             ko: '불 대상자',
             tc: '傳火點名',

--- a/ui/raidboss/data/06-ew/trial/sephirot-un.ts
+++ b/ui/raidboss/data/06-ew/trial/sephirot-un.ts
@@ -227,8 +227,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Orange (${force})',
           de: 'Orange (${force})',
           fr: '${force} Orange',
-          ja: '自分に${force}',
-          // FIXME
+          ja: '自分に${force}', // FIXME
           cn: '橙点名 (${force})',
           ko: '노랑 (${force})',
           tc: '橙點名 (${force})',
@@ -247,8 +246,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Green (${force})',
           de: 'Grün (${force})',
           fr: '${force} Vert',
-          ja: '自分に${force}',
-          // FIXME
+          ja: '自分に${force}', // FIXME
           cn: '绿点名 (${force})',
           ko: '초록 (${force})',
           tc: '綠點名 (${force})',

--- a/ui/raidboss/data/06-ew/trial/zurvan-un.ts
+++ b/ui/raidboss/data/06-ew/trial/zurvan-un.ts
@@ -197,8 +197,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Stay outside hitbox',
           de: 'Auserhalb der Hitbox stehen',
           fr: 'Restez à l\'extérieur de la hitbox',
-          ja: '範囲攻撃を避ける',
-          // FIXME
+          ja: '範囲攻撃を避ける', // FIXME
           cn: '站在目标圈外',
           ko: '히트박스 밖으로',
           tc: '站在目標圈外',


### PR DESCRIPTION
#891
Not sure why `lintfix` changed them before. I can't reproduce it even if I run it again.