### PR TITLE
raidboss: r11s configurable options

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r11s.ts
+++ b/ui/raidboss/data/07-dt/raid/r11s.ts
@@ -156,7 +156,7 @@ const triggerSet: TriggerSet<Data> = {
         },
         ko: {
           '동/서': 'ew',
-          '남/북': 'ns',
+          '북/남': 'ns',
         },
       },
       default: 'ew',


### PR DESCRIPTION
Configure position options for Majestic Meteowrath and Two-Way Fireball.

This is primarily for the Korean server.

## Majestic Meteowrath
<img width="443" height="442" alt="image" src="https://github.com/user-attachments/assets/3a52e2c1-4a4a-46a6-9694-0c29b89c3732" />

## Two-Way Fireball
<img width="440" height="442" alt="image" src="https://github.com/user-attachments/assets/e474c8d7-96ac-48a9-862d-07021c022679" />

