### PR TITLE
raidemulator: support critical encounters

### DIFF
--- a/ui/raidboss/emulator/EmulatorCommon.ts
+++ b/ui/raidboss/emulator/EmulatorCommon.ts
@@ -160,6 +160,16 @@ export default class EmulatorCommon {
         language: res.groups?.language ?? undefined,
       };
     }
+    res = EmulatorCommon.doesLineMatch(line, EmulatorCommon.ceRegexes);
+    if (res) {
+      if (res.groups?.data0 !== '00') {
+        return {
+          StartIn: '0',
+          StartType: 'CE Start',
+          language: res.groups?.language ?? undefined,
+        };
+      }
+    }
     res = EmulatorCommon.doesLineMatch(line, EmulatorCommon.engageRegexes);
     if (res) {
       return {
@@ -202,12 +212,22 @@ export default class EmulatorCommon {
         language: res.groups?.language ?? undefined,
       };
     }
+    res = EmulatorCommon.doesLineMatch(line, EmulatorCommon.ceRegexes);
+    if (res) {
+      if (res.groups?.data0 === '00') {
+        return {
+          EndType: 'CE End',
+          language: res.groups?.language ?? undefined,
+        };
+      }
+    }
   }
 
   static sealRegexes = LocaleNetRegex.areaSeal;
   static engageRegexes = LocaleNetRegex.countdownEngage;
   static countdownRegexes = LocaleNetRegex.countdownStart;
   static unsealRegexes = LocaleNetRegex.areaUnseal;
+  static ceRegexes = NetRegexes.network6d({ command: '80000014' });
   static wipeRegex = commonNetRegex.wipe;
   static winRegex = NetRegexes.network6d({ command: '4000000[23]' });
   static cactbotWipeRegex = NetRegexes.echo({ line: 'cactbot wipe.*?' });


### PR DESCRIPTION
The raid emulator does not use the log tools to split network log files
for encounter data. Currently this means that critical encounters in OC
and other zones do not get separated properly. This is problematic as it
means you cannot use the emulator to easily test such encounters.
Additionally, this can result in extremely long encounters which take a
long time to parse. In my case, this resulted in Firefox repeatedly
complaining about the thread taking too long and trying to stop it.

Add support for the CE start and end to the EmulatorCommon.ts regex
list to allow splitting the critical encounters properly within the
emulator.
