### PR TITLE
raidboss: fix OC CE timelines if already in combat

### DIFF
--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.txt
@@ -289,7 +289,7 @@ hideall "--sync--"
 3000.0 "--sync--" ActorControl { command: "80000014", data0: "330" } window 100000,0
 3100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
 # Backup sync on first cast bar
-3105.1 "--sync--" StartsUsing { id: "A174", source: "Death Claw" } window 5.2,2
+3105.1 "--sync--" StartsUsing { id: "A174", source: "Death Claw" } window 105,2
 3110.2 "Dirty Nails" Ability { id: "A174", source: "Death Claw" }
 
 # Clawmarks tutorial
@@ -364,7 +364,7 @@ hideall "--sync--"
 # A9BC What're You Buying?
 4000.0 "--sync--" ActorControl { command: "80000014", data0: "32B" } window 100000,0
 4100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
-4128.8 "--sync--" StartsUsing { id: "A22E", source: "Trade Tortoise" } window 30,5
+4128.8 "--sync--" StartsUsing { id: "A22E", source: "Trade Tortoise" } window 130,5
 4131.8 "Ill-gotten Goods (Red)" Ability { id: "A22E", source: "Trade Tortoise" }
 4138.9 "Material World " Ability { id: "A22D", source: "Trade Tortoise" }
 4146.8 "Ruby Blaze (Stop)" #Ability { id: "A23D" }
@@ -437,7 +437,7 @@ hideall "--sync--"
 # A155 Scratch
 5000.0 "--sync--" ActorControl { command: "80000014", data0: "329" } window 100000,0
 5100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
-5117.2 "--sync--" StartsUsing { id: "A13F", source: "Repaired Lion" } window 20,5
+5117.2 "--sync--" StartsUsing { id: "A13F", source: "Repaired Lion" } window 120,5
 5122.2 "Radiant Wave" Ability { id: "A13F", source: "Repaired Lion" } duration 1
 
 # Ancient Stone and Ancient Aero Tutorial
@@ -585,7 +585,7 @@ hideall "--sync--"
 # A0B5 Arcane Light
 7000.0 "--sync--" ActorControl { command: "80000014", data0: "323" } window 100000,0
 7100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
-7118.6 "--sync--" StartsUsing { id: "A0B1", source: "Mythic Idol" } window 20,5
+7118.6 "--sync--" StartsUsing { id: "A0B1", source: "Mythic Idol" } window 120,5
 7123.6 "Mystic Heat" Ability { id: "A0B1", source: "Mythic Idol" }
 7129.5 "--middle--"
 7133.4 "Shifting Shape" Ability { id: "A0A6", source: "Mythic Idol" }
@@ -829,7 +829,7 @@ hideall "--sync--"
 8000.0 "--sync--" ActorControl { command: "80000014", data0: "327" } window 100000,0
 8100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
 # Tutorial
-8117.4 "--sync--" StartsUsing { id: "A0E5", source: "Neo Garula" } window 20,5
+8117.4 "--sync--" StartsUsing { id: "A0E5", source: "Neo Garula" } window 120,5
 8122.4 "Squash" Ability { id: "A0E5", source: "Neo Garula" }
 8128.7 "--middle--"
 
@@ -969,7 +969,7 @@ hideall "--sync--"
 # A1C6 Shockwave (damage)
 9000.0 "--sync--" ActorControl { command: "80000014", data0: "338" } window 100000,0
 9100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
-9119.0 "--sync--" StartsUsing { id: "A1C3", source: "Lion Rampant" } window 20,5
+9119.0 "--sync--" StartsUsing { id: "A1C3", source: "Lion Rampant" } window 120,5
 9125.0 "Fearsome Glint" Ability { id: "A1C3", source: "Lion Rampant" }
 
 # Beacon Tutorial
@@ -1067,7 +1067,7 @@ hideall "--sync--"
 # TODO: Retime forced move once debuff is logged
 10000.0 "--sync--" ActorControl { command: "80000014", data0: "320" } window 100000,0
 10100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
-10117.1 "--sync--" StartsUsing { id: "A0D2", source: "Mysterious Mindflayer" } window 20,5
+10117.1 "--sync--" StartsUsing { id: "A0D2", source: "Mysterious Mindflayer" } window 120,5
 10123.1 "Dark II" Ability { id: "A0D2", source: "Mysterious Mindflayer" }
 
 # Mind Blast Tutorial
@@ -1144,7 +1144,7 @@ hideall "--sync--"
 # A88D Hydrocleave
 11000.0 "--sync--" ActorControl { command: "80000014", data0: "32E" } window 100000,0
 11100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
-11117.2 "--sync--" StartsUsing { id: "A2D9", source: "Nymian Petalodus" } window 20,5
+11117.2 "--sync--" StartsUsing { id: "A2D9", source: "Nymian Petalodus" } window 120,5
 11122.2 "Marine Mayhem" Ability { id: "A2D9", source: "Nymian Petalodus" }
 11141.9 "Pelagic Cleaver 1" Ability { id: "A2D5", source: "Petalodus Progeny" } duration 0.8
 11144.7 "--sync--" Ability { id: "A2DD", source: "Petalodus Progeny" }
@@ -1345,7 +1345,7 @@ hideall "--sync--"
 13000.0 "--sync--" ActorControl { command: "80000014", data0: "348" } window 100000,0
 13100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
 # Backup sync on first cast bar
-13105.1 "--sync--" StartsUsing { id: "7845", source: "Crescent Berserker" } window 17.4,2
+13105.1 "--sync--" StartsUsing { id: "7845", source: "Crescent Berserker" } window 105,2
 
 # Scathing Sweep tutorial
 13111.1 "Boil Over" Ability { id: "7845", source: "Crescent Berserker" }
@@ -1457,7 +1457,7 @@ hideall "--sync--"
 # * Verify loop (if possible..)
 14000.0 "--sync--" ActorControl { command: "80000014", data0: "349" } window 100000,0
 14100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
-14105.1 "--sync--" StartsUsing { id: "A323", source: "Crystal Dragon" } window 5,2
+14105.1 "--sync--" StartsUsing { id: "A323", source: "Crystal Dragon" } window 105,2
 14110.1 "Primal Roar" Ability { id: "A323", source: "Crystal Dragon" }
 # Prismatic Wing Lightning Tutorial
 14116.3 "--sync--" StartsUsing { id: "A315", source: "Crystal Dragon" }
@@ -1545,7 +1545,7 @@ hideall "--sync--"
 #
 15000.0 "--sync--" ActorControl { command: "80000014", data0: "339" } window 100000,0
 15100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
-15117.0 "--sync--" StartsUsing { id: "A1C8", source: "Command Urn" } window 20,5
+15117.0 "--sync--" StartsUsing { id: "A1C8", source: "Command Urn" } window 120,5
 15120.0 "Summon" Ability { id: "A1C8", source: "Command Urn" }
 # Stone Swell Tutorial
 15126.1 "Assail" Ability { id: "A1C9", source: "Command Urn" }
@@ -1649,7 +1649,7 @@ hideall "--sync--"
 # A1B5 Blowout (damage + knockback)
 16000.0 "--sync--" ActorControl { command: "80000014", data0: "32A" } window 100000,0
 16100.0 "--sync--" InCombat { inGameCombat: "1" } window 100,3
-16119.1 "--sync--" StartsUsing { id: "A1A5", source: "Hinkypunk" } window 20,5
+16119.1 "--sync--" StartsUsing { id: "A1A5", source: "Hinkypunk" } window 120,5
 16124.1 "Lamplight" Ability { id: "A1A5", source: "Hinkypunk" } duration 0.9
 16137.4 "Dread Dive" Ability { id: "A1A4", source: "Hinkypunk" }
 16144.8 "--Tell 1 (Blowout)--" Ability { id: "A1A3", source: "Hinkypunk" }


### PR DESCRIPTION
Most of the CE timelines have an InCombat sync line to ensure that the
timeline matches up with what we expect. In some circumstances, players
may accidentally already be in combat when the CE starts. If this
occurs, the timeline will never sync up, as the InCombat sync will not
be triggered. This results in broken timelines. In many cases the
timeline still "appears" but becomes wildly inaccurate.

Fix this by increasing the window for the first StartsUsing cast which
is used to re-sync the timeline in case of a backup. Ensure this window
is large enough to fully cover the 100 seconds skipped at the start of
entering a CE.
