### PR TITLE
resources: add response compose helpers

### DIFF
--- a/resources/responses.ts
+++ b/resources/responses.ts
@@ -31,6 +31,7 @@ import {
   TriggerOutput,
 } from '../types/trigger';
 
+import type { Lang } from './languages';
 import Outputs from './outputs';
 
 type TargetedResponseOutput = ResponseOutput<Data, TargetedMatches>;
@@ -164,15 +165,15 @@ const staticResponse = (field: SevText, text: LocaleText): StaticResponseFunc =>
   };
 };
 
-type LocaleTextPart = [sep: string, text: LocaleText];
+type LocaleTextWithSeparator = [sep: string, text: LocaleText];
 
-const combineLocaleText = (first: LocaleText, rest: LocaleTextPart[]): LocaleText => {
-  const parts: LocaleTextPart[] = [['', first], ...rest];
-  const langs = new Set<keyof LocaleText>(['en']);
+const combineLocaleText = (first: LocaleText, rest: LocaleTextWithSeparator[]): LocaleText => {
+  const parts: LocaleTextWithSeparator[] = [['', first], ...rest];
+  const langs = new Set<Lang>(['en']);
 
   for (const [, text] of parts) {
     for (const lang of Object.keys(text))
-      langs.add(lang as keyof LocaleText);
+      langs.add(lang as Lang);
   }
 
   const result: Record<string, string> = {};

--- a/resources/responses.ts
+++ b/resources/responses.ts
@@ -31,6 +31,7 @@ import {
   TriggerOutput,
 } from '../types/trigger';
 
+import type { Lang } from './languages';
 import Outputs from './outputs';
 
 type TargetedResponseOutput = ResponseOutput<Data, TargetedMatches>;
@@ -162,6 +163,28 @@ const staticResponse = (field: SevText, text: LocaleText): StaticResponseFunc =>
       [field]: (_data: unknown, _matches: unknown, output: Output) => output.text?.(),
     };
   };
+};
+
+export const combineLocaleText = (
+  first: LocaleText,
+  ...rest: [sep: string, text: LocaleText][]
+): LocaleText => {
+  const parts: [sep: string, text: LocaleText][] = [['', first], ...rest];
+  const langs = new Set<Lang>(['en']);
+
+  for (const [, text] of parts) {
+    for (const lang of Object.keys(text))
+      langs.add(lang as Lang);
+  }
+
+  const result: Record<string, string> = {};
+  for (const lang of langs) {
+    result[lang] = parts
+      .map(([sep, text]) => `${sep}${text[lang] ?? text.en}`)
+      .join('');
+  }
+
+  return result as LocaleText;
 };
 
 type SingleSevToResponseFunc = (sev?: Severity) => TargetedResponseFunc | StaticResponseFunc;
@@ -624,6 +647,21 @@ export const Responses = {
   wakeUp: (sev?: Severity) => staticResponse(defaultAlarmText(sev), Outputs.wakeUp),
   getTowers: (sev?: Severity) => staticResponse(defaultInfoText(sev), Outputs.getTowers),
 } as const;
+
+// Example usage:
+// {
+//   id: 'Some In => Out Mechanic',
+//   type: 'StartsUsing',
+//   netRegex: { id: '0000', source: 'Name' },
+//   response: compose(Outputs.in, [' => ', Outputs.out])(),
+// },
+export const compose = (
+  first: LocaleText,
+  ...rest: [sep: string, text: LocaleText][]
+): SingleSevToResponseFunc => {
+  return (sev?: Severity) =>
+    staticResponse(defaultInfoText(sev), combineLocaleText(first, ...rest));
+};
 
 // Don't give `Responses` a type in its declaration so that it can be treated as more strict
 // than `ResponsesMap`, but do assert that its type is correct.  This allows callers to know

--- a/resources/responses.ts
+++ b/resources/responses.ts
@@ -165,10 +165,11 @@ const staticResponse = (field: SevText, text: LocaleText): StaticResponseFunc =>
   };
 };
 
-type LocaleTextWithSeparator = [sep: string, text: LocaleText];
-
-const combineLocaleText = (first: LocaleText, rest: LocaleTextWithSeparator[]): LocaleText => {
-  const parts: LocaleTextWithSeparator[] = [['', first], ...rest];
+export const combineLocaleText = (
+  first: LocaleText,
+  ...rest: [sep: string, text: LocaleText][]
+): LocaleText => {
+  const parts: [sep: string, text: LocaleText][] = [['', first], ...rest];
   const langs = new Set<Lang>(['en']);
 
   for (const [, text] of parts) {
@@ -653,7 +654,7 @@ export const compose = (
   text2: LocaleText,
   sev?: Severity,
 ): StaticResponseFunc => {
-  return staticResponse(defaultInfoText(sev), combineLocaleText(text1, [[sep, text2]]));
+  return staticResponse(defaultInfoText(sev), combineLocaleText(text1, [sep, text2]));
 };
 
 export const compose3 = (
@@ -666,7 +667,7 @@ export const compose3 = (
 ): StaticResponseFunc => {
   return staticResponse(
     defaultInfoText(sev),
-    combineLocaleText(text1, [[sep1, text2], [sep2, text3]]),
+    combineLocaleText(text1, [sep1, text2], [sep2, text3]),
   );
 };
 

--- a/resources/responses.ts
+++ b/resources/responses.ts
@@ -648,27 +648,19 @@ export const Responses = {
   getTowers: (sev?: Severity) => staticResponse(defaultInfoText(sev), Outputs.getTowers),
 } as const;
 
+// Example usage:
+// {
+//   id: 'Some In => Out Mechanic',
+//   type: 'StartsUsing',
+//   netRegex: { id: '0000', source: 'Name' },
+//   response: compose(Outputs.in, [' => ', Outputs.out])(),
+// },
 export const compose = (
-  text1: LocaleText,
-  sep: string,
-  text2: LocaleText,
-  sev?: Severity,
-): StaticResponseFunc => {
-  return staticResponse(defaultInfoText(sev), combineLocaleText(text1, [sep, text2]));
-};
-
-export const compose3 = (
-  text1: LocaleText,
-  sep1: string,
-  text2: LocaleText,
-  sep2: string,
-  text3: LocaleText,
-  sev?: Severity,
-): StaticResponseFunc => {
-  return staticResponse(
-    defaultInfoText(sev),
-    combineLocaleText(text1, [sep1, text2], [sep2, text3]),
-  );
+  first: LocaleText,
+  ...rest: [sep: string, text: LocaleText][]
+): SingleSevToResponseFunc => {
+  return (sev?: Severity) =>
+    staticResponse(defaultInfoText(sev), combineLocaleText(first, ...rest));
 };
 
 // Don't give `Responses` a type in its declaration so that it can be treated as more strict

--- a/resources/responses.ts
+++ b/resources/responses.ts
@@ -178,13 +178,9 @@ const combineLocaleText = (first: LocaleText, rest: LocaleTextWithSeparator[]): 
 
   const result: Record<string, string> = {};
   for (const lang of langs) {
-    let combined = '';
-    for (const [sep, text] of parts) {
-      combined += sep;
-      combined += text[lang] ?? text.en;
-    }
-
-    result[lang] = combined;
+    result[lang] = parts
+      .map(([sep, text]) => `${sep}${text[lang] ?? text.en}`)
+      .join('');
   }
 
   return result as LocaleText;

--- a/resources/responses.ts
+++ b/resources/responses.ts
@@ -164,6 +164,31 @@ const staticResponse = (field: SevText, text: LocaleText): StaticResponseFunc =>
   };
 };
 
+type LocaleTextPart = [sep: string, text: LocaleText];
+
+const combineLocaleText = (first: LocaleText, rest: LocaleTextPart[]): LocaleText => {
+  const parts: LocaleTextPart[] = [['', first], ...rest];
+  const langs = new Set<keyof LocaleText>(['en']);
+
+  for (const [, text] of parts) {
+    for (const lang of Object.keys(text))
+      langs.add(lang as keyof LocaleText);
+  }
+
+  const result: Record<string, string> = {};
+  for (const lang of langs) {
+    let combined = '';
+    for (const [sep, text] of parts) {
+      combined += sep;
+      combined += text[lang] ?? text.en;
+    }
+
+    result[lang] = combined;
+  }
+
+  return result as LocaleText;
+};
+
 type SingleSevToResponseFunc = (sev?: Severity) => TargetedResponseFunc | StaticResponseFunc;
 type DoubleSevToResponseFunc = (targetSev?: Severity, otherSev?: Severity) => TargetedResponseFunc;
 type ResponsesMap = {
@@ -624,6 +649,29 @@ export const Responses = {
   wakeUp: (sev?: Severity) => staticResponse(defaultAlarmText(sev), Outputs.wakeUp),
   getTowers: (sev?: Severity) => staticResponse(defaultInfoText(sev), Outputs.getTowers),
 } as const;
+
+export const compose = (
+  text1: LocaleText,
+  sep: string,
+  text2: LocaleText,
+  sev?: Severity,
+): StaticResponseFunc => {
+  return staticResponse(defaultInfoText(sev), combineLocaleText(text1, [[sep, text2]]));
+};
+
+export const compose3 = (
+  text1: LocaleText,
+  sep1: string,
+  text2: LocaleText,
+  sep2: string,
+  text3: LocaleText,
+  sev?: Severity,
+): StaticResponseFunc => {
+  return staticResponse(
+    defaultInfoText(sev),
+    combineLocaleText(text1, [[sep1, text2], [sep2, text3]]),
+  );
+};
 
 // Don't give `Responses` a type in its declaration so that it can be treated as more strict
 // than `ResponsesMap`, but do assert that its type is correct.  This allows callers to know

--- a/resources/responses.ts
+++ b/resources/responses.ts
@@ -648,13 +648,17 @@ export const Responses = {
   getTowers: (sev?: Severity) => staticResponse(defaultInfoText(sev), Outputs.getTowers),
 } as const;
 
-// Example usage:
-// {
-//   id: 'Some In => Out Mechanic',
-//   type: 'StartsUsing',
-//   netRegex: { id: '0000', source: 'Name' },
-//   response: compose(Outputs.in, [' => ', Outputs.out])(),
-// },
+/**
+ * Creates a static response from localized text, defaulting to info severity.
+ *
+ * @example
+ * {
+ *   id: 'Some In => Out Mechanic',
+ *   type: 'StartsUsing',
+ *   netRegex: { id: '0000', source: 'Name' },
+ *   response: compose(Outputs.in, [' => ', Outputs.out])(),
+ * }
+ */
 export const compose = (
   first: LocaleText,
   ...rest: [sep: string, text: LocaleText][]

--- a/test/unittests/responses_test.ts
+++ b/test/unittests/responses_test.ts
@@ -40,7 +40,7 @@ const runResponseFuncWithOutputStrings = (
   func: ResponseFunc<RaidbossData, Matches>,
 ): [ResponseFuncOutput, OutputStrings] => {
   const empty = {};
-  const output = {
+  const output: { responseOutputStrings: OutputStrings } = {
     responseOutputStrings: {},
   };
   return [

--- a/test/unittests/responses_test.ts
+++ b/test/unittests/responses_test.ts
@@ -1,7 +1,10 @@
 import { assert } from 'chai';
 
+import Outputs from '../../resources/outputs';
 import {
   builtInResponseStr,
+  combineLocaleText,
+  compose,
   Responses,
   severityList,
   severityMap,
@@ -9,7 +12,13 @@ import {
 } from '../../resources/responses';
 import { RaidbossData } from '../../types/data';
 import { Matches } from '../../types/net_matches';
-import { Output, ResponseFunc, ResponseOutput } from '../../types/trigger';
+import {
+  LocaleText,
+  Output,
+  OutputStrings,
+  ResponseFunc,
+  ResponseOutput,
+} from '../../types/trigger';
 
 // test_trigger.js will validate the field names, so no need to do that here.
 
@@ -25,6 +34,19 @@ const runResponseFunc = (
   // Built-in responses must be callable with empty parameters.
   const empty = {};
   return func(empty as RaidbossData, empty as Matches, empty as Output);
+};
+
+const runResponseFuncWithOutputStrings = (
+  func: ResponseFunc<RaidbossData, Matches>,
+): [ResponseFuncOutput, OutputStrings] => {
+  const empty = {};
+  const output: { responseOutputStrings: OutputStrings } = {
+    responseOutputStrings: {},
+  };
+  return [
+    func(empty as RaidbossData, empty as Matches, output as Output),
+    output.responseOutputStrings,
+  ];
 };
 
 describe('response tests', () => {
@@ -105,5 +127,86 @@ describe('response tests', () => {
         }
       }
     }
+  });
+  it('combineLocaleText combines localized text with fallbacks', () => {
+    const fallbackText: LocaleText = {
+      en: 'Fallback',
+      ja: 'Japanese Fallback',
+    };
+
+    assert.deepEqual(
+      combineLocaleText(
+        Outputs.in,
+        [' => ', Outputs.out],
+        [' + ', fallbackText],
+      ),
+      {
+        en: 'In => Out + Fallback',
+        de: 'Rein => Raus + Fallback',
+        fr: 'Intérieur => Extérieur + Fallback',
+        ja: '中へ => 外へ + Japanese Fallback',
+        cn: '靠近 => 远离 + Fallback',
+        ko: '안으로 => 밖으로 + Fallback',
+        tc: '靠近 => 遠離 + Fallback',
+      },
+    );
+  });
+  it('compose returns a built-in static response', () => {
+    const responseFunc = compose(Outputs.in, [' => ', Outputs.out])();
+    assert.include(responseFunc.toString(), outputStringSetterStr);
+    assert.include(responseFunc.toString(), builtInResponseStr);
+
+    const [result, outputStrings] = runResponseFuncWithOutputStrings(responseFunc);
+    assert.isObject(result);
+    assert.property(result, 'infoText');
+    assert.deepEqual(outputStrings.text, {
+      en: 'In => Out',
+      de: 'Rein => Raus',
+      fr: 'Intérieur => Extérieur',
+      ja: '中へ => 外へ',
+      cn: '靠近 => 远离',
+      ko: '안으로 => 밖으로',
+      tc: '靠近 => 遠離',
+    });
+  });
+  it('compose respects explicit severity and locale fallbacks', () => {
+    const fallbackText: LocaleText = {
+      en: 'Fallback',
+      ja: 'Japanese Fallback',
+    };
+    const responseFunc = compose(Outputs.spread, [' 😗 ', fallbackText])('alarm');
+
+    const [result, outputStrings] = runResponseFuncWithOutputStrings(responseFunc);
+    assert.isObject(result);
+    assert.property(result, 'alarmText');
+    assert.deepEqual(outputStrings.text, {
+      en: 'Spread 😗 Fallback',
+      de: 'Verteilen 😗 Fallback',
+      fr: 'Dispersez-vous 😗 Fallback',
+      ja: 'さんかい 😗 Japanese Fallback',
+      cn: '分散 😗 Fallback',
+      ko: '산개 😗 Fallback',
+      tc: '分散 😗 Fallback',
+    });
+  });
+  it('compose combines multiple pieces', () => {
+    const responseFunc = compose(
+      Outputs.in,
+      [' => ', Outputs.out],
+      [' + ', Outputs.spread],
+    )('alert');
+
+    const [result, outputStrings] = runResponseFuncWithOutputStrings(responseFunc);
+    assert.isObject(result);
+    assert.property(result, 'alertText');
+    assert.deepEqual(outputStrings.text, {
+      en: 'In => Out + Spread',
+      de: 'Rein => Raus + Verteilen',
+      fr: 'Intérieur => Extérieur + Dispersez-vous',
+      ja: '中へ => 外へ + さんかい',
+      cn: '靠近 => 远离 + 分散',
+      ko: '안으로 => 밖으로 + 산개',
+      tc: '靠近 => 遠離 + 分散',
+    });
   });
 });

--- a/test/unittests/responses_test.ts
+++ b/test/unittests/responses_test.ts
@@ -5,7 +5,6 @@ import {
   builtInResponseStr,
   combineLocaleText,
   compose,
-  compose3,
   Responses,
   severityList,
   severityMap,
@@ -153,7 +152,7 @@ describe('response tests', () => {
     );
   });
   it('compose returns a built-in static response', () => {
-    const responseFunc = compose(Outputs.in, ' => ', Outputs.out);
+    const responseFunc = compose(Outputs.in, [' => ', Outputs.out])();
     assert.include(responseFunc.toString(), outputStringSetterStr);
     assert.include(responseFunc.toString(), builtInResponseStr);
 
@@ -175,7 +174,7 @@ describe('response tests', () => {
       en: 'Fallback',
       ja: 'Japanese Fallback',
     };
-    const responseFunc = compose(Outputs.spread, ' 😗 ', fallbackText, 'alarm');
+    const responseFunc = compose(Outputs.spread, [' 😗 ', fallbackText])('alarm');
 
     const [result, outputStrings] = runResponseFuncWithOutputStrings(responseFunc);
     assert.isObject(result);
@@ -190,15 +189,12 @@ describe('response tests', () => {
       tc: '分散 😗 Fallback',
     });
   });
-  it('compose3 returns a built-in static response', () => {
-    const responseFunc = compose3(
+  it('compose combines multiple pieces', () => {
+    const responseFunc = compose(
       Outputs.in,
-      ' => ',
-      Outputs.out,
-      ' + ',
-      Outputs.spread,
-      'alert',
-    );
+      [' => ', Outputs.out],
+      [' + ', Outputs.spread],
+    )('alert');
 
     const [result, outputStrings] = runResponseFuncWithOutputStrings(responseFunc);
     assert.isObject(result);

--- a/test/unittests/responses_test.ts
+++ b/test/unittests/responses_test.ts
@@ -1,7 +1,10 @@
 import { assert } from 'chai';
 
+import Outputs from '../../resources/outputs';
 import {
   builtInResponseStr,
+  compose,
+  compose3,
   Responses,
   severityList,
   severityMap,
@@ -9,7 +12,13 @@ import {
 } from '../../resources/responses';
 import { RaidbossData } from '../../types/data';
 import { Matches } from '../../types/net_matches';
-import { Output, ResponseFunc, ResponseOutput } from '../../types/trigger';
+import {
+  LocaleText,
+  Output,
+  OutputStrings,
+  ResponseFunc,
+  ResponseOutput,
+} from '../../types/trigger';
 
 // test_trigger.js will validate the field names, so no need to do that here.
 
@@ -25,6 +34,19 @@ const runResponseFunc = (
   // Built-in responses must be callable with empty parameters.
   const empty = {};
   return func(empty as RaidbossData, empty as Matches, empty as Output);
+};
+
+const runResponseFuncWithOutputStrings = (
+  func: ResponseFunc<RaidbossData, Matches>,
+): [ResponseFuncOutput, OutputStrings] => {
+  const empty = {};
+  const output = {
+    responseOutputStrings: {},
+  };
+  return [
+    func(empty as RaidbossData, empty as Matches, output as Output),
+    output.responseOutputStrings,
+  ];
 };
 
 describe('response tests', () => {
@@ -105,5 +127,66 @@ describe('response tests', () => {
         }
       }
     }
+  });
+  it('compose returns a built-in static response', () => {
+    const responseFunc = compose(Outputs.in, ' => ', Outputs.out);
+    assert.include(responseFunc.toString(), outputStringSetterStr);
+    assert.include(responseFunc.toString(), builtInResponseStr);
+
+    const [result, outputStrings] = runResponseFuncWithOutputStrings(responseFunc);
+    assert.isObject(result);
+    assert.property(result, 'infoText');
+    assert.deepEqual(outputStrings.text, {
+      en: 'In => Out',
+      de: 'Rein => Raus',
+      fr: 'Intérieur => Extérieur',
+      ja: '中へ => 外へ',
+      cn: '靠近 => 远离',
+      ko: '안으로 => 밖으로',
+      tc: '靠近 => 遠離',
+    });
+  });
+  it('compose respects explicit severity and locale fallbacks', () => {
+    const fallbackText: LocaleText = {
+      en: 'Fallback',
+      ja: 'Japanese Fallback',
+    };
+    const responseFunc = compose(Outputs.spread, ' 😗 ', fallbackText, 'alarm');
+
+    const [result, outputStrings] = runResponseFuncWithOutputStrings(responseFunc);
+    assert.isObject(result);
+    assert.property(result, 'alarmText');
+    assert.deepEqual(outputStrings.text, {
+      en: 'Spread 😗 Fallback',
+      de: 'Verteilen 😗 Fallback',
+      fr: 'Dispersez-vous 😗 Fallback',
+      ja: 'さんかい 😗 Japanese Fallback',
+      cn: '分散 😗 Fallback',
+      ko: '산개 😗 Fallback',
+      tc: '分散 😗 Fallback',
+    });
+  });
+  it('compose3 returns a built-in static response', () => {
+    const responseFunc = compose3(
+      Outputs.in,
+      ' => ',
+      Outputs.out,
+      ' + ',
+      Outputs.spread,
+      'alert',
+    );
+
+    const [result, outputStrings] = runResponseFuncWithOutputStrings(responseFunc);
+    assert.isObject(result);
+    assert.property(result, 'alertText');
+    assert.deepEqual(outputStrings.text, {
+      en: 'In => Out + Spread',
+      de: 'Rein => Raus + Verteilen',
+      fr: 'Intérieur => Extérieur + Dispersez-vous',
+      ja: '中へ => 外へ + さんかい',
+      cn: '靠近 => 远离 + 分散',
+      ko: '안으로 => 밖으로 + 산개',
+      tc: '靠近 => 遠離 + 分散',
+    });
   });
 });

--- a/test/unittests/responses_test.ts
+++ b/test/unittests/responses_test.ts
@@ -3,6 +3,7 @@ import { assert } from 'chai';
 import Outputs from '../../resources/outputs';
 import {
   builtInResponseStr,
+  combineLocaleText,
   compose,
   compose3,
   Responses,
@@ -127,6 +128,29 @@ describe('response tests', () => {
         }
       }
     }
+  });
+  it('combineLocaleText combines localized text with fallbacks', () => {
+    const fallbackText: LocaleText = {
+      en: 'Fallback',
+      ja: 'Japanese Fallback',
+    };
+
+    assert.deepEqual(
+      combineLocaleText(
+        Outputs.in,
+        [' => ', Outputs.out],
+        [' + ', fallbackText],
+      ),
+      {
+        en: 'In => Out + Fallback',
+        de: 'Rein => Raus + Fallback',
+        fr: 'Intérieur => Extérieur + Fallback',
+        ja: '中へ => 外へ + Japanese Fallback',
+        cn: '靠近 => 远离 + Fallback',
+        ko: '안으로 => 밖으로 + Fallback',
+        tc: '靠近 => 遠離 + Fallback',
+      },
+    );
   });
   it('compose returns a built-in static response', () => {
     const responseFunc = compose(Outputs.in, ' => ', Outputs.out);


### PR DESCRIPTION
fixes #1058

Add `compose` and `compose3` helper functions for combining LocaleText output strings into static built-in responses.

Based on my experience so far, I am confident that as long as it is used only for simple and clear content, there will be no translation issues.

### 2026-06-05

- make `combineLocaleText` function public

### 2026-06-23

- Change `compose` to a variadic function that takes `severity` as an argument later, and remove `compose3`.
