### PR TITLE
raidboss: add timeline reset for Jueno: The First Walk

### DIFF
--- a/ui/raidboss/data/07-dt/alliance/jeuno-first-walk.txt
+++ b/ui/raidboss/data/07-dt/alliance/jeuno-first-walk.txt
@@ -4,6 +4,11 @@
 hideall "--Reset--"
 hideall "--sync--"
 
+0.0 "--Reset--" ActorControl { command: "4000000F" } window 0,1000000 jump 0
+
+# .*is no longer sealed
+0.0 "--Reset--" SystemLogMessage { id: "7DE" } window 0,1000000 jump 0
+
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 # Prishe Of The Distant Chains #
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#


### PR DESCRIPTION
The timeline for the Jueno alliance raid doesn't have a reset entry to
pause the timeline upon fights ending. This results in the timeline
continuing even as the fight ends. I think this also results in the
timelines failing to reset if the party wipes.

Other alliance raids do seem to have the appropriate reset lines, so add
them to the Jueno timeline.
