### PR TITLE
ci: Update actions to latest versions

### DIFF
--- a/.github/scripts/npm-package.cjs
+++ b/.github/scripts/npm-package.cjs
@@ -10,7 +10,7 @@ const pkg = require('../../package.json');
 
 const projectRoot = path.join(__dirname, '..', '..');
 
-const npmrc = '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}\nalways-auth=true';
+const npmrc = '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}';
 
 async function main() {
   // force pwd to at .../cactbot/

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -31,7 +31,7 @@ jobs:
   msbuild:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-js-env
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Check dependencies cache
         id: cache-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ./plugin/ThirdParty
           key: |
@@ -57,7 +57,7 @@ jobs:
           npm run fetch-deps
 
       - name: Set up msbuild
-        uses: microsoft/setup-msbuild@v1
+        uses: microsoft/setup-msbuild@v3
 
       - name: Add Custom Problem Matcher
         run: |
@@ -76,7 +76,7 @@ jobs:
         run: ./util/publish.sh
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cactbot-${{ env.artifact_sha }}
           path: publish/cactbot-release/

--- a/.github/workflows/css-lint.yml
+++ b/.github/workflows/css-lint.yml
@@ -20,7 +20,7 @@ jobs:
   stylelint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-js-env
 

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -26,7 +26,7 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-js-env
 

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -73,7 +73,7 @@ jobs:
     needs: job_picker
     if: needs.job_picker.outputs.run == 'pr_review'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Force checkout the main repo (base branch) so that repo secrets
           # are not available to unexpected/malicious PR code.
@@ -104,7 +104,7 @@ jobs:
     needs: job_picker
     if: needs.job_picker.outputs.run == 'push_commit'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Force checkout the main repo (base branch) so that repo secrets
           # are not available to unexpected/malicious PR code.

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -20,7 +20,7 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-js-env
 

--- a/.github/workflows/post-process.yml
+++ b/.github/workflows/post-process.yml
@@ -27,7 +27,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-js-env
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,13 @@ jobs:
       do_release: ${{ steps.check_tag.outputs.do_release }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Get Project Version
         id: get_version
-        uses: 'euberdeveloper/ga-project-version@main'
+        run: echo "version=$(npm pkg get version | tr -d '\"')" >> $GITHUB_OUTPUT
 
       - name: Check Tag Exists
         id: check_tag
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -65,18 +65,18 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up msbuild
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v3
 
       - uses: ./.github/actions/setup-js-env
 
       - name: Check dependencies cache
         id: cache-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ./plugin/ThirdParty
           key: |
@@ -118,9 +118,10 @@ jobs:
 
       - name: Fetch Release Attributes
         id: fetch_attributes
-        uses: zoexx/github-action-json-file-properties@release
-        with:
-          file_path: "package.json"
+        shell: bash
+        run: |
+          echo "releaseSummary=$(npm pkg get releaseSummary | tr -d '\"')" >> $GITHUB_OUTPUT
+          echo "releaseInDraft=$(npm pkg get releaseInDraft | tr -d '\"')" >> $GITHUB_OUTPUT
 
       - name: Set Release Attributes
         id: set_attributes
@@ -142,7 +143,7 @@ jobs:
           echo "release_draft=$release_draft" >> $env:GITHUB_OUTPUT
 
       - name: Create Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@v1.21.0
         with:
           name: ${{ steps.set_attributes.outputs.release_name }}
           tag: v${{ needs.validate_tag.outputs.version }}
@@ -160,7 +161,7 @@ jobs:
     if: ${{ github.repository == 'OverlayPlugin/cactbot' }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-js-env
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,9 @@ jobs:
           echo "release_draft=$release_draft" >> $env:GITHUB_OUTPUT
 
       - name: Create Release
+        # Note: This action has a literal `@v1` tag and release which are no longer being updated.
+        # As such, we have to specify an exact version to avoid getting the outdated build.
+        # Should it ever release a v2 release with proper semantic version, update to use that.
         uses: ncipollo/release-action@v1.21.0
         with:
           name: ${{ steps.set_attributes.outputs.release_name }}

--- a/.github/workflows/test-sync-files.yml
+++ b/.github/workflows/test-sync-files.yml
@@ -18,7 +18,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-js-env
 

--- a/.github/workflows/test-validate-versions.yml
+++ b/.github/workflows/test-validate-versions.yml
@@ -18,7 +18,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-js-env
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-js-env
 

--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -32,7 +32,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist

--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -46,7 +46,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4.1.0
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist

--- a/.github/workflows/update-triggers-branch.yml
+++ b/.github/workflows/update-triggers-branch.yml
@@ -37,7 +37,7 @@ jobs:
           npm run process-triggers
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4.1.0
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist/triggers/ui/raidboss/data

--- a/.github/workflows/update-triggers-branch.yml
+++ b/.github/workflows/update-triggers-branch.yml
@@ -28,7 +28,7 @@ jobs:
     needs: check-triggers
     if: needs.check-triggers.outputs.found == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-js-env
 
@@ -37,7 +37,7 @@ jobs:
           npm run process-triggers
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist/triggers/ui/raidboss/data

--- a/.github/workflows/update_logdefs.yml
+++ b/.github/workflows/update_logdefs.yml
@@ -29,7 +29,10 @@ jobs:
 
       - name: Render PR Template
         id: template
-        uses: chuhlomin/render-template@v1.12
+        # Note: This action has a literal `@v1` tag and release which is actively being updated.
+        # If that status changes, we will have to specify an exact version to avoid getting the
+        # outdated build.
+        uses: chuhlomin/render-template@v1
         with:
           template: .github/logdef_update_pr_template.md
           vars: |

--- a/.github/workflows/update_logdefs.yml
+++ b/.github/workflows/update_logdefs.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'OverlayPlugin/cactbot' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
 
@@ -29,14 +29,14 @@ jobs:
 
       - name: Render PR Template
         id: template
-        uses: chuhlomin/render-template@v1.9
+        uses: chuhlomin/render-template@v1.12
         with:
           template: .github/logdef_update_pr_template.md
           vars: |
             changelist: "${{ steps.script.outputs.changelist }}"
 
       - name: Create PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: 'update netlog_defs filters'
           title: 'resources: Update netlog_defs filters (auto-generated)'

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -18,7 +18,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install yamllint
         run: |


### PR DESCRIPTION
Updated all out of date actions to use the latest versions (no breaking changes were listed on them which impact us):
- actions/cache
- actions/checkout
- actions/upload-artifact
- chuhlomin/render-template
- microsoft/setup-msbuild
- ncipollo/release-action
- peaceiris/actions-gh-pages
- peter-evans/create-pull-request

The following packages appear to be under-maintained or unmaintained and therefore their functionality was replaced with commands instead (these were for getting properties from `package.json`). One of these (I can't remember which off the top of my head) was still using node 20 with no commits, open PRs, or issues to update. Might as well update both places to use the same code/logic:
- zoexx/github-action-json-file-properties
- euberdeveloper/ga-project-version

Closes #1049

---

Reference action runs on https://github.com/valarnin/cactbot/pull/1 if you want to see detailed output logs for each action change (ignore `Lint PR Title` failing, I don't have the token configured on my personal repo).

This is (mostly) pre-squashed to eliminate the version bump test and temporary action changes.