### PR TITLE
raidboss: better visibility for zh-CN

### DIFF
--- a/resources/timerbar.ts
+++ b/resources/timerbar.ts
@@ -357,6 +357,14 @@ export default class TimerBar extends HTMLElement {
         :host-context(.just-a-number) .timerbar-fg {
           display: none;
         }
+        /* Chinese better visibility CSS */
+        :lang(zh-CN) .text-container {
+          top: calc(50% - 1.4ex);
+          overflow: visible;
+        }
+        :lang(zh-CN) .timerbar-righttext {
+          top: 0.2ex;
+        }
         /* Korean better visibility CSS */
         :lang(ko) .text-container {
           top: calc(50% - 1.5ex);


### PR DESCRIPTION
## when scale 1x
<img width="219" height="99" alt="image" src="https://github.com/user-attachments/assets/3f03af77-e427-4ac0-a0d3-98db44794a68" />

→

<img width="218" height="99" alt="image" src="https://github.com/user-attachments/assets/6ce55f30-79aa-4bd6-acdf-a851ca1aa68d" />

## when scale 2x
<img width="556" height="248" alt="image" src="https://github.com/user-attachments/assets/a59fab6d-e01a-42da-9e0f-f7891bcafac7" />

→

<img width="553" height="248" alt="image" src="https://github.com/user-attachments/assets/d64fffeb-7836-491f-abb8-192cb6241d0f" />
