### PR TITLE
raidboss: fix Meso Terminal cleanse doom trigger

### DIFF
--- a/ui/raidboss/data/07-dt/dungeon/meso-terminal.ts
+++ b/ui/raidboss/data/07-dt/dungeon/meso-terminal.ts
@@ -251,8 +251,9 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Meso Terminal Executioners Death Penalty',
       type: 'GainsEffect',
-      // The effect ID changed in Patch 7.4 from 11F2 to 1441. The old ID is
-      // kept to allow older logs to continue working in the simulator.
+      // The Doom effect ID applied changed from 11F2 in 7.3 to 1441 in 7.4
+      // Both IDs are kept to enable parsing older logs and for regions not
+      // yet on Patch 7.4
       netRegex: { effectId: ['11F2', '1441'], capture: true },
       condition: (data) => data.CanCleanse(),
       alarmText: (_data, matches, output) => output.cleanseDoom!({ target: matches.target }),


### PR DESCRIPTION
The cleanse doom trigger for the Meso Terminal dungeon uses the 11F2
effect ID. This appears to no longer be the ID used for the dungeon (as
of Patch 7.4), as it now comes in the log as 1441. Based on log data
from FFLogs, it appears that the ID changed in Patch 7.4

Update the effectId for Death Penalty to support the new ID. To avoid
issues with parsing legacy log files (for example, in the simulator),
keep the old ID as well.

Fixes #995
