### PR TITLE
util: handle Air Force One map conflict

### DIFF
--- a/resources/zone_info.ts
+++ b/resources/zone_info.ts
@@ -6058,6 +6058,23 @@ const data: ZoneInfoType = {
     'sizeFactor': 100,
     'weatherRate': 0,
   },
+  832: {
+    'contentType': 19,
+    'exVersion': 0,
+    'name': {
+      'cn': '空军装甲驾驶员',
+      'de': 'Luftwaffe, Feuer frei!',
+      'en': 'Air Force One',
+      'fr': 'As de l\'air',
+      'ja': '出撃！ エアフォースパイロット',
+      'ko': '출격! 에어포스 조종사',
+      'tc': '空軍裝甲駕駛員',
+    },
+    'offsetX': 0,
+    'offsetY': 0,
+    'sizeFactor': 100,
+    'weatherRate': 0,
+  },
   834: {
     'contentType': 7,
     'exVersion': 0,

--- a/util/zone_overrides.ts
+++ b/util/zone_overrides.ts
@@ -118,6 +118,7 @@ const _KNOWN_COLLISIONS: NameKeyToTerritoryIds = {
   'LeapOfFaith': [792, 899, 1098],
   'OceanFishing': [900, 1163],
   'SleepNowInSapphire': [925, 926],
+  'AirForceOne': [832, 1335],
 };
 
 // In theory, we shouldn't include zones in our output when we cannot determine


### PR DESCRIPTION
With the addition of the new Air Force One map in 7.4, we have a conflict between the two zone IDs.