### PR TITLE
resources: add data.party.isLimitedJob and update triggers

### DIFF
--- a/resources/conditions.ts
+++ b/resources/conditions.ts
@@ -14,14 +14,16 @@ export default {
   caresAboutAOE(): (data: Data) => boolean {
     return (data: Data) =>
       data.role === 'tank' || data.role === 'healer' || data.CanAddle() || data.CanFeint() ||
-      data.job === 'BLU';
+      data.party.isLimitedJob(data.me);
   },
   caresAboutMagical(): (data: Data) => boolean {
     return (data: Data) =>
-      data.role === 'tank' || data.role === 'healer' || data.CanAddle() || data.job === 'BLU';
+      data.role === 'tank' || data.role === 'healer' || data.CanAddle() ||
+      data.party.isLimitedJob(data.me);
   },
   caresAboutPhysical(): (data: Data) => boolean {
     return (data: Data) =>
-      data.role === 'tank' || data.role === 'healer' || data.CanFeint() || data.job === 'BLU';
+      data.role === 'tank' || data.role === 'healer' || data.CanFeint() ||
+      data.party.isLimitedJob(data.me);
   },
 };

--- a/resources/party.ts
+++ b/resources/party.ts
@@ -948,6 +948,12 @@ export default class PartyTracker {
     return this.isRole(name, 'dps');
   }
 
+  // returns true if the named player in your alliance is a limited job
+  isLimitedJob(name: string): boolean {
+    const job = this.jobName(name);
+    return job !== undefined && Util.isLimitedJob(job);
+  }
+
   // returns true if the named player is in your immediate party
   inParty(name: string): boolean {
     return this.partyNames.includes(name);

--- a/resources/party.ts
+++ b/resources/party.ts
@@ -860,6 +860,7 @@ export default class PartyTracker {
   allianceNames_: string[] = [];
   allianceIds_: string[] = [];
   nameToRole_: { [name: string]: Role } = {};
+  nameToJob_: { [name: string]: Job } = {};
   idToName_: { [id: string]: string } = {};
   roleToPartyNames_: Record<Role, string[]> = emptyRoleToPartyNames();
 
@@ -877,6 +878,7 @@ export default class PartyTracker {
       const role = Util.jobToRole(jobName);
       this.idToName_[p.id] = p.name;
       this.nameToRole_[p.name] = role;
+      this.nameToJob_[p.name] = jobName;
       if (p.inParty) {
         this.partyIds_.push(p.id);
         this.partyNames_.push(p.name);
@@ -893,6 +895,7 @@ export default class PartyTracker {
     this.allianceNames_ = [];
     this.allianceIds_ = [];
     this.nameToRole_ = {};
+    this.nameToJob_ = {};
     this.idToName_ = {};
 
     // role -> [names] but only for party
@@ -990,13 +993,7 @@ export default class PartyTracker {
 
   // returns the job name of the specified party member
   jobName(name: string): Job | undefined {
-    const partyIndex = this.partyNames.indexOf(name);
-    if (partyIndex < 0)
-      return;
-    const job = this.details[partyIndex]?.job;
-    if (job === undefined)
-      return;
-    return Util.jobEnumToJob(job);
+    return this.nameToJob_[name];
   }
 
   nameFromId(id: string): string | undefined {

--- a/resources/responses.ts
+++ b/resources/responses.ts
@@ -266,7 +266,7 @@ export const Responses = {
         const target = getTarget(matches);
         if (target === data.me)
           return output.cleaveOnYou?.();
-        if (data.role === 'tank' || data.job === 'BLU') {
+        if (data.role === 'tank' || data.party.isLimitedJob(data.me)) {
           // targetless tank cleave
           // BLU players should always get this generic cleave message.
           // We have no robust way to determine whether they have tank Mimicry on,

--- a/ui/oopsyraidsy/data/03-hw/trial/sephirot-ex.ts
+++ b/ui/oopsyraidsy/data/03-hw/trial/sephirot-ex.ts
@@ -115,7 +115,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       type: 'Ability',
       netRegex: NetRegexes.ability({ id: '1576', source: 'Sephirot' }),
       condition: (data, matches) => {
-        if (data.party.isTank(matches.target) || data.job === 'BLU')
+        if (data.party.isTank(matches.target) || data.party.isLimitedJob(data.me))
           return false;
         return data?.force?.[matches.target] === undefined;
       },

--- a/ui/oopsyraidsy/data/06-ew/trial/sephirot-un.ts
+++ b/ui/oopsyraidsy/data/06-ew/trial/sephirot-un.ts
@@ -115,7 +115,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       type: 'Ability',
       netRegex: NetRegexes.ability({ id: '76A3', source: 'Sephirot' }),
       condition: (data, matches) => {
-        if (data.party.isTank(matches.target) || data.job === 'BLU')
+        if (data.party.isTank(matches.target) || data.party.isLimitedJob(data.me))
           return false;
         return data?.force?.[matches.target] === undefined;
       },

--- a/ui/raidboss/data/00-misc/general.ts
+++ b/ui/raidboss/data/00-misc/general.ts
@@ -6,7 +6,7 @@ import { TriggerSet } from '../../../../types/trigger';
 export type Data = RaidbossData;
 
 const caresAboutTankStuff = (data: RaidbossData) => {
-  return data.role === 'tank' || data.role === 'healer' || data.job === 'BLU';
+  return data.role === 'tank' || data.role === 'healer' || data.party.isLimitedJob(data.me);
 };
 
 // Triggers for all occasions and zones.

--- a/ui/raidboss/data/02-arr/raid/t6.ts
+++ b/ui/raidboss/data/02-arr/raid/t6.ts
@@ -209,7 +209,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'Ability',
       netRegex: { id: '7A0', source: 'Rafflesia' },
       condition: (data, matches) =>
-        data.me === matches.target || data.role === 'healer' || data.job === 'BLU',
+        data.me === matches.target || data.role === 'healer' || data.party.isLimitedJob(data.me),
       alertText: (data, matches, output) => {
         if (matches.target === data.me)
           return output.swarmOnYou!();

--- a/ui/raidboss/data/02-arr/raid/t7.ts
+++ b/ui/raidboss/data/02-arr/raid/t7.ts
@@ -87,7 +87,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'T7 Tail Slap',
       type: 'Ability',
       netRegex: { id: '7A8', source: 'Melusine' },
-      condition: (data, matches) => data.me === matches.target && data.job === 'BLU',
+      condition: (data, matches) => data.me === matches.target && data.party.isLimitedJob(data.me),
       delaySeconds: 6,
       suppressSeconds: 5,
       infoText: (_data, _matches, output) => output.text!(),

--- a/ui/raidboss/data/02-arr/trial/ultima-ex.ts
+++ b/ui/raidboss/data/02-arr/trial/ultima-ex.ts
@@ -71,7 +71,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Ultima EX Viscous Aetheroplasm',
       type: 'GainsEffect',
       netRegex: { effectId: '171', count: '04', capture: false },
-      condition: (data) => data.role === 'tank' || data.job === 'BLU',
+      condition: (data) => data.role === 'tank' || data.party.isLimitedJob(data.me),
       alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: Outputs.tankSwap,

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.ts
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.ts
@@ -295,7 +295,8 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Weeping City Flare Star Orbs',
       type: 'AddedCombatant',
       netRegex: { npcBaseId: '4889', capture: false },
-      condition: (data) => data.role === 'tank' || data.role === 'healer' || data.job === 'BLU',
+      condition: (data) =>
+        data.role === 'tank' || data.role === 'healer' || data.party.isLimitedJob(data.me),
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/03-hw/dungeon/the_lost_city_of_amdapor_hard.ts
+++ b/ui/raidboss/data/03-hw/dungeon/the_lost_city_of_amdapor_hard.ts
@@ -239,7 +239,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'LostCityHard Kuribu Regen',
       type: 'StartsUsing',
       netRegex: { id: '15DC', source: 'Kuribu', capture: false },
-      condition: (data) => data.role === 'tank' || data.job === 'BLU',
+      condition: (data) => data.role === 'tank' || data.party.isLimitedJob(data.me),
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/03-hw/raid/a10s.ts
+++ b/ui/raidboss/data/03-hw/raid/a10s.ts
@@ -195,7 +195,7 @@ const triggerSet: TriggerSet<Data> = {
         if (data.role === 'tank')
           return output.tankSwap!();
 
-        if (data.role === 'healer' || data.job === 'BLU')
+        if (data.role === 'healer' || data.party.isLimitedJob(data.me))
           return output.shieldPlayer!({ player: data.party.member(matches.target) });
       },
       outputStrings: {

--- a/ui/raidboss/data/03-hw/raid/a11s.ts
+++ b/ui/raidboss/data/03-hw/raid/a11s.ts
@@ -299,7 +299,7 @@ const triggerSet: TriggerSet<Data> = {
         if (data.me === matches.target)
           return output.sharedTankbusterOnYou!();
 
-        if (data.role === 'tank' || data.role === 'healer' || data.job === 'BLU')
+        if (data.role === 'tank' || data.role === 'healer' || data.party.isLimitedJob(data.me))
           return output.sharedTankbusterOn!({ player: data.party.member(matches.target) });
       },
       outputStrings: {

--- a/ui/raidboss/data/03-hw/raid/a12s.ts
+++ b/ui/raidboss/data/03-hw/raid/a12s.ts
@@ -77,7 +77,7 @@ const triggerSet: TriggerSet<Data> = {
         if (data.scourge.length > 2)
           return false;
 
-        return data.role === 'healer' || data.job === 'BLU';
+        return data.role === 'healer' || data.party.isLimitedJob(data.me);
       },
       delaySeconds: 0.5,
       suppressSeconds: 1,

--- a/ui/raidboss/data/03-hw/raid/a2s.ts
+++ b/ui/raidboss/data/03-hw/raid/a2s.ts
@@ -60,7 +60,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'A2S Prey',
       type: 'Ability',
       netRegex: { source: 'Magitek Gobwidow G-IX', id: '1413' },
-      condition: (data) => data.role === 'healer' || data.job === 'BLU',
+      condition: (data) => data.role === 'healer' || data.party.isLimitedJob(data.me),
       suppressSeconds: 10,
       infoText: (data, matches, output) =>
         output.text!({ player: data.party.member(matches.target) }),

--- a/ui/raidboss/data/03-hw/raid/a3s.ts
+++ b/ui/raidboss/data/03-hw/raid/a3s.ts
@@ -33,7 +33,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'A3S Hand of Stuff',
       regex: /Hand of Prayer\/Parting/,
       beforeSeconds: 5,
-      condition: (data) => data.role === 'tank' || data.job === 'BLU',
+      condition: (data) => data.role === 'tank' || data.party.isLimitedJob(data.me),
       suppressSeconds: 1,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
@@ -300,7 +300,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'A3S Embolus',
       type: 'Ability',
       netRegex: { source: 'Living Liquid', id: 'F1B', capture: false },
-      condition: (data) => data.role === 'tank' || data.job === 'BLU',
+      condition: (data) => data.role === 'tank' || data.party.isLimitedJob(data.me),
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/03-hw/raid/a5s.ts
+++ b/ui/raidboss/data/03-hw/raid/a5s.ts
@@ -146,7 +146,7 @@ const triggerSet: TriggerSet<Data> = {
       condition: (data, matches) => {
         if (data.me !== matches.target)
           return false;
-        return data.role !== 'tank' && data.job === 'BLU';
+        return data.role !== 'tank' && data.party.isLimitedJob(data.me);
       },
       response: Responses.tankBusterSwap('info'),
     },

--- a/ui/raidboss/data/03-hw/raid/a6n.ts
+++ b/ui/raidboss/data/03-hw/raid/a6n.ts
@@ -22,14 +22,16 @@ const triggerSet: TriggerSet<Data> = {
       id: 'A6N Brute Force',
       regex: /Brute Force/,
       beforeSeconds: 4,
-      condition: (data) => data.role === 'tank' || data.role === 'healer' || data.job === 'BLU',
+      condition: (data) =>
+        data.role === 'tank' || data.role === 'healer' || data.party.isLimitedJob(data.me),
       response: Responses.miniBuster(),
     },
     {
       id: 'A6N Magicked Mark',
       regex: /Magicked Mark/,
       beforeSeconds: 4,
-      condition: (data) => data.role === 'tank' || data.role === 'healer' || data.job === 'BLU',
+      condition: (data) =>
+        data.role === 'tank' || data.role === 'healer' || data.party.isLimitedJob(data.me),
       response: Responses.miniBuster(),
     },
   ],

--- a/ui/raidboss/data/03-hw/raid/a8n.ts
+++ b/ui/raidboss/data/03-hw/raid/a8n.ts
@@ -94,7 +94,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'A8N Execution',
       type: 'Ability',
       netRegex: { source: 'Onslaughter', id: '1632', capture: false },
-      condition: (data) => data.role === 'dps' || data.job === 'BLU',
+      condition: (data) => data.role === 'dps' || data.party.isLimitedJob(data.me),
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/03-hw/raid/a8s.ts
+++ b/ui/raidboss/data/03-hw/raid/a8s.ts
@@ -135,7 +135,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'A8S Execution',
       type: 'Ability',
       netRegex: { source: 'Onslaughter', id: '1632', capture: false },
-      condition: (data) => data.role === 'dps' || data.job === 'BLU',
+      condition: (data) => data.role === 'dps' || data.party.isLimitedJob(data.me),
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -652,6 +652,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'A8S Verdict Max HP Blu Devour',
       type: 'GainsEffect',
       netRegex: { effectId: '407' },
+      // This trigger is intended only for Blue Mage, so do not use `data.party.isLimitedJob` here.
       condition: (data, matches) => data.me === matches.target && data.job === 'BLU',
       delaySeconds: 27,
       alarmText: (_data, _matches, output) => output.text!(),

--- a/ui/raidboss/data/04-sb/alliance/orbonne_monastery.ts
+++ b/ui/raidboss/data/04-sb/alliance/orbonne_monastery.ts
@@ -389,7 +389,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Orbonne Cid Cleansing Strike',
       type: 'Ability',
       netRegex: { id: '3751', source: 'The Thunder God', capture: false },
-      condition: (data) => data.role === 'healer' || data.job === 'BLU',
+      condition: (data) => data.role === 'healer' || data.party.isLimitedJob(data.me),
       suppressSeconds: 10,
       alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {
@@ -625,7 +625,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Orbonne Ultima Ultimate Illusion Healer',
       type: 'StartsUsing',
       netRegex: { id: '3895', source: 'Ultima, The High Seraph', capture: false },
-      condition: (data) => data.role === 'healer' || data.job === 'BLU',
+      condition: (data) => data.role === 'healer' || data.party.isLimitedJob(data.me),
       alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/04-sb/dungeon/temple_of_the_fist.ts
+++ b/ui/raidboss/data/04-sb/dungeon/temple_of_the_fist.ts
@@ -118,7 +118,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Temple Touch Of Slaughter',
       type: 'StartsUsing',
       netRegex: { id: '1FE6', source: 'Ivon Coeurlfist' },
-      condition: (data) => data.role === 'healer' || data.job === 'BLU',
+      condition: (data) => data.role === 'healer' || data.party.isLimitedJob(data.me),
       infoText: (data, matches, output) =>
         output.text!({ player: data.party.member(matches.target) }),
       outputStrings: {

--- a/ui/raidboss/data/04-sb/raid/o11n.ts
+++ b/ui/raidboss/data/04-sb/raid/o11n.ts
@@ -18,7 +18,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'O11N Blaster',
       regex: /Blaster/,
       beforeSeconds: 3,
-      condition: (data) => data.role === 'tank' || data.job === 'BLU',
+      condition: (data) => data.role === 'tank' || data.party.isLimitedJob(data.me),
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/04-sb/raid/o12n.ts
+++ b/ui/raidboss/data/04-sb/raid/o12n.ts
@@ -63,7 +63,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'O12N Local Resonance',
       type: 'GainsEffect',
       netRegex: { target: 'Omega', effectId: '67E', capture: false },
-      condition: (data) => data.role === 'tank' || data.job === 'BLU',
+      condition: (data) => data.role === 'tank' || data.party.isLimitedJob(data.me),
       alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/04-sb/raid/o12s.ts
+++ b/ui/raidboss/data/04-sb/raid/o12s.ts
@@ -216,7 +216,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'O12S Shield Blades Setup',
       type: 'Ability',
       netRegex: { id: ['3350', '3351'], source: ['Omega', 'Omega-M'], capture: false },
-      condition: (data) => data.role === 'tank' || data.job === 'BLU',
+      condition: (data) => data.role === 'tank' || data.party.isLimitedJob(data.me),
       suppressSeconds: 1,
       infoText: (_data, _matches, output) => output.text!(),
       run: (data) => delete data.weaponPhase,
@@ -496,7 +496,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'StartsUsing',
       netRegex: { id: '3364', source: 'Omega', capture: false },
       infoText: (data, _matches, output) => {
-        if (data.role === 'tank' || data.job === 'BLU')
+        if (data.role === 'tank' || data.party.isLimitedJob(data.me))
           return output.monitorsLeft!();
 
         return output.dodgeLeft!();
@@ -527,7 +527,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'StartsUsing',
       netRegex: { id: '3365', source: 'Omega', capture: false },
       infoText: (data, _matches, output) => {
-        if (data.role === 'tank' || data.job === 'BLU')
+        if (data.role === 'tank' || data.party.isLimitedJob(data.me))
           return output.monitorsRight!();
 
         return output.dodgeRight!();
@@ -564,7 +564,7 @@ const triggerSet: TriggerSet<Data> = {
       infoText: (data, matches, output) => {
         if (data.me === matches.target)
           return;
-        if (data.role !== 'tank' && data.job !== 'BLU')
+        if (data.role !== 'tank' && !data.party.isLimitedJob(data.me))
           return;
         return output.vulnOn!({ player: data.party.member(matches.target) });
       },
@@ -713,7 +713,7 @@ const triggerSet: TriggerSet<Data> = {
           // It can be useful to know who has the short stack because they
           // might need an extra shield.  However, common blu strats have
           // folks diamondback this, so it's just noise.
-          if (data.job !== 'BLU')
+          if (!data.party.isLimitedJob(data.me))
             return output.shortStackOn!({ player: data.party.member(matches.target) });
         }
         return;

--- a/ui/raidboss/data/04-sb/raid/o1n.ts
+++ b/ui/raidboss/data/04-sb/raid/o1n.ts
@@ -65,7 +65,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'O1N Charybdis',
       type: 'StartsUsing',
       netRegex: { id: '23DB', source: 'Alte Roite', capture: false },
-      condition: (data) => data.role === 'healer' || data.job === 'BLU',
+      condition: (data) => data.role === 'healer' || data.party.isLimitedJob(data.me),
       // Alert rather than info, as any further raid damage is lethal if unhealed.
       response: Responses.hpTo1Aoe('alert'),
     },

--- a/ui/raidboss/data/04-sb/raid/o2s.ts
+++ b/ui/raidboss/data/04-sb/raid/o2s.ts
@@ -187,7 +187,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'O2S Elevated',
       type: 'GainsEffect',
       netRegex: { effectId: '54E', capture: false },
-      condition: (data) => data.job !== 'BLU',
+      condition: (data) => !data.party.isLimitedJob(data.me),
       alarmText: (data, _matches, output) => {
         if (data.role.startsWith('dps') && !data.levitating)
           return output.dpsLevitate!();
@@ -237,7 +237,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'O2S Maniacal Probe',
       type: 'StartsUsing',
       netRegex: { id: '235A', source: 'Catastrophe', capture: false },
-      condition: (data) => data.job !== 'BLU',
+      condition: (data) => !data.party.isLimitedJob(data.me),
       alertText: (data, _matches, output) => {
         if (data.myProbe) {
           if (!data.dpsProbe)

--- a/ui/raidboss/data/04-sb/raid/o9n.ts
+++ b/ui/raidboss/data/04-sb/raid/o9n.ts
@@ -25,7 +25,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'O9N Orbs Fiend',
       type: 'StartsUsing',
       netRegex: { id: '315C', source: 'Chaos', capture: false },
-      condition: (data) => data.role === 'tank' || data.job === 'BLU',
+      condition: (data) => data.role === 'tank' || data.party.isLimitedJob(data.me),
       alarmText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/04-sb/raid/o9s.ts
+++ b/ui/raidboss/data/04-sb/raid/o9s.ts
@@ -108,7 +108,7 @@ const triggerSet: TriggerSet<Data> = {
           return output.orbTethers!();
       },
       infoText: (data, _matches, output) => {
-        if (data.role === 'healer' || data.job === 'BLU')
+        if (data.role === 'healer' || data.party.isLimitedJob(data.me))
           return output.orbTethers!();
       },
       outputStrings: {
@@ -406,7 +406,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'O9S Accretion',
       type: 'GainsEffect',
       netRegex: { effectId: '644', capture: false },
-      condition: (data) => data.role === 'healer' || data.job === 'BLU',
+      condition: (data) => data.role === 'healer' || data.party.isLimitedJob(data.me),
       suppressSeconds: 10,
       infoText: (data, _matches, output) => {
         if (data.phaseType !== 'earth')

--- a/ui/raidboss/data/04-sb/raid/o9s.ts
+++ b/ui/raidboss/data/04-sb/raid/o9s.ts
@@ -92,7 +92,7 @@ const triggerSet: TriggerSet<Data> = {
           return output.orbTethers!();
       },
       infoText: (data, _matches, output) => {
-        if (data.role === 'healer' || data.job === 'BLU')
+        if (data.role === 'healer' || data.party.isLimitedJob(data.me))
           return output.orbTethers!();
       },
       outputStrings: {
@@ -390,7 +390,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'O9S Accretion',
       type: 'GainsEffect',
       netRegex: { effectId: '644', capture: false },
-      condition: (data) => data.role === 'healer' || data.job === 'BLU',
+      condition: (data) => data.role === 'healer' || data.party.isLimitedJob(data.me),
       suppressSeconds: 10,
       infoText: (data, _matches, output) => {
         if (data.phaseType !== 'earth')

--- a/ui/raidboss/data/04-sb/trial/byakko-ex.ts
+++ b/ui/raidboss/data/04-sb/trial/byakko-ex.ts
@@ -110,7 +110,7 @@ const triggerSet: TriggerSet<Data> = {
         if (data.roarCount !== 2)
           return;
 
-        if (data.role === 'tank' || data.job === 'BLU')
+        if (data.role === 'tank' || data.party.isLimitedJob(data.me))
           return output.text!();
       },
       outputStrings: {
@@ -199,7 +199,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'ByakkoEx Tiger Add',
       type: 'BattleTalk2',
       netRegex: { instanceContentTextId: '48AE', capture: false },
-      condition: (data) => data.role === 'tank' || data.job === 'BLU',
+      condition: (data) => data.role === 'tank' || data.party.isLimitedJob(data.me),
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/04-sb/trial/seiryu-ex.ts
+++ b/ui/raidboss/data/04-sb/trial/seiryu-ex.ts
@@ -37,7 +37,7 @@ const triggerSet: TriggerSet<Data> = {
       regex: /Kanabo/,
       beforeSeconds: 7,
       alertText: (data, _matches, output) => {
-        if (data.role === 'tank' || data.job === 'BLU')
+        if (data.role === 'tank' || data.party.isLimitedJob(data.me))
           return output.grabTether!();
         return output.avoidTether!();
       },

--- a/ui/raidboss/data/05-shb/hunts/the_raktika_greatwood.ts
+++ b/ui/raidboss/data/05-shb/hunts/the_raktika_greatwood.ts
@@ -99,7 +99,8 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Hunt Ixtab Cryptcall',
       type: 'Ability',
       netRegex: { id: '45B7', source: 'Ixtab', capture: false },
-      condition: (data) => data.inCombat && (data.role === 'healer' || data.job === 'BLU'),
+      condition: (data) =>
+        data.inCombat && (data.role === 'healer' || data.party.isLimitedJob(data.me)),
       suppressSeconds: 1,
       alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {

--- a/ui/raidboss/data/05-shb/raid/e12s.ts
+++ b/ui/raidboss/data/05-shb/raid/e12s.ts
@@ -333,7 +333,7 @@ const triggerSet: TriggerSet<Data> = {
             ko: '탱버 + 교대',
             tc: '死刑 + 換坦',
           },
-          formlessBusterBLU: {
+          formlessBusterLimitedJob: {
             en: 'Buster on YOU (w/${player})',
             de: 'Tankbuster auf DIR (mit ${player})',
             fr: 'Tankbuster sur VOUS (avec ${player})',
@@ -364,11 +364,11 @@ const triggerSet: TriggerSet<Data> = {
         if (data.role === 'tank')
           return { alertText: output.formlessBusterAndSwap!() };
 
-        // BLU tends to avail here, so call out your friend.
-        if (data.job === 'BLU') {
+        // LimitedJob tends to avail here, so call out your friend.
+        if (data.party.isLimitedJob(data.me)) {
           const [otherPlayer] = data.formlessTargets.filter((x) => x !== data.me);
           return {
-            alertText: output.formlessBusterBLU!({ player: data.party.member(otherPlayer) }),
+            alertText: output.formlessBusterLimitedJob!({ player: data.party.member(otherPlayer) }),
           };
         }
 

--- a/ui/raidboss/data/05-shb/raid/e8s.ts
+++ b/ui/raidboss/data/05-shb/raid/e8s.ts
@@ -401,7 +401,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'E8S Forgetful Tank Second Frost',
       type: 'StartsUsing',
       netRegex: { source: 'Shiva', id: '4D6[67]', capture: false },
-      condition: (data) => data.role === 'tank' || data.job === 'BLU',
+      condition: (data) => data.role === 'tank' || data.party.isLimitedJob(data.me),
       delaySeconds: 43,
       suppressSeconds: 80,
       infoText: (data, _matches, output) => {
@@ -1208,7 +1208,7 @@ const triggerSet: TriggerSet<Data> = {
       condition: (data) => Util.canCleanse(data.job),
       suppressSeconds: 1,
       infoText: (data, _matches, output) => {
-        if (data.job === 'BLU')
+        if (data.party.isLimitedJob(data.me))
           return output.bluCleanse!();
         return output.cleanseOnlyDPS!();
       },

--- a/ui/raidboss/data/05-shb/trial/hades-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/hades-ex.ts
@@ -28,7 +28,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'HadesEx Comet',
       regex: /Comet 1/,
       beforeSeconds: 5,
-      condition: (data) => data.role === 'tank' || data.job === 'BLU',
+      condition: (data) => data.role === 'tank' || data.party.isLimitedJob(data.me),
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -252,7 +252,7 @@ const triggerSet: TriggerSet<Data> = {
         target: ['Igeyorhm\'s Shade', 'Lahabrea\'s Shade'],
         capture: false,
       },
-      condition: (data) => data.role === 'tank' || data.job === 'BLU',
+      condition: (data) => data.role === 'tank' || data.party.isLimitedJob(data.me),
       suppressSeconds: 10,
       alarmText: (_data, _matches, output) => output.text!(),
       outputStrings: {
@@ -271,7 +271,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'HadesEx Spheres',
       type: 'StartsUsing',
       netRegex: { id: '47BD', source: 'Igeyorhm\'s Shade', capture: false },
-      condition: (data) => data.role === 'tank' || data.job === 'BLU',
+      condition: (data) => data.role === 'tank' || data.party.isLimitedJob(data.me),
       infoText: (data, _matches, output) => {
         if (!data.sphereCount)
           return;
@@ -368,7 +368,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'HadesEx Doom',
       type: 'GainsEffect',
       netRegex: { effectId: '6E9', capture: false },
-      condition: (data) => data.role === 'healer' || data.job === 'BLU',
+      condition: (data) => data.role === 'healer' || data.party.isLimitedJob(data.me),
       suppressSeconds: 5,
       alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {
@@ -681,10 +681,11 @@ const triggerSet: TriggerSet<Data> = {
       id: 'HadesEx Quadrastrike 2',
       type: 'StartsUsing',
       netRegex: { id: '47F6', source: 'Hades', capture: false },
-      condition: (data) => data.role === 'tank' || data.role === 'healer' || data.job === 'BLU',
+      condition: (data) =>
+        data.role === 'tank' || data.role === 'healer' || data.party.isLimitedJob(data.me),
       suppressSeconds: 2,
       alarmText: (data, _matches, output) => {
-        if (data.role === 'tank' || data.job === 'BLU')
+        if (data.role === 'tank' || data.party.isLimitedJob(data.me))
           return output.getTowers!();
       },
       infoText: (data, _matches, output) => {

--- a/ui/raidboss/data/05-shb/trial/innocence-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/innocence-ex.ts
@@ -194,7 +194,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'InnoEx Adds',
       type: 'Ability',
       netRegex: { id: '42B0', source: 'Innocence', capture: false },
-      condition: (data) => data.role === 'tank' || data.job === 'BLU',
+      condition: (data) => data.role === 'tank' || data.party.isLimitedJob(data.me),
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/05-shb/trial/ruby_weapon-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/ruby_weapon-ex.ts
@@ -260,7 +260,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'StartsUsing',
       netRegex: { source: 'Raven\'s Image', id: '4AFF' },
       condition: (data, matches) => {
-        if (data.role === 'dps' && data.job !== 'BLU')
+        if (data.role === 'dps' && !data.party.isLimitedJob(data.me))
           return false;
         const myColor = data.colors?.[data.me];
         if (myColor !== undefined && myColor === data.colors?.[matches.target])
@@ -556,7 +556,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'RubyEx Mark II Magitek Comet Tank',
       type: 'Ability',
       netRegex: { source: 'The Ruby Weapon', id: '4AB6', capture: false },
-      condition: (data) => data.role === 'tank' || data.job === 'BLU',
+      condition: (data) => data.role === 'tank' || data.party.isLimitedJob(data.me),
       delaySeconds: 11.5,
       alarmText: (_data, _matches, output) => output.text!(),
       outputStrings: {

--- a/ui/raidboss/data/05-shb/trial/ruby_weapon.ts
+++ b/ui/raidboss/data/05-shb/trial/ruby_weapon.ts
@@ -160,7 +160,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'StartsUsing',
       netRegex: { source: 'Raven\'s Image', id: '4ABF' },
       condition: (data, matches) => {
-        if (data.role === 'dps' && data.job !== 'BLU')
+        if (data.role === 'dps' && !data.party.isLimitedJob(data.me))
           return false;
         const myColor = data.colors?.[data.me];
         return myColor !== undefined && myColor === data.colors?.[matches.target];

--- a/ui/raidboss/data/05-shb/trial/titania-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/titania-ex.ts
@@ -248,7 +248,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'TitaniaEx Pummel',
       type: 'StartsUsing',
       netRegex: { id: '3D37', source: 'Puck', capture: false },
-      condition: (data) => data.role === 'tank' || data.job === 'BLU',
+      condition: (data) => data.role === 'tank' || data.party.isLimitedJob(data.me),
       preRun: (data) => {
         data.pummelCount ??= 0;
         data.pummelCount++;

--- a/ui/raidboss/data/05-shb/trial/titania.ts
+++ b/ui/raidboss/data/05-shb/trial/titania.ts
@@ -156,7 +156,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'Ability',
       netRegex: { id: '3D31', source: 'Titania', capture: false },
       infoText: (data, _matches, output) => {
-        if (data.role === 'tank' || data.job === 'BLU')
+        if (data.role === 'tank' || data.party.isLimitedJob(data.me))
           return output.groupAddsEastOnMustardseed!();
 
         return output.killMustardseedEast!();

--- a/ui/raidboss/data/05-shb/trial/varis-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/varis-ex.ts
@@ -144,7 +144,7 @@ const triggerSet: TriggerSet<Data> = {
         if (data.me === target)
           return output.tankBusterOnYou!();
 
-        if (data.role === 'dps' && data.job !== 'BLU')
+        if (data.role === 'dps' && !data.party.isLimitedJob(data.me))
           return output.avoidTankCleave!();
 
         return output.tankBusterOn!({ player: data.party.member(target) });

--- a/ui/raidboss/data/05-shb/trial/wol-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/wol-ex.ts
@@ -145,7 +145,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'WOLEx Terror Unleashed',
       type: 'Ability',
       netRegex: { source: 'Warrior Of Light', id: '4F09', capture: false },
-      condition: (data) => data.role === 'healer' || data.job === 'BLU',
+      condition: (data) => data.role === 'healer' || data.party.isLimitedJob(data.me),
       suppressSeconds: 5,
       alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {
@@ -392,7 +392,7 @@ const triggerSet: TriggerSet<Data> = {
       // This is still 1 second before this cast goes off, giving ~7 seconds before LB is needed.
       delaySeconds: 4,
       alarmText: (data, _matches, output) => {
-        if (data.role === 'tank' || data.job === 'BLU')
+        if (data.role === 'tank' || data.party.isLimitedJob(data.me))
           return output.text!();
       },
       run: (data) => {

--- a/ui/raidboss/data/05-shb/trial/wol.ts
+++ b/ui/raidboss/data/05-shb/trial/wol.ts
@@ -18,7 +18,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'WOL Ultimate Crossover',
       regex: /Ultimate Crossover/,
       beforeSeconds: 8,
-      condition: (data) => data.role === 'tank' || data.job === 'BLU',
+      condition: (data) => data.role === 'tank' || data.party.isLimitedJob(data.me),
       alarmText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -56,7 +56,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'WOL Terror Unleashed',
       type: 'Ability',
       netRegex: { source: 'Warrior Of Light', id: '4F27', capture: false },
-      condition: (data) => data.role === 'healer' || data.job === 'BLU',
+      condition: (data) => data.role === 'healer' || data.party.isLimitedJob(data.me),
       suppressSeconds: 5,
       alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {

--- a/ui/raidboss/data/06-ew/alliance/thaleia.ts
+++ b/ui/raidboss/data/06-ew/alliance/thaleia.ts
@@ -127,7 +127,7 @@ const triggerSet: TriggerSet<Data> = {
           return;
         if (!data.busterTargets.includes(data.me))
           return { infoText: output.tankCleaves!() };
-        if (data.role !== 'tank' && data.job !== 'BLU')
+        if (data.role !== 'tank' && !data.party.isLimitedJob(data.me))
           return { alarmText: output.tankCleaveOnYou!() };
         return { alertText: output.tankCleaveOnYou!() };
       },
@@ -395,7 +395,7 @@ const triggerSet: TriggerSet<Data> = {
           return;
         if (!data.busterTargets.includes(data.me))
           return { infoText: output.tankCleaves!() };
-        if (data.role !== 'tank' && data.job !== 'BLU')
+        if (data.role !== 'tank' && !data.party.isLimitedJob(data.me))
           return { alarmText: output.tankCleaveOnYou!() };
         return { alertText: output.tankCleaveOnYou!() };
       },

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.ts
@@ -926,7 +926,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'ASSS Hells\' Nebula',
       type: 'StartsUsing',
       netRegex: { id: '7984', source: 'Sil\'dihn Armor', capture: false },
-      condition: (data) => data.role === 'healer' || data.job === 'BLU',
+      condition: (data) => data.role === 'healer' || data.party.isLimitedJob(data.me),
       response: Responses.hpTo1Aoe(),
     },
     {

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
@@ -921,7 +921,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'ASS Hells\' Nebula',
       type: 'StartsUsing',
       netRegex: { id: '796C', source: 'Sil\'dihn Armor', capture: false },
-      condition: (data) => data.role === 'healer' || data.job === 'BLU',
+      condition: (data) => data.role === 'healer' || data.party.isLimitedJob(data.me),
       response: Responses.hpTo1Aoe(),
     },
     {

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -2030,7 +2030,7 @@ const triggerSet: TriggerSet<Data> = {
           return { alertText: output.cleaveOnYou!() };
         if (data.role === 'tank')
           return { alertText: output.cleaveSwap!() };
-        if (data.role === 'healer' || data.job === 'BLU')
+        if (data.role === 'healer' || data.party.isLimitedJob(data.me))
           return { alertText: output.tankBusterCleaves!() };
         return { infoText: output.avoidTankCleaves!() };
       },
@@ -2051,7 +2051,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'P12S Glaukopis Second Cleave Swap',
       type: 'Ability',
       netRegex: { id: '82FD', source: 'Athena', capture: false },
-      condition: (data) => data.role === 'tank' || data.job === 'BLU',
+      condition: (data) => data.role === 'tank' || data.party.isLimitedJob(data.me),
       delaySeconds: 0.1,
       suppressSeconds: 1,
       alertText: (data, _matches, output) => {
@@ -4310,7 +4310,7 @@ const triggerSet: TriggerSet<Data> = {
 
         if (data.palladionGrapsTarget === data.me)
           return { alertText: output.tankBusterCleavesOnYou!() };
-        if (data.role === 'tank' || data.role === 'healer' || data.job === 'BLU')
+        if (data.role === 'tank' || data.role === 'healer' || data.party.isLimitedJob(data.me))
           return { alertText: output.tankBusterCleaves!() };
         return { infoText: output.avoidTankCleaves!() };
       },

--- a/ui/raidboss/data/06-ew/raid/p3n.ts
+++ b/ui/raidboss/data/06-ew/raid/p3n.ts
@@ -121,7 +121,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { name: 'Sunbird', capture: false },
       suppressSeconds: 1,
       alertText: (data, _matches, output) => {
-        if (data.role === 'tank' || data.job === 'BLU')
+        if (data.role === 'tank' || data.party.isLimitedJob(data.me))
           return output.tank!();
         return output.text!();
       },

--- a/ui/raidboss/data/06-ew/raid/p9n.ts
+++ b/ui/raidboss/data/06-ew/raid/p9n.ts
@@ -177,7 +177,7 @@ const triggerSet: TriggerSet<Data> = {
         if (data.me === matches.target)
           return output.tankbusterOnYouStretchTethers!();
 
-        if (data.role === 'healer' || data.job === 'BLU')
+        if (data.role === 'healer' || data.party.isLimitedJob(data.me))
           return output.tankbusterOn!({ player: data.party.member(matches.target) });
       },
       outputStrings: {

--- a/ui/raidboss/data/06-ew/raid/p9s.ts
+++ b/ui/raidboss/data/06-ew/raid/p9s.ts
@@ -157,7 +157,7 @@ const triggerSet: TriggerSet<Data> = {
         };
 
         if (data.dualityBuster.includes(data.me)) {
-          if (data.role !== 'tank' && data.job !== 'BLU')
+          if (data.role !== 'tank' && !data.party.isLimitedJob(data.me))
             return { alarmText: output.tankBusterOnYou!() };
           return { alertText: output.tankSwap!() };
         }

--- a/ui/raidboss/data/06-ew/trial/endsinger.ts
+++ b/ui/raidboss/data/06-ew/trial/endsinger.ts
@@ -290,7 +290,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'StartsUsing',
       netRegex: { id: '6B59', source: 'The Endsinger', capture: false },
       alarmText: (data, _matches, output) => {
-        if (data.role === 'tank' || data.job === 'BLU')
+        if (data.role === 'tank' || data.party.isLimitedJob(data.me))
           return output.text!();
       },
       outputStrings: {

--- a/ui/raidboss/data/06-ew/trial/golbez-ex.ts
+++ b/ui/raidboss/data/06-ew/trial/golbez-ex.ts
@@ -137,7 +137,7 @@ const triggerSet: TriggerSet<Data> = {
       condition: (data, matches) => {
         if (data.me === matches.target)
           return false;
-        return data.role === 'tank' || data.job === 'BLU';
+        return data.role === 'tank' || data.party.isLimitedJob(data.me);
       },
       suppressSeconds: 10,
       alertText: (_data, _matches, output) => output.text!(),

--- a/ui/raidboss/data/07-dt/trial/byakko-un.ts
+++ b/ui/raidboss/data/07-dt/trial/byakko-un.ts
@@ -115,7 +115,7 @@ const triggerSet: TriggerSet<Data> = {
         if (data.roarCount !== 2)
           return;
 
-        if (data.role === 'tank' || data.job === 'BLU')
+        if (data.role === 'tank' || data.party.isLimitedJob(data.me))
           return output.text!();
       },
       outputStrings: {
@@ -204,7 +204,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'ByakkoUn Tiger Add',
       type: 'BattleTalk2',
       netRegex: { instanceContentTextId: '48AE', capture: false },
-      condition: (data) => data.role === 'tank' || data.job === 'BLU',
+      condition: (data) => data.role === 'tank' || data.party.isLimitedJob(data.me),
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/07-dt/trial/seiryu-un.ts
+++ b/ui/raidboss/data/07-dt/trial/seiryu-un.ts
@@ -42,7 +42,7 @@ const triggerSet: TriggerSet<Data> = {
       regex: /Kanabo/,
       beforeSeconds: 7,
       alertText: (data, _matches, output) => {
-        if (data.role === 'tank' || data.job === 'BLU')
+        if (data.role === 'tank' || data.party.isLimitedJob(data.me))
           return output.grabTether!();
         return output.avoidTether!();
       },


### PR DESCRIPTION
Triggers written for Blue Mages are now modified to function for all Limited Job targets.
I also included a refactoring that adds `nameToJob_` to PartyTracker.
