### PR TITLE
raidboss: zelenia ex improvements

### DIFF
--- a/ui/raidboss/data/07-dt/trial/zelenia-ex.ts
+++ b/ui/raidboss/data/07-dt/trial/zelenia-ex.ts
@@ -252,7 +252,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'select',
       options: {
         en: {
-          'None': 'None',
+          'None': 'none',
           'DPS In': 'dpsIn',
           'Support First': 'supportFirst',
           'DPS First': 'dpsFirst',


### PR DESCRIPTION
I've been carrying these on a personal branch for some time, and I figured
it would be good to submit these.

First, the bloom 1 logic can be simplified to remove potential inconsistency
and errors, since there are only two outcomes.

Second, the Escelons Fall mechanic has multiple strategies used in PF back
when it was new. The default can work for any strategy, but it would be nice
if the callouts could be tailored to specific strategies. I added these
here.

The improvements may not be that useful since the fight is getting older and
overgeared.. but I've had them and tested for some time and liked the
changes.

- **raidboss: simplify bloom 1 logic for Zelenia Ex**
- **raidboss: add strategy for Zelenia Ex Escelons' Fall**
