### PR TITLE
raidemulator: analyze party members in batches of 8

### DIFF
--- a/ui/raidboss/emulator/data/AnalyzedEncounter.ts
+++ b/ui/raidboss/emulator/data/AnalyzedEncounter.ts
@@ -111,10 +111,15 @@ export default class AnalyzedEncounter extends EventBus {
   }
 
   async analyze(): Promise<void> {
-    // @TODO: Make this run in parallel sometime in the future, since it could be really slow?
     if (this.encounter.combatantTracker) {
-      for (const id of this.encounter.combatantTracker.partyMembers)
-        await this.analyzeFor(id);
+      const partyMembers = this.encounter.combatantTracker.partyMembers;
+      const batchSize = 8;
+
+      for (let i = 0; i < partyMembers.length; i += batchSize) {
+        const batch = partyMembers.slice(i, i + batchSize);
+        const tasks = batch.map((id) => this.analyzeFor(id));
+        await Promise.all(tasks);
+      }
     }
 
     // Free up this memory


### PR DESCRIPTION
Loading an encounter in the emulator can sometimes take a long time. In
particular, field content encounters such as the Forked Tower and CEs, or
alliance raids load slowly. To the user, this appears like a "freeze"
because the encounter loading happens in the main thread.

The bottleneck on my setup appears to be the process of analyzing an
encounter. The analyze() function uses a for loop to await analyzing
each party member serially.

Switching this to await all party members at once is dangerous for large
encounters. In particular, field content could potentially have 72
people in the same critical encounter. On my system, a large CE would
cause the browser javascript engine to crash due to running out of
memory.

However, waiting for each party member in serial is very slow. On some
browsers this can result in waiting multiple minutes to load. Even on
chromium-based browsers it can take a minute or more to load a large
encounter.

Instead of waiting for each party member in serial, slice the party
member list into chunks of 8 and await each block of 8 together. This
will work well for the majority of raids, trials, dungeons, etc which
all have 8 or fewer encounters. For larger encounters it will avoid
running out of memory by limiting the concurrency. The batch size can be
tuned in the event that 8 is too much for all developers systems.
