### PR TITLE
config: add category for '99-custom' directory

### DIFF
--- a/ui/config/config.ts
+++ b/ui/config/config.ts
@@ -144,6 +144,10 @@ export const kPrefixToCategory = {
     ko: '황금의 유산 (7.x)',
     tc: '黃金遺產 (7.x)',
   },
+  '99-custom': {
+    en: 'Custom Developer Triggers',
+    cn: '自定义开发者触发器',
+  },
   'user': {
     en: 'User Triggers',
     de: 'Benutzer Trigger',


### PR DESCRIPTION
Triggers in the `99-custom` folder will now appear under `Custom Dev Triggers` instead of falling back to `General Triggers`, ensuring the correct override order