### PR TITLE
raidboss: add strategy for Dead Stars Vengeful Direction

### DIFF
--- a/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.ts
+++ b/ui/raidboss/data/07-dt/eureka/occult_crescent_south_horn.ts
@@ -627,6 +627,21 @@ const triggerSet: TriggerSet<Data> = {
       default: 'none',
     },
     {
+      id: 'deadStarsVengefulDirection',
+      name: {
+        en: 'Forked Tower: Blood Dead Stars Vengeful Direction Strategy',
+      },
+      type: 'select',
+      options: {
+        en: {
+          'Direction: Just call the 8-way direction of the safe spot.': 'direction',
+          'Waymark: Call the ABBA/FOE/CAFE Waymark of the safe spot.': 'waymark',
+          'Both: Call both direction and waymark of the safe spot.': 'both',
+        },
+      },
+      default: 'direction',
+    },
+    {
       id: 'marbleDragonImitationRainStrategy',
       name: {
         en: 'Forked Tower: Blood Marble Dragon Imitation Rain 1 and 5 Strategy',
@@ -3063,7 +3078,29 @@ const triggerSet: TriggerSet<Data> = {
           deadStarsCenterX,
           deadStarsCenterY,
         );
-        return output[Directions.outputFrom8DirNum(dirNum)]!();
+        const dir = Directions.outputFrom8DirNum(dirNum);
+
+        if (data.triggerSetConfig.deadStarsVengefulDirection === 'direction')
+          return output[dir]!();
+
+        let waymark: 'waymarkA' | 'waymark2and3' | 'waymarkCandD' | 'unknown' = 'unknown';
+
+        // Based on popular ABBA/FOE/CAFE Waymark callouts
+        if (dir === 'dirN') {
+          waymark = 'waymarkA';
+        } else if (dir === 'dirSW') {
+          waymark = 'waymark2and3';
+        } else if (dir === 'dirSE') {
+          waymark = 'waymarkCandD';
+        }
+
+        if (waymark === 'unknown' || data.triggerSetConfig.deadStarsVengefulDirection === 'both')
+          return output.combined!({
+            waymark: output[waymark]!(),
+            dir: output[dir]!(),
+          });
+
+        return output[waymark]!();
       },
       run: (data) => {
         // Reset for next set of casts
@@ -3078,6 +3115,19 @@ const triggerSet: TriggerSet<Data> = {
       },
       outputStrings: {
         ...Directions.outputStrings8Dir,
+        unknown: Outputs.unknown,
+        waymarkA: {
+          en: 'A',
+        },
+        waymark2and3: {
+          en: '2/3',
+        },
+        waymarkCandD: {
+          en: 'C/D',
+        },
+        combined: {
+          en: '${waymark} (${dir})',
+        },
       },
     },
     {


### PR DESCRIPTION
The Vengeful Direction attack during Dead Stars in the Forked Tower:
Blood is sometimes called out using standardized Waymarks. This is true
for several discords who organize the tower, FOE, ABBA, and CAFE.

Add a strategy option to allow configuring the callout to use the
waymark, the direction, or both. If for any reason the callout direction
is not one of the expected waymark direction, we fall back to calling
the direction along with '???'.

This option makes it easier to align with standard strategies based
around the waymarks.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
