### PR TITLE
raidboss: r12s p1 blob safe spots

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r12s.ts
+++ b/ui/raidboss/data/07-dt/raid/r12s.ts
@@ -1854,6 +1854,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'R12S Slaughershed Stack/Spread Spots (Early)',
+      // Data available by StartsUsing, trigger on ability 3s after to avoid conflict
       type: 'Ability',
       netRegex: { id: ['B4C6', 'B4C3'], source: 'Lindwurm', capture: false },
       suppressSeconds: 1,


### PR DESCRIPTION
My only comment about it is the curtain call contains two outputs. I had a hard time thinking about a configurator to prefer certain locations, so left it at calling both.

Melee probably would prefer a call that just has northwest or northeast while range would prefer whichever is the shortest distance from them, typically I find this is just the side they are on rather than cutting across east/west.