### PR TITLE
raidemulator: fix inconsistent ParserLanguage

### DIFF
--- a/ui/raidboss/emulator/data/RaidEmulator.ts
+++ b/ui/raidboss/emulator/data/RaidEmulator.ts
@@ -35,7 +35,7 @@ export default class RaidEmulator extends EventBus {
   ): void {
     // If language was autodetected from the encounter, set the current ParserLanguage
     // appropriately
-    if (enc.language) {
+    if (enc.language !== 'en') {
       this.options.ParserLanguage = enc.language;
       this.popupText?.setParserLanguage(enc.language);
     }


### PR DESCRIPTION
`ParserLanguage` should depend on the result of `browserLanguagesToLang` when the user is **not** connected to WebSocket.

Feature initially implemented in #2970. 

Changes in #3029 set the default behavior to `en`, making the `if (enc.language)` condition always evaluate to `true`.

---

[ui\raidboss\emulator\data\Encounter.ts#L46](https://github.com/OverlayPlugin/cactbot/blob/main/ui/raidboss/emulator/data/Encounter.ts#L46)

```typescript
  language: Lang = 'en'; // ← this
```

---

Not sure about potential side effects; would appreciate a review from @valarnin.



---

**Added**: This also fixes an issue where `setCurrent` incorrectly calls `setParserLanguage("en")` when `enc.language` is not defined within the log segment.