### PR TITLE
raidboss: r10s call move or stay after alley-oop hits

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r10s.ts
+++ b/ui/raidboss/data/07-dt/raid/r10s.ts
@@ -545,8 +545,7 @@ const triggerSet: TriggerSet<Data> = {
         return data.snakingDebuff !== 'fire' && data.phase !== 'arenaSplit';
       },
       infoText: (data, matches, output) => {
-        // During snaking and the arena split it is always move since the
-        // baits are too close.
+        // During saking it is always move since the baits are too close.
         if (data.phase === 'snaking')
           return output.move!();
         return matches.id === 'B5E0' ? output.stay!() : output.move!();


### PR DESCRIPTION
During r10s, Deep Blue uses Double-dip Alleyoop or Reverse Alleyoop which
is a 2-part hit mechanic where you need to spread out and then move or
stay to dodge a followup aoe. The duration for the current protean =>
move/stay is only 3 seconds. Add a followup callout after the first hit
resolves indicating when it is safe to move, or functions as a reminder
to stay put.
