### PR TITLE
resources: add clockwise point sorting helpers

### DIFF
--- a/resources/util.ts
+++ b/resources/util.ts
@@ -420,30 +420,12 @@ const sortPointEntriesClockwiseFrom = <T extends SortablePoint>(
     .map((entry) => entry.point);
 };
 
-const sortPointsClockwiseFrom = <T extends SortablePoint>(
-  points: readonly T[],
-  centerX: number,
-  centerY: number,
-  referenceX: number,
-  referenceY: number,
-): T[] => {
-  // Sorts points clockwise, starting from the angle of `reference`.
-  const referenceAngle = xyToClockwiseAngle(referenceX, referenceY, centerX, centerY);
-  const entries: PointSortEntry<T>[] = points.map((point) => ({
-    point: point,
-    angle: xyToClockwiseAngle(point.x, point.y, centerX, centerY),
-  }));
-
-  return sortPointEntriesClockwiseFrom(entries, referenceAngle);
-};
-
 const sortPointsClockwise = <T extends SortablePoint>(
   points: readonly T[],
   centerX: number,
   centerY: number,
-): T[] | undefined => {
-  // Sorts points clockwise if they fit within a semicircle around `center`.
-  // otherwise, returns undefined.
+  options: { reference?: { x: number; y: number } } = {},
+): T[] => {
   if (points.length <= 1)
     return [...points];
 
@@ -454,6 +436,15 @@ const sortPointsClockwise = <T extends SortablePoint>(
     }))
     .sort((a, b) => a.angle - b.angle);
 
+  const reference = options.reference;
+  if (reference !== undefined) {
+    const referenceAngle = reference.x === centerX && reference.y === centerY
+      ? 0
+      : xyToClockwiseAngle(reference.x, reference.y, centerX, centerY);
+    return sortPointEntriesClockwiseFrom(entries, referenceAngle);
+  }
+
+  const eps = 1e-9;
   let largestGap = 0;
   let startIdx = 0;
   for (const [idx, entry] of entries.entries()) {
@@ -463,7 +454,14 @@ const sortPointsClockwise = <T extends SortablePoint>(
       continue;
     const gap = clockwiseAngleDelta(nextEntry.angle, entry.angle);
 
-    if (gap > largestGap) {
+    const startEntry = entries[startIdx];
+    if (startEntry === undefined)
+      continue;
+    // If there are multiple largest gaps, start from the smallest angle.
+    if (
+      gap > largestGap + eps ||
+      (Math.abs(gap - largestGap) <= eps && nextEntry.angle < startEntry.angle)
+    ) {
       largestGap = gap;
       startIdx = nextIdx;
     }
@@ -472,11 +470,6 @@ const sortPointsClockwise = <T extends SortablePoint>(
   // With no angular separation, there is no clockwise ordering signal.
   if (largestGap === 0)
     return [...points];
-
-  // Return undefined for 180-degree or wider spans because this helper infers its start point.
-  const arcLength = twoPi - largestGap;
-  if (arcLength >= Math.PI - 1e-9)
-    return undefined;
 
   const referenceAngle = entries[startIdx]?.angle ?? 0;
   return sortPointEntriesClockwiseFrom(entries, referenceAngle);
@@ -502,7 +495,6 @@ export const Directions = {
   outputFrom8DirNum: outputFrom8DirNum,
   outputFromCardinalNum: outputFromCardinalNum,
   sortPointsClockwise: sortPointsClockwise,
-  sortPointsClockwiseFrom: sortPointsClockwiseFrom,
   combatantStatePosTo8Dir: (
     combatant: PluginCombatantState,
     centerX: number,

--- a/resources/util.ts
+++ b/resources/util.ts
@@ -395,10 +395,20 @@ export type AnyDirection =
   | DirectionOutput8
   | DirectionOutput16;
 
-// Example usage:
-// const dirs: DirectionOutputCardinal[] = ['dirN', 'dirW'];
-// dirs.sort(getSortDirectionsClockwiseFunction('dirE'));
-// `dirs` should equal `['dirW', 'dirN']`
+/**
+ * Get a function to pass to Array.sort to sort an array of DirectionOutput entries
+ *
+ * Example usage:
+ *
+ * const dirs: DirectionOutputCardinal[] = ['dirN', 'dirW'];
+ *
+ * dirs.sort(getSortDirectionsClockwiseFunction('dirE'));
+ *
+ * `dirs` should equal `['dirW', 'dirN']`
+ *
+ * @param from The DirectionOutput to treat as the start point for sort comparison
+ * @returns A function to pass to the Array.sort function
+ */
 export const getSortDirectionsClockwiseFunction = (
   from?: AnyDirection,
 ): (left: AnyDirection, right: AnyDirection) => number => {
@@ -424,11 +434,21 @@ type Point = {
   y: number;
 };
 
-// Example usage:
-// getSortPointsClockwiseFunction
-// const points = [{ x: 101, y: 101 }, { x: 99, y: 99 }];
-// points.sort(getSortPointsClockwiseFunction({x: 100, y: 100}, {x: 99, y: 101}));
-// `points` should now equal `[{ x: 99, y: 99 }, { x: 101, y: 101 }]`
+/**
+ * Get a function to pass to Array.sort to sort an array of objects with `x` and `y` properties
+ *
+ * Example usage:
+ *
+ * const points = [{ x: 101, y: 101 }, { x: 99, y: 99 }];
+ *
+ * points.sort(getSortPointsClockwiseFunction({x: 100, y: 100}, {x: 99, y: 101}));
+ *
+ * `points` should now equal `[{ x: 99, y: 99 }, { x: 101, y: 101 }]`
+ *
+ * @param center The x/y point to treat as the center to calculate headings from
+ * @param reference The heading or x/y point to treat as the start point for sort comparison
+ * @returns A function to pass to the Array.sort function
+ */
 export const getSortPointsClockwiseFunction = <T extends Point>(
   center: T,
   reference: number | T = Math.PI, // Default to north

--- a/resources/util.ts
+++ b/resources/util.ts
@@ -356,13 +356,6 @@ const xyTo4DirIntercardNum = (x: number, y: number, centerX: number, centerY: nu
   return Math.round(2 - 2 * ((Math.PI / 4) + Math.atan2(x, y)) / Math.PI) % 4;
 };
 
-const xyToClockwiseAngle = (x: number, y: number, centerX: number, centerY: number): number => {
-  // Returns a continuous angle where north is 0 and values increase clockwise.
-  x = x - centerX;
-  y = y - centerY;
-  return (Math.PI - Math.atan2(x, y) + 2 * Math.PI) % (2 * Math.PI);
-};
-
 const hdgTo16DirNum = (heading: number): number => {
   // N = 0, NNE = 1, ..., NNW = 15
   return (Math.round(8 - 8 * heading / Math.PI) % 16 + 16) % 16;
@@ -390,24 +383,31 @@ const outputFromIntercardNum = (dirNum: number): DirectionOutputIntercard => {
   return outputIntercardDir[dirNum] ?? 'unknown';
 };
 
-interface SortablePoint {
+type Point = {
   x: number;
   y: number;
-}
+};
 
-type PointSortEntry<T extends SortablePoint> = {
+type PointSortEntry<T extends Point> = {
   point: T;
   angle: number;
 };
 
 const twoPi = 2 * Math.PI;
 
+const xyToClockwiseAngle = (x: number, y: number, centerX: number, centerY: number): number => {
+  // Returns a continuous angle where north is 0 and values increase clockwise.
+  x = x - centerX;
+  y = y - centerY;
+  return (Math.PI - Math.atan2(x, y) + 2 * Math.PI) % (2 * Math.PI);
+};
+
 const clockwiseAngleDelta = (toAngle: number, fromAngle: number): number => {
   // Normalize the wraparound case so the result is always in [0, 2π).
   return (toAngle - fromAngle + twoPi) % twoPi;
 };
 
-const sortPointEntriesClockwiseFrom = <T extends SortablePoint>(
+const sortPointEntriesClockwiseFrom = <T extends Point>(
   entries: PointSortEntry<T>[],
   referenceAngle: number,
 ): T[] => {
@@ -420,7 +420,7 @@ const sortPointEntriesClockwiseFrom = <T extends SortablePoint>(
     .map((entry) => entry.point);
 };
 
-const sortPointsClockwise = <T extends SortablePoint>(
+const sortPointsClockwise = <T extends Point>(
   points: readonly T[],
   centerX: number,
   centerY: number,

--- a/resources/util.ts
+++ b/resources/util.ts
@@ -477,9 +477,9 @@ const sortPointsClockwise = <T extends SortablePoint>(
   if (largestGap === 0)
     return [...points];
 
-  // Points fit in a semicircle if the complement of their largest gap is <= 180 degrees.
+  // Return undefined for 180-degree or wider spans because this helper infers its start point.
   const arcLength = twoPi - largestGap;
-  if (arcLength > Math.PI + 1e-9)
+  if (arcLength >= Math.PI - 1e-9)
     return undefined;
 
   const referenceAngle = entries[startIdx]?.angle ?? 0;

--- a/resources/util.ts
+++ b/resources/util.ts
@@ -398,12 +398,15 @@ export const getSortDirectionsClockwiseFunction = (
 ): (left: AnyDirection, right: AnyDirection) => number => {
   // Default to dirN
   let offset = 0;
-  if (from !== undefined)
+  if (from !== undefined && from !== 'unknown')
     offset = getDirectionIndex(from);
 
-  const count = output16Dir.length + 1; // +1 for unknown
+  const count = output16Dir.length;
 
   return (left: AnyDirection, right: AnyDirection) => {
+    if (left === 'unknown' || right === 'unknown') {
+      return left === right ? 0 : left === 'unknown' ? 1 : -1;
+    }
     const rightIndex = (count + getDirectionIndex(right) - offset) % count;
     const leftIndex = (count + getDirectionIndex(left) - offset) % count;
     return leftIndex - rightIndex;

--- a/resources/util.ts
+++ b/resources/util.ts
@@ -264,16 +264,16 @@ const output16Dir: DirectionOutput16[] = [
 const outputCardinalDir: DirectionOutputCardinal[] = ['dirN', 'dirE', 'dirS', 'dirW'];
 const outputIntercardDir: DirectionOutputIntercard[] = ['dirNE', 'dirSE', 'dirSW', 'dirNW'];
 
-const compareDirectionOutput = (a: DirectionOutput16, b: DirectionOutput16): number => {
-  const getIndex = (n: DirectionOutput16) => {
-    const index = output16Dir.indexOf(n);
-    // Values outside of output16Dir (i.e. 'unknown') sort last
-    if (index < 0)
-      return output16Dir.length;
-    return index;
-  };
+const getDirectionIndex = (n: DirectionOutput16) => {
+  const index = output16Dir.indexOf(n);
+  // Values outside of output16Dir (i.e. 'unknown') sort last
+  if (index < 0)
+    return output16Dir.length;
+  return index;
+};
 
-  return getIndex(a) - getIndex(b);
+const compareDirectionOutput = (a: DirectionOutput16, b: DirectionOutput16): number => {
+  return getDirectionIndex(a) - getDirectionIndex(b);
 };
 
 const outputStrings16Dir: OutputStrings = {
@@ -383,96 +383,71 @@ const outputFromIntercardNum = (dirNum: number): DirectionOutputIntercard => {
   return outputIntercardDir[dirNum] ?? 'unknown';
 };
 
+export type AnyDirection =
+  | DirectionOutputCardinal
+  | DirectionOutputIntercard
+  | DirectionOutput8
+  | DirectionOutput16;
+
+// Example usage:
+// const dirs: DirectionOutputCardinal[] = ['dirN', 'dirW'];
+// dirs.sort(getSortDirectionsClockwiseFunction('dirE'));
+// `dirs` should equal `['dirW', 'dirN']`
+export const getSortDirectionsClockwiseFunction = (
+  from?: AnyDirection,
+): (left: AnyDirection, right: AnyDirection) => number => {
+  // Default to dirN
+  let offset = 0;
+  if (from !== undefined)
+    offset = getDirectionIndex(from);
+
+  const count = output16Dir.length + 1; // +1 for unknown
+
+  return (left: AnyDirection, right: AnyDirection) => {
+    const rightIndex = (count + getDirectionIndex(right) - offset) % count;
+    const leftIndex = (count + getDirectionIndex(left) - offset) % count;
+    return leftIndex - rightIndex;
+  };
+};
+
 type Point = {
   x: number;
   y: number;
 };
 
-type PointSortEntry<T extends Point> = {
-  point: T;
-  angle: number;
-};
-
-const twoPi = 2 * Math.PI;
-
-const xyToClockwiseAngle = (x: number, y: number, centerX: number, centerY: number): number => {
-  // Returns a continuous angle where north is 0 and values increase clockwise.
+const xyToHeading = (x: number, y: number, centerX: number, centerY: number) => {
   x = x - centerX;
   y = y - centerY;
-  return (Math.PI - Math.atan2(x, y) + 2 * Math.PI) % (2 * Math.PI);
+  return Math.atan2(x, y);
 };
 
-const clockwiseAngleDelta = (toAngle: number, fromAngle: number): number => {
-  // Normalize the wraparound case so the result is always in [0, 2π).
-  return (toAngle - fromAngle + twoPi) % twoPi;
-};
+// Example usage:
+// getSortPointsClockwiseFunction
+// const points = [{ x: 101, y: 101 }, { x: 99, y: 99 }];
+// points.sort(getSortPointsClockwiseFunction({x: 100, y: 100}, {x: 99, y: 101}));
+// `points` should now equal `[{ x: 99, y: 99 }, { x: 101, y: 101 }]`
+export const getSortPointsClockwiseFunction = <T extends Point>(
+  center: T,
+  reference: number | T = Math.PI, // Default to north
+): (left: T, right: T) => number => {
+  // Convert point to heading if needed
+  const offset = typeof reference === 'object'
+    ? xyToHeading(reference.x, reference.y, center.x, center.y)
+    : reference;
 
-const sortPointEntriesClockwiseFrom = <T extends Point>(
-  entries: PointSortEntry<T>[],
-  referenceAngle: number,
-): T[] => {
-  return entries
-    .map((entry) => ({
-      ...entry,
-      delta: clockwiseAngleDelta(entry.angle, referenceAngle),
-    }))
-    .sort((a, b) => a.delta - b.delta)
-    .map((entry) => entry.point);
-};
+  const twoPI = Math.PI * 2;
 
-const sortPointsClockwise = <T extends Point>(
-  points: readonly T[],
-  centerX: number,
-  centerY: number,
-  options: { reference?: { x: number; y: number } } = {},
-): T[] => {
-  if (points.length <= 1)
-    return [...points];
+  return (left: T, right: T) => {
+    // Get our base headings for the two points
+    const rightHeading = xyToHeading(right.x, right.y, center.x, center.y);
+    const leftHeading = xyToHeading(left.x, left.y, center.x, center.y);
 
-  const entries: PointSortEntry<T>[] = points
-    .map((point) => ({
-      point: point,
-      angle: xyToClockwiseAngle(point.x, point.y, centerX, centerY),
-    }))
-    .sort((a, b) => a.angle - b.angle);
+    // Adjust by reference offset
+    const rightHeadingOffset = (twoPI + (offset - rightHeading)) % twoPI;
+    const leftHeadingOffset = (twoPI + (offset - leftHeading)) % twoPI;
 
-  const reference = options.reference;
-  if (reference !== undefined) {
-    const referenceAngle = reference.x === centerX && reference.y === centerY
-      ? 0
-      : xyToClockwiseAngle(reference.x, reference.y, centerX, centerY);
-    return sortPointEntriesClockwiseFrom(entries, referenceAngle);
-  }
-
-  const eps = 1e-9;
-  let largestGap = 0;
-  let startIdx = 0;
-  for (const [idx, entry] of entries.entries()) {
-    const nextIdx = (idx + 1) % entries.length;
-    const nextEntry = entries[nextIdx];
-    if (nextEntry === undefined)
-      continue;
-    const gap = clockwiseAngleDelta(nextEntry.angle, entry.angle);
-
-    const startEntry = entries[startIdx];
-    if (startEntry === undefined)
-      continue;
-    // If there are multiple largest gaps, start from the smallest angle.
-    if (
-      gap > largestGap + eps ||
-      (Math.abs(gap - largestGap) <= eps && nextEntry.angle < startEntry.angle)
-    ) {
-      largestGap = gap;
-      startIdx = nextIdx;
-    }
-  }
-
-  // With no angular separation, there is no clockwise ordering signal.
-  if (largestGap === 0)
-    return [...points];
-
-  const referenceAngle = entries[startIdx]?.angle ?? 0;
-  return sortPointEntriesClockwiseFrom(entries, referenceAngle);
+    return leftHeadingOffset - rightHeadingOffset;
+  };
 };
 
 export const Directions = {
@@ -494,7 +469,6 @@ export const Directions = {
   hdgTo4DirNum: hdgTo4DirNum,
   outputFrom8DirNum: outputFrom8DirNum,
   outputFromCardinalNum: outputFromCardinalNum,
-  sortPointsClockwise: sortPointsClockwise,
   combatantStatePosTo8Dir: (
     combatant: PluginCombatantState,
     centerX: number,

--- a/resources/util.ts
+++ b/resources/util.ts
@@ -356,6 +356,12 @@ const xyTo4DirIntercardNum = (x: number, y: number, centerX: number, centerY: nu
   return Math.round(2 - 2 * ((Math.PI / 4) + Math.atan2(x, y)) / Math.PI) % 4;
 };
 
+const xyToHeading = (x: number, y: number, centerX: number, centerY: number): number => {
+  x = x - centerX;
+  y = y - centerY;
+  return Math.atan2(x, y);
+};
+
 const hdgTo16DirNum = (heading: number): number => {
   // N = 0, NNE = 1, ..., NNW = 15
   return (Math.round(8 - 8 * heading / Math.PI) % 16 + 16) % 16;
@@ -418,12 +424,6 @@ type Point = {
   y: number;
 };
 
-const xyToHeading = (x: number, y: number, centerX: number, centerY: number) => {
-  x = x - centerX;
-  y = y - centerY;
-  return Math.atan2(x, y);
-};
-
 // Example usage:
 // getSortPointsClockwiseFunction
 // const points = [{ x: 101, y: 101 }, { x: 99, y: 99 }];
@@ -467,6 +467,7 @@ export const Directions = {
   xyTo16DirNum: xyTo16DirNum,
   xyTo8DirNum: xyTo8DirNum,
   xyTo4DirNum: xyTo4DirNum,
+  xyToHeading: xyToHeading,
   hdgTo16DirNum: hdgTo16DirNum,
   hdgTo8DirNum: hdgTo8DirNum,
   hdgTo4DirNum: hdgTo4DirNum,

--- a/resources/util.ts
+++ b/resources/util.ts
@@ -398,7 +398,6 @@ interface SortablePoint {
 type PointSortEntry<T extends SortablePoint> = {
   point: T;
   angle: number;
-  index: number;
 };
 
 const twoPi = 2 * Math.PI;
@@ -412,13 +411,12 @@ const sortPointEntriesClockwiseFrom = <T extends SortablePoint>(
   entries: PointSortEntry<T>[],
   referenceAngle: number,
 ): T[] => {
-  // Use original index as a stable tie-breaker for points on the same ray.
   return entries
     .map((entry) => ({
       ...entry,
       delta: clockwiseAngleDelta(entry.angle, referenceAngle),
     }))
-    .sort((a, b) => a.delta - b.delta || a.index - b.index)
+    .sort((a, b) => a.delta - b.delta)
     .map((entry) => entry.point);
 };
 
@@ -431,10 +429,9 @@ const sortPointsClockwiseFrom = <T extends SortablePoint>(
 ): T[] => {
   // Sorts points clockwise, starting from the angle of `reference`.
   const referenceAngle = xyToClockwiseAngle(referenceX, referenceY, centerX, centerY);
-  const entries: PointSortEntry<T>[] = points.map((point, index) => ({
+  const entries: PointSortEntry<T>[] = points.map((point) => ({
     point: point,
     angle: xyToClockwiseAngle(point.x, point.y, centerX, centerY),
-    index: index,
   }));
 
   return sortPointEntriesClockwiseFrom(entries, referenceAngle);
@@ -451,12 +448,11 @@ const sortPointsClockwise = <T extends SortablePoint>(
     return [...points];
 
   const entries: PointSortEntry<T>[] = points
-    .map((point, index) => ({
+    .map((point) => ({
       point: point,
       angle: xyToClockwiseAngle(point.x, point.y, centerX, centerY),
-      index: index,
     }))
-    .sort((a, b) => a.angle - b.angle || a.index - b.index);
+    .sort((a, b) => a.angle - b.angle);
 
   let largestGap = 0;
   let startIdx = 0;

--- a/resources/util.ts
+++ b/resources/util.ts
@@ -356,6 +356,13 @@ const xyTo4DirIntercardNum = (x: number, y: number, centerX: number, centerY: nu
   return Math.round(2 - 2 * ((Math.PI / 4) + Math.atan2(x, y)) / Math.PI) % 4;
 };
 
+const xyToClockwiseAngle = (x: number, y: number, centerX: number, centerY: number): number => {
+  // Returns a continuous angle where north is 0 and values increase clockwise.
+  x = x - centerX;
+  y = y - centerY;
+  return (Math.PI - Math.atan2(x, y) + 2 * Math.PI) % (2 * Math.PI);
+};
+
 const hdgTo16DirNum = (heading: number): number => {
   // N = 0, NNE = 1, ..., NNW = 15
   return (Math.round(8 - 8 * heading / Math.PI) % 16 + 16) % 16;
@@ -383,6 +390,102 @@ const outputFromIntercardNum = (dirNum: number): DirectionOutputIntercard => {
   return outputIntercardDir[dirNum] ?? 'unknown';
 };
 
+interface SortablePoint {
+  x: number;
+  y: number;
+}
+
+type PointSortEntry<T extends SortablePoint> = {
+  point: T;
+  angle: number;
+  index: number;
+};
+
+const twoPi = 2 * Math.PI;
+
+const clockwiseAngleDelta = (toAngle: number, fromAngle: number): number => {
+  // Normalize the wraparound case so the result is always in [0, 2π).
+  return (toAngle - fromAngle + twoPi) % twoPi;
+};
+
+const sortPointEntriesClockwiseFrom = <T extends SortablePoint>(
+  entries: PointSortEntry<T>[],
+  referenceAngle: number,
+): T[] => {
+  // Use original index as a stable tie-breaker for points on the same ray.
+  return entries
+    .map((entry) => ({
+      ...entry,
+      delta: clockwiseAngleDelta(entry.angle, referenceAngle),
+    }))
+    .sort((a, b) => a.delta - b.delta || a.index - b.index)
+    .map((entry) => entry.point);
+};
+
+const sortPointsClockwiseFrom = <T extends SortablePoint>(
+  points: readonly T[],
+  centerX: number,
+  centerY: number,
+  referenceX: number,
+  referenceY: number,
+): T[] => {
+  // Sorts points clockwise, starting from the angle of `reference`.
+  const referenceAngle = xyToClockwiseAngle(referenceX, referenceY, centerX, centerY);
+  const entries: PointSortEntry<T>[] = points.map((point, index) => ({
+    point: point,
+    angle: xyToClockwiseAngle(point.x, point.y, centerX, centerY),
+    index: index,
+  }));
+
+  return sortPointEntriesClockwiseFrom(entries, referenceAngle);
+};
+
+const sortPointsClockwise = <T extends SortablePoint>(
+  points: readonly T[],
+  centerX: number,
+  centerY: number,
+): T[] | undefined => {
+  // Sorts points clockwise if they fit within a semicircle around `center`.
+  // otherwise, returns undefined.
+  if (points.length <= 1)
+    return [...points];
+
+  const entries: PointSortEntry<T>[] = points
+    .map((point, index) => ({
+      point: point,
+      angle: xyToClockwiseAngle(point.x, point.y, centerX, centerY),
+      index: index,
+    }))
+    .sort((a, b) => a.angle - b.angle || a.index - b.index);
+
+  let largestGap = 0;
+  let startIdx = 0;
+  for (const [idx, entry] of entries.entries()) {
+    const nextIdx = (idx + 1) % entries.length;
+    const nextEntry = entries[nextIdx];
+    if (nextEntry === undefined)
+      continue;
+    const gap = clockwiseAngleDelta(nextEntry.angle, entry.angle);
+
+    if (gap > largestGap) {
+      largestGap = gap;
+      startIdx = nextIdx;
+    }
+  }
+
+  // With no angular separation, there is no clockwise ordering signal.
+  if (largestGap === 0)
+    return [...points];
+
+  // Points fit in a semicircle if the complement of their largest gap is <= 180 degrees.
+  const arcLength = twoPi - largestGap;
+  if (arcLength > Math.PI + 1e-9)
+    return undefined;
+
+  const referenceAngle = entries[startIdx]?.angle ?? 0;
+  return sortPointEntriesClockwiseFrom(entries, referenceAngle);
+};
+
 export const Directions = {
   output8Dir: output8Dir,
   output16Dir: output16Dir,
@@ -402,6 +505,8 @@ export const Directions = {
   hdgTo4DirNum: hdgTo4DirNum,
   outputFrom8DirNum: outputFrom8DirNum,
   outputFromCardinalNum: outputFromCardinalNum,
+  sortPointsClockwise: sortPointsClockwise,
+  sortPointsClockwiseFrom: sortPointsClockwiseFrom,
   combatantStatePosTo8Dir: (
     combatant: PluginCombatantState,
     centerX: number,

--- a/resources/util.ts
+++ b/resources/util.ts
@@ -398,13 +398,12 @@ export type AnyDirection =
 /**
  * Get a function to pass to Array.sort to sort an array of DirectionOutput entries
  *
- * Example usage:
- *
+ * @example
  * const dirs: DirectionOutputCardinal[] = ['dirN', 'dirW'];
  *
  * dirs.sort(getSortDirectionsClockwiseFunction('dirE'));
  *
- * `dirs` should equal `['dirW', 'dirN']`
+ * // `dirs` should equal `['dirW', 'dirN']`
  *
  * @param from The DirectionOutput to treat as the start point for sort comparison
  * @returns A function to pass to the Array.sort function
@@ -437,13 +436,12 @@ type Point = {
 /**
  * Get a function to pass to Array.sort to sort an array of objects with `x` and `y` properties
  *
- * Example usage:
- *
+ * @example
  * const points = [{ x: 101, y: 101 }, { x: 99, y: 99 }];
  *
  * points.sort(getSortPointsClockwiseFunction({x: 100, y: 100}, {x: 99, y: 101}));
  *
- * `points` should now equal `[{ x: 99, y: 99 }, { x: 101, y: 101 }]`
+ * // `points` should now equal `[{ x: 99, y: 99 }, { x: 101, y: 101 }]`
  *
  * @param center The x/y point to treat as the center to calculate headings from
  * @param reference The heading or x/y point to treat as the start point for sort comparison

--- a/test/unittests/util_test.ts
+++ b/test/unittests/util_test.ts
@@ -110,11 +110,15 @@ describe('util tests', () => {
     const expected = ['NW', 'N', 'NE', 'E', 'SE', 'S', 'SW', 'W'];
 
     let [refX, refY] = [-1, -1]; // same as NW
-    let sorted = Directions.sortPointsClockwiseFrom(points, 0, 0, refX, refY);
+    let sorted = Directions.sortPointsClockwise(points, 0, 0, {
+      reference: { x: refX, y: refY },
+    });
     assert.deepEqual(sorted.map((point) => point.id), expected);
 
     [refX, refY] = [-1.2, -0.8];
-    sorted = Directions.sortPointsClockwiseFrom(points, 0, 0, refX, refY);
+    sorted = Directions.sortPointsClockwise(points, 0, 0, {
+      reference: { x: refX, y: refY },
+    });
     assert.deepEqual(sorted.map((point) => point.id), expected);
   });
 
@@ -127,10 +131,10 @@ describe('util tests', () => {
 
     const sorted = Directions.sortPointsClockwise(points, 0, 0);
 
-    assert.deepEqual(sorted?.map((point) => point.id), ['NW', 'N', 'NE']);
+    assert.deepEqual(sorted.map((point) => point.id), ['NW', 'N', 'NE']);
   });
 
-  it('returns undefined when points are not contained within a semicircle', () => {
+  it('sorts points that are not contained within a semicircle', () => {
     const points = [
       { id: 'N', x: 0, y: -1 },
       { id: 'E', x: 1, y: 0 },
@@ -138,16 +142,35 @@ describe('util tests', () => {
       { id: 'W', x: -1, y: 0 },
     ];
 
-    assert.isUndefined(Directions.sortPointsClockwise(points, 0, 0));
+    const sorted = Directions.sortPointsClockwise(points, 0, 0);
+
+    assert.deepEqual(sorted.map((point) => point.id), ['N', 'E', 'S', 'W']);
   });
 
-  it('returns undefined when points are exactly opposite', () => {
+  it('sorts points that are exactly opposite', () => {
     const points = [
       { id: 'N', x: 0, y: -1 },
       { id: 'S', x: 0, y: 1 },
     ];
 
-    assert.isUndefined(Directions.sortPointsClockwise(points, 0, 0));
+    const sorted = Directions.sortPointsClockwise(points, 0, 0);
+
+    assert.deepEqual(sorted.map((point) => point.id), ['N', 'S']);
+  });
+
+  it('sorts points clockwise from north when reference is the center', () => {
+    const points = [
+      { id: 'E', x: 1, y: 0 },
+      { id: 'S', x: 0, y: 1 },
+      { id: 'N', x: 0, y: -1 },
+      { id: 'W', x: -1, y: 0 },
+    ];
+
+    const sorted = Directions.sortPointsClockwise(points, 0, 0, {
+      reference: { x: 0, y: 0 },
+    });
+
+    assert.deepEqual(sorted.map((point) => point.id), ['N', 'E', 'S', 'W']);
   });
 
   it('keeps points in input order when all angles are equal', () => {
@@ -158,7 +181,7 @@ describe('util tests', () => {
 
     const sorted = Directions.sortPointsClockwise(points, 0, 0);
 
-    assert.deepEqual(sorted?.map((point) => point.id), ['near', 'far']);
+    assert.deepEqual(sorted.map((point) => point.id), ['near', 'far']);
     assert.notStrictEqual(sorted, points);
   });
 

--- a/test/unittests/util_test.ts
+++ b/test/unittests/util_test.ts
@@ -119,7 +119,7 @@ describe('util tests', () => {
   });
 
   it('sorts directions and unknowns, putting unknowns at the end', () => {
-    const dirs: AnyDirection[] = [
+    const dirs1: AnyDirection[] = [
       'dirNE',
       'unknown',
       'dirN',
@@ -128,13 +128,19 @@ describe('util tests', () => {
       'dirS',
     ];
 
-    const expected = ['dirN', 'dirNE', 'dirS', 'dirNW', 'unknown', 'unknown'];
-    const sorted = dirs.sort(getSortDirectionsClockwiseFunction());
-    assert.deepEqual(sorted, expected);
+    const expected1 = ['dirN', 'dirNE', 'dirS', 'dirNW', 'unknown', 'unknown'];
+    assert.deepEqual(dirs1.sort(getSortDirectionsClockwiseFunction()), expected1);
+
+    const dirs2: AnyDirection[] = ['dirNE', 'unknown', 'dirN', 'dirNW'];
+    const expected2 = ['dirNW', 'dirN', 'dirNE', 'unknown'];
+    assert.deepEqual(
+      dirs2.sort(getSortDirectionsClockwiseFunction('dirNW')),
+      expected2,
+    );
   });
 
   it('sorts points clockwise from a reference point', () => {
-    const points = [
+    const getPoints = () => [
       { id: 'NE', x: 1, y: -1 },
       { id: 'SW', x: -1, y: 1 },
       { id: 'N', x: 0, y: -1 },
@@ -148,13 +154,13 @@ describe('util tests', () => {
     const expected = ['NW', 'N', 'NE', 'E', 'SE', 'S', 'SW', 'W'];
 
     let [refX, refY] = [-1, -1]; // same as NW
-    let sorted = points.sort(
+    let sorted = getPoints().sort(
       getSortPointsClockwiseFunction({ x: 0, y: 0 }, { x: refX, y: refY }),
     );
     assert.deepEqual(sorted.map((point) => point.id), expected);
 
     [refX, refY] = [-1.2, -0.8];
-    sorted = points.sort(getSortPointsClockwiseFunction({ x: 0, y: 0 }, { x: refX, y: refY }));
+    sorted = getPoints().sort(getSortPointsClockwiseFunction({ x: 0, y: 0 }, { x: refX, y: refY }));
     assert.deepEqual(sorted.map((point) => point.id), expected);
   });
 

--- a/test/unittests/util_test.ts
+++ b/test/unittests/util_test.ts
@@ -2,10 +2,12 @@ import { assert } from 'chai';
 
 import Util, {
   allJobs,
+  AnyDirection,
   casterDpsJobs,
   craftingJobs,
-  Directions,
   gatheringJobs,
+  getSortDirectionsClockwiseFunction,
+  getSortPointsClockwiseFunction,
   healerJobs,
   limitedJobs,
   meleeDpsJobs,
@@ -95,6 +97,42 @@ describe('util tests', () => {
     );
   });
 
+  it('sorts directions clockwise from a reference direction and undefined reference', () => {
+    const dirs: AnyDirection[] = [
+      'dirNE',
+      'dirSW',
+      'dirN',
+      'dirNW',
+      'dirS',
+      'dirW',
+      'dirSE',
+      'dirE',
+    ];
+
+    let expected = ['dirNW', 'dirN', 'dirNE', 'dirE', 'dirSE', 'dirS', 'dirSW', 'dirW'];
+    let sorted = dirs.sort(getSortDirectionsClockwiseFunction('dirNW'));
+    assert.deepEqual(sorted, expected);
+
+    expected = ['dirN', 'dirNE', 'dirE', 'dirSE', 'dirS', 'dirSW', 'dirW', 'dirNW'];
+    sorted = dirs.sort(getSortDirectionsClockwiseFunction());
+    assert.deepEqual(sorted, expected);
+  });
+
+  it('sorts directions and unknowns, putting unknowns at the end', () => {
+    const dirs: AnyDirection[] = [
+      'dirNE',
+      'unknown',
+      'dirN',
+      'unknown',
+      'dirNW',
+      'dirS',
+    ];
+
+    const expected = ['dirN', 'dirNE', 'dirS', 'dirNW', 'unknown', 'unknown'];
+    const sorted = dirs.sort(getSortDirectionsClockwiseFunction());
+    assert.deepEqual(sorted, expected);
+  });
+
   it('sorts points clockwise from a reference point', () => {
     const points = [
       { id: 'NE', x: 1, y: -1 },
@@ -110,84 +148,39 @@ describe('util tests', () => {
     const expected = ['NW', 'N', 'NE', 'E', 'SE', 'S', 'SW', 'W'];
 
     let [refX, refY] = [-1, -1]; // same as NW
-    let sorted = Directions.sortPointsClockwise(points, 0, 0, {
-      reference: { x: refX, y: refY },
-    });
+    let sorted = points.sort(
+      getSortPointsClockwiseFunction({ x: 0, y: 0 }, { x: refX, y: refY }),
+    );
     assert.deepEqual(sorted.map((point) => point.id), expected);
 
     [refX, refY] = [-1.2, -0.8];
-    sorted = Directions.sortPointsClockwise(points, 0, 0, {
-      reference: { x: refX, y: refY },
-    });
+    sorted = points.sort(getSortPointsClockwiseFunction({ x: 0, y: 0 }, { x: refX, y: refY }));
     assert.deepEqual(sorted.map((point) => point.id), expected);
   });
 
-  it('sorts clustered points clockwise when contained within a semicircle', () => {
+  it('sorts points clockwise with numeric reference', () => {
     const points = [
       { id: 'NE', x: 1, y: -1 },
       { id: 'NW', x: -1, y: -1 },
       { id: 'N', x: 0, y: -1 },
     ];
 
-    const sorted = Directions.sortPointsClockwise(points, 0, 0);
+    const sorted = points.sort(
+      getSortPointsClockwiseFunction({ x: 0, y: 0 }, 0), // reference is south
+    );
 
     assert.deepEqual(sorted.map((point) => point.id), ['NW', 'N', 'NE']);
   });
 
-  it('sorts points that are not contained within a semicircle', () => {
-    const points = [
-      { id: 'N', x: 0, y: -1 },
-      { id: 'E', x: 1, y: 0 },
-      { id: 'S', x: 0, y: 1 },
-      { id: 'W', x: -1, y: 0 },
-    ];
-
-    const sorted = Directions.sortPointsClockwise(points, 0, 0);
-
-    assert.deepEqual(sorted.map((point) => point.id), ['N', 'E', 'S', 'W']);
-  });
-
-  it('sorts points that are exactly opposite', () => {
-    const points = [
-      { id: 'N', x: 0, y: -1 },
-      { id: 'S', x: 0, y: 1 },
-    ];
-
-    const sorted = Directions.sortPointsClockwise(points, 0, 0);
-
-    assert.deepEqual(sorted.map((point) => point.id), ['N', 'S']);
-  });
-
-  it('sorts points clockwise from north when reference is the center', () => {
-    const points = [
-      { id: 'E', x: 1, y: 0 },
-      { id: 'S', x: 0, y: 1 },
-      { id: 'N', x: 0, y: -1 },
-      { id: 'W', x: -1, y: 0 },
-    ];
-
-    const sorted = Directions.sortPointsClockwise(points, 0, 0, {
-      reference: { x: 0, y: 0 },
-    });
-
-    assert.deepEqual(sorted.map((point) => point.id), ['N', 'E', 'S', 'W']);
-  });
-
   it('keeps points in input order when all angles are equal', () => {
     const points = [
-      { id: 'near', x: 0, y: -1 },
-      { id: 'far', x: 0, y: -2 },
+      { id: '1', x: 0, y: -3 },
+      { id: '2', x: 0, y: -4 },
+      { id: '3', x: 0, y: -1 },
+      { id: '4', x: 0, y: -2 },
     ];
 
-    const sorted = Directions.sortPointsClockwise(points, 0, 0);
-
-    assert.deepEqual(sorted.map((point) => point.id), ['near', 'far']);
-    assert.notStrictEqual(sorted, points);
-  });
-
-  it('handles empty point sorting', () => {
-    const points: { id: string; x: number; y: number }[] = [];
-
-    assert.deepEqual(Directions.sortPointsClockwise(points, 0, 0), []);
+    const sorted = points.sort(getSortPointsClockwiseFunction({ x: 0, y: 0 }));
+    assert.deepEqual(sorted.map((point) => point.id), ['1', '2', '3', '4']);
   });
 });

--- a/test/unittests/util_test.ts
+++ b/test/unittests/util_test.ts
@@ -132,6 +132,15 @@ describe('util tests', () => {
     assert.isUndefined(Directions.sortPointsClockwise(points, 0, 0));
   });
 
+  it('returns undefined when points are exactly opposite', () => {
+    const points = [
+      { id: 'N', x: 0, y: -1 },
+      { id: 'S', x: 0, y: 1 },
+    ];
+
+    assert.isUndefined(Directions.sortPointsClockwise(points, 0, 0));
+  });
+
   it('keeps points in input order when all angles are equal', () => {
     const points = [
       { id: 'near', x: 0, y: -1 },

--- a/test/unittests/util_test.ts
+++ b/test/unittests/util_test.ts
@@ -4,6 +4,7 @@ import Util, {
   allJobs,
   casterDpsJobs,
   craftingJobs,
+  Directions,
   gatheringJobs,
   healerJobs,
   limitedJobs,
@@ -92,5 +93,60 @@ describe('util tests', () => {
     allJobs.filter((job) => !limitedJobs.includes(job)).forEach((job) =>
       assert(!Util.isLimitedJob(job))
     );
+  });
+
+  it('sorts points clockwise from a reference point', () => {
+    const points = [
+      { id: 'NE', x: 1, y: -1 },
+      { id: 'N', x: 0, y: -1 },
+      { id: 'NW', x: -1, y: -1 },
+    ];
+
+    const sorted = Directions.sortPointsClockwiseFrom(points, 0, 0, -1, -1);
+
+    assert.deepEqual(sorted.map((point) => point.id), ['NW', 'N', 'NE']);
+    assert.deepEqual(points.map((point) => point.id), ['NE', 'N', 'NW']);
+    assert.deepEqual(sorted, [points[2], points[1], points[0]]);
+  });
+
+  it('sorts clustered points clockwise when contained within a semicircle', () => {
+    const points = [
+      { id: 'NE', x: 1, y: -1 },
+      { id: 'NW', x: -1, y: -1 },
+      { id: 'N', x: 0, y: -1 },
+    ];
+
+    const sorted = Directions.sortPointsClockwise(points, 0, 0);
+
+    assert.deepEqual(sorted?.map((point) => point.id), ['NW', 'N', 'NE']);
+  });
+
+  it('returns undefined when points are not contained within a semicircle', () => {
+    const points = [
+      { id: 'N', x: 0, y: -1 },
+      { id: 'E', x: 1, y: 0 },
+      { id: 'S', x: 0, y: 1 },
+      { id: 'W', x: -1, y: 0 },
+    ];
+
+    assert.isUndefined(Directions.sortPointsClockwise(points, 0, 0));
+  });
+
+  it('keeps points in input order when all angles are equal', () => {
+    const points = [
+      { id: 'near', x: 0, y: -1 },
+      { id: 'far', x: 0, y: -2 },
+    ];
+
+    const sorted = Directions.sortPointsClockwise(points, 0, 0);
+
+    assert.deepEqual(sorted?.map((point) => point.id), ['near', 'far']);
+    assert.notStrictEqual(sorted, points);
+  });
+
+  it('handles empty point sorting', () => {
+    const points: { id: string; x: number; y: number }[] = [];
+
+    assert.deepEqual(Directions.sortPointsClockwise(points, 0, 0), []);
   });
 });

--- a/test/unittests/util_test.ts
+++ b/test/unittests/util_test.ts
@@ -98,15 +98,24 @@ describe('util tests', () => {
   it('sorts points clockwise from a reference point', () => {
     const points = [
       { id: 'NE', x: 1, y: -1 },
+      { id: 'SW', x: -1, y: 1 },
       { id: 'N', x: 0, y: -1 },
       { id: 'NW', x: -1, y: -1 },
+      { id: 'S', x: 0, y: 1 },
+      { id: 'W', x: -1, y: 0 },
+      { id: 'SE', x: 3, y: 3 },
+      { id: 'E', x: 2, y: 0 },
     ];
 
-    const sorted = Directions.sortPointsClockwiseFrom(points, 0, 0, -1, -1);
+    const expected = ['NW', 'N', 'NE', 'E', 'SE', 'S', 'SW', 'W'];
 
-    assert.deepEqual(sorted.map((point) => point.id), ['NW', 'N', 'NE']);
-    assert.deepEqual(points.map((point) => point.id), ['NE', 'N', 'NW']);
-    assert.deepEqual(sorted, [points[2], points[1], points[0]]);
+    let [refX, refY] = [-1, -1]; // same as NW
+    let sorted = Directions.sortPointsClockwiseFrom(points, 0, 0, refX, refY);
+    assert.deepEqual(sorted.map((point) => point.id), expected);
+
+    [refX, refY] = [-1.2, -0.8];
+    sorted = Directions.sortPointsClockwiseFrom(points, 0, 0, refX, refY);
+    assert.deepEqual(sorted.map((point) => point.id), expected);
   });
 
   it('sorts clustered points clockwise when contained within a semicircle', () => {


### PR DESCRIPTION
I am opening this PR because, while thinking about a Korean server strategy implementation for Forsaken, I thought these functions would be useful as shared utilities.

These are two functions that take objects containing `x` and `y` coordinates and return them sorted in clockwise order.

### sortPointsClockwise

This function sorts target points clockwise around their center point when the points are clustered on one side.

If the target points are on a semicircle, it returns the sorted points; otherwise, it returns `undefined`. (There may be cases where the points appear sortable even when they span more than a semicircle, but those are very limited exceptions.)

![img](https://i.imgur.com/6dJQE78.png)
![img](https://i.imgur.com/zMMTBYu.png)

### sortPointsClockwise with reference point

This function sorts points clockwise from the position of a specific reference point.

Because there is a reference point, there are no constraints on the positions of the points.

![img](https://i.imgur.com/dKeTOH7.png)


## 2026-06-13

- Merged `sortPointsClockwiseFrom` into `sortPointsClockwise` via an optional `{ reference }` option.
- Removed the semicircle restriction so `sortPointsClockwise` now always returns `T[]`.
