### PR TITLE
raidboss: r8s replace Math.abs in Hero's Blow Left cleaves

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r8s.ts
+++ b/ui/raidboss/data/07-dt/raid/r8s.ts
@@ -1643,7 +1643,7 @@ const triggerSet: TriggerSet<Data> = {
 
         switch (matches.id) {
           case 'A45F':
-            data.herosBlowSafeDir = Math.abs(Directions.hdgTo16DirNum(actor.Heading) - 4) % 16;
+            data.herosBlowSafeDir = ((Directions.hdgTo16DirNum(actor.Heading) - 4) + 16) % 16;
             break;
           case 'A461':
             data.herosBlowSafeDir = (Directions.hdgTo16DirNum(actor.Heading) + 4) % 16;


### PR DESCRIPTION
Actually was able to test a similar situation in m12s and found that the issue could happen, albeit less likely in m8s since these possible values are very close to or off the platform.

fixes #752