### PR TITLE
raidboss: DMU P1 trigger fix 2nd lookaway call

### DIFF
--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -1319,6 +1319,17 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
+      id: 'DMU P1 Ave Maria / Indolent Will Collect',
+      // Collect for reminder with Myster Magic
+      type: 'ActorControlExtra',
+      netRegex: { category: '019D', param1: '40', param2: '80', capture: true },
+      run: (data, matches) => {
+        const id = matches.id;
+        if (data.eyeTowerIds.includes(id) || data.fakeEyeTowerIds.includes(matches.id))
+          data.isTowerLookAway = data.eyeTowerIds.includes(id);
+      },
+    },
+    {
       id: 'DMU P1 Ave Maria (Early)',
       // BAB3 Ave Maria
       // The animation is visible ~9.89s before cast goes off, however


### PR DESCRIPTION
I missed this trigger to add to the PR but had it in my testing. This meant the PR would never define `data.isTowerLookAway`.

Fixes #1089 