### PR TITLE
raidboss: fix r9s half moon coffin filler filter logic

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r9s.ts
+++ b/ui/raidboss/data/07-dt/raid/r9s.ts
@@ -326,22 +326,22 @@ const triggerSet: TriggerSet<Data> = {
         let dir2Text = output[dir2]!();
 
         if (dir1 === 'dirW') {
-          coffinSafe1 = coffinSafe1.filter((pos) => !westPositions.includes(pos));
+          coffinSafe1 = coffinSafe1.filter((pos) => westPositions.includes(pos));
           dir1Text = output.leftWest!();
         }
 
         if (dir1 === 'dirE') {
-          coffinSafe1 = coffinSafe1.filter((pos) => !eastPositions.includes(pos));
+          coffinSafe1 = coffinSafe1.filter((pos) => eastPositions.includes(pos));
           dir1Text = output.rightEast!();
         }
 
         if (dir2 === 'dirW') {
-          coffinSafe2 = coffinSafe2.filter((pos) => !westPositions.includes(pos));
+          coffinSafe2 = coffinSafe2.filter((pos) => westPositions.includes(pos));
           dir2Text = output.leftWest!();
         }
 
         if (dir2 === 'dirE') {
-          coffinSafe2 = coffinSafe2.filter((pos) => !eastPositions.includes(pos));
+          coffinSafe2 = coffinSafe2.filter((pos) => eastPositions.includes(pos));
           dir2Text = output.rightEast!();
         }
 


### PR DESCRIPTION
The R9S Half Moon trigger tracks the coffinfiller safe spots, and has
some filtering logic to simplify the overall callout to more precise
single safe spots.

The half moon cleave callouts during the end of the coffinmaker phase
are incorrect. This occurs because the filtering of the coffinfiller
safe spots is wrong.

The function checks the safe direction for each hit of the half moon,
and tries to filter the coffin filler safe spot arrays. However, it
incorrectly *removes* the safe side instead of keeping only the safe
side. This appears to have occurred due to refactors which resulted in
flipping what the direction variable meant.

Fix the logic by removing the negation. This makes it more clear: If the
safe spot is west, keep only the safe west coffin filler spots.
Similarly, do the same for the east safe spots when the half moon
safe side is east.

Closes: #962
Reported-by: xumy1995
