### PR TITLE
raidboss: DMU P3 Timeline Updates

### DIFF
--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.txt
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.txt
@@ -2,7 +2,7 @@
 # ZoneId: 1363
 
 # NOTE: Abilities are sorted by order of appearance
-# -ii C252 BA9E BAA0 BAAB BA95 BAAF BAAD BABF BAD6 BAD8 BAD7 BAD9 BACF C250 BAF7 BAF9 C572 BAFA BAF1 BB06 BB38
+# -ii C252 BA9E BAA0 BAAB BA95 BAAF BAAD BABF BAD6 BAD8 BAD7 BAD9 BACF C250 BAF7 BAF9 C572 BAFA BAEA BAF1 BB06 BB38
 # -p C403:15.6 C24C:219.8 C3F7:500.0 C2DC:1000.0 BB40:1300.0
 # -it Kefka Chaos Exdeath
 
@@ -151,12 +151,12 @@ hideall "--sync--"
 537.3 "Definition of Insanity" Ability { id: "BAE2", source: "Kefka" }
 540.3 "--both targetable--"
 543.5 "The Decisive Battle" Ability { id: ["C2E2", "C2E3"], source: ["Chaos", "Exdeath"] }
-543.5 "--single target--" #GainsEffect { effectId: ['1061', '1063'] } # Epic Villain (Chaos)/Fated Villain (Exdeath)
+543.5 "--single target--" #GainsEffect { effectId: ['1061', '1063'] } # Epic Villain (Chaos)/Fated Villian (Exdeath)
 547.7 "--sync--" Ability { id: "C554", source: "Kefka" }
 
 # Fire, Water, and Wind Elements
 562.9 "Bowels of Agony" Ability { id: "BAF2", source: "Chaos" }
-575.0 "--both targetable--" LosesEffect { effectId: ['1061', '1063'] } # Epic Villain (Chaos)/Fated Villain (Exdeath)
+575.0 "--both targetable--" LosesEffect { effectId: ['1061', '1063'] } # Epic Villain (Chaos)/Fated Villian (Exdeath)
 582.0 "Stray Flames/Stray Spray" Ability { id: ["BAF3", "BAF6"], source: ["Chaos", "Kefka"] }
 582.0 "Thunder III" #Ability { id: "BB12", source: "Exdeath" }
 583.0 "Inferno/Tsunami" Ability { id: ["BAF4", "BAF5"], source: ["Chaos", "Kefka"] } # Supposed to be from Chaos, but can bug
@@ -174,19 +174,19 @@ hideall "--sync--"
 611.7 "Cyclone" Ability { id: "BAF8", source: "Chaos" }
 
 # Ultima Blaster Preview
-620.3 "Ultima Blaster 1" #Ability { id: "BAE3", source: "Kefka" }
-622.3 "Ultima Blaster 2" #Ability { id: "BAE3", source: "Kefka" }
-624.3 "Ultima Blaster 3" #Ability { id: "BAE3", source: "Kefka" }
+620.1 "Ultima Blaster 1" #Ability { id: "BAE3", source: "Kefka" }
+622.1 "Ultima Blaster 2" #Ability { id: "BAE3", source: "Kefka" }
+624.1 "Ultima Blaster 3" #Ability { id: "BAE3", source: "Kefka" }
 624.4 "Umbra Smash" Ability { id: "BB00", source: "Chaos" }
-626.3 "Ultima Blaster 4" #Ability { id: "BAE3", source: "Kefka" }
-627.3 "Vacuum Wave" Ability { id: "BB13", source: "Exdeath" }
-628.3 "Ultima Blaster 5" #Ability { id: "BAE3", source: "Kefka" }
-629.3 "--numbers--" # TODO: Get log timing
-630.3 "Ultima Blaster 6" #Ability { id: "BAE3", source: "Kefka" }
-631.3 "Cyclone" Ability { id: "BAF8", source: "Chaos" }
-632.4 "Ultima Blaster 7" #Ability { id: "BAE3", source: "Kefka" }
-632.7 "Aetherlink" Ability { id: ["C2E4", "C2E5"], source: ["Chaos", "Exdeath"] }
-634.4 "Ultima Blaster 8" #Ability { id: "BAE3", source: "Kefka" }
+626.1 "Ultima Blaster 4" #Ability { id: "BAE3", source: "Kefka" }
+627.1 "Vacuum Wave" Ability { id: "BB13", source: "Exdeath" }
+628.0 "Ultima Blaster 5" #Ability { id: "BAE3", source: "Kefka" }
+629.9 "--numbers--" HeadMarker { id: "0150" } # 1 marker
+630.0 "Ultima Blaster 6" #Ability { id: "BAE3", source: "Kefka" }
+631.0 "Cyclone" Ability { id: "BAF8", source: "Chaos" }
+632.0 "Ultima Blaster 7" #Ability { id: "BAE3", source: "Kefka" }
+632.4 "Aetherlink" Ability { id: ["C2E4", "C2E5"], source: ["Chaos", "Exdeath"] }
+634.0 "Ultima Blaster 8" #Ability { id: "BAE3", source: "Kefka" }
 
 # Ultima Blaster
 642.4 "Ultima Blaster 1" #Ability { id: "BAE4", source: "Kefka" }
@@ -201,7 +201,7 @@ hideall "--sync--"
 649.7 "Thunder III 1" #Ability { id: "BB0C", source: "Exdeath" }
 652.7 "Thunder III 2" #Ability { id: "BB0C", source: "Exdeath" }
 657.7 "The Decisive Battle" Ability { id: ["C2E2", "C2E3"], source: ["Chaos", "Exdeath"] }
-657.7 "--single target--" #GainsEffect { effectId: ['1061', '1063'] } # Epic Villain (Chaos)/Fated Villain (Exdeath)
+657.7 "--single target--" #GainsEffect { effectId: ['1061', '1063'] } # Epic Villain (Chaos)/Fated Villian (Exdeath)
 666.8 "--sync--" Ability { id: "BB09", source: "Exdeath" }
 666.8 "Thunder III 1" #Ability { id: "BB0C", source: "Exdeath" }
 
@@ -265,7 +265,6 @@ hideall "--sync--"
 787.4 "Slap Happy 2" #Ability { id: "BAE8", source: "Kefka" }
 788.1 "Slap Happy 3" #Ability { id: "BAE8", source: "Kefka" }
 789.3 "Slap Happy 4" Ability { id: "BAE9", source: "Kefka" }
-789.3 "Shocking Impact" Ability { id: "BAEA", source: "Kefka" }
 792.5 "Black Spark" Ability { id: "BCCD", source: ["Black Hole", "Kefka"] } # Supposed to be from Black Hole, but can bug
 796.5 "Nothingness" Ability { id: "BAFC", source: "Black Hole" }
 802.2 "Look upon Me and Despair (castbar)" Ability { id: "BAED", source: "Kefka" }
@@ -295,7 +294,7 @@ hideall "--sync--"
 823.3 "Knock Down 2" Ability { id: "BB03", source: "Chaos" }
 826.4 "Blizzard III" Ability { id: "BB11", source: "Exdeath" }
 827.4 "Big Bang" Ability { id: "BB05", source: "Chaos" }
-830.3 "--both targetable--" LosesEffect { effectId: ['1061', '1063'] } # Epic Villain (Chaos)/Fated Villain (Exdeath)
+830.3 "--both targetable--" LosesEffect { effectId: ['1061', '1063'] } # Epic Villain (Chaos)/Fated Villian (Exdeath)
 
 840.7 "--sync--" StartsUsing { id: "C61F", source: "Chaos" } window 840,5 jump "p3-chaos-enrage" # This starts when Exdeath dies
 840.7 "--sync--" StartsUsing { id: "C61E", source: "Exdeath" } window 840,5 jump "p3-exdeath-enrage" # This starts when Chaos dies
@@ -532,6 +531,7 @@ hideall "--sync--"
 # BAF9 Stray Earth: Some sort of failed P3 mechanic
 # C572 Earthquake: VFX
 # BAFA Earthquake: Cast when Accretion or Primordial Crust are cleansed
+# BAEA Shocking Impact: Getting hit by BAE9 Slap Happy center slam
 # BAF1 Unmitigated Impact: P3 Failing to soak a tower
 # BB06 Big Bang: 2 Circle AOEs that target locations where BB03 Knock Down stacks occurred
 
@@ -599,7 +599,7 @@ hideall "--sync--"
 # BAE7 Slap Happy: Boss slaps his left 3 times (role cleaves) + right once
 # BAE8 Slap Happy: 3 slaps on one side
 # BAE9 Slap Happy: Last slap that flips sides
-# BAEA Shocking Impact
+# BAEA Shocking Impact: Getting hit by BAE9 Slap Happy center slam
 # BAEB Shockwave
 # BAEC Look upon Me and Despair: Kefka falls on his right side across center of arena
 # BAED Look upon Me and Despair: Kefka falls on his left side across center of arena

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.txt
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.txt
@@ -2,7 +2,7 @@
 # ZoneId: 1363
 
 # NOTE: Abilities are sorted by order of appearance
-# -ii C252 BA9E BAA0 BAAB BA95 BAAF BAAD BABF BAD6 BAD8 BAD7 BAD9 BACF C250 BAF7 BAF9 C572 BAFA BAEA BAF1 BB06 BB38
+# -ii C252 BA9E BAA0 BAAB BA95 BAAF BAAD BABF BAD6 BAD8 BAD7 BAD9 BACF C250 BAF7 BAF9 C572 BAFA BAF1 BB06 BB38
 # -p C403:15.6 C24C:219.8 C3F7:500.0 C2DC:1000.0 BB40:1300.0
 # -it Kefka Chaos Exdeath
 
@@ -218,7 +218,7 @@ hideall "--sync--"
 688.9 "Slap Happy 2" #Ability { id: "BAE8", source: "Kefka" }
 689.7 "Slap Happy 3" #Ability { id: "BAE8", source: "Kefka" }
 690.9 "Slap Happy 4" Ability { id: "BAE9", source: "Kefka" }
-690.9 "Shockwave" #Ability { id: "BAEB", source: "Kefka" }
+690.9 "Shocking Impact/Shockwave" #Ability { id: ["BAEA", "BAEB"], source: "Kefka" }
 
 691.2 "Black Hole" Ability { id: "BAFB", source: "Exdeath" }
 698.3 "Nothingness" Ability { id: "BAFC", source: "Black Hole" }
@@ -234,7 +234,7 @@ hideall "--sync--"
 719.2 "Slap Happy 2" #Ability { id: "BAE8", source: "Kefka" }
 720.0 "Slap Happy 3" #Ability { id: "BAE8", source: "Kefka" }
 721.2 "Slap Happy 4" Ability { id: "BAE9", source: "Kefka" }
-721.2 "Shockwave" #Ability { id: "BAEB", source: "Kefka" }
+721.2 "Shocking Impact/Shockwave" #Ability { id: ["BAEA", "BAEB"], source: "Kefka" }
 724.6 "Black Spark" Ability { id: "BCCD", source: "Black Hole" }
 728.6 "Nothingness" Ability { id: "BAFC", source: "Black Hole" }
 730.2 "Primordial Crust Quake?" #Ability { id: "BAFA", source: "Chaos" }
@@ -265,6 +265,7 @@ hideall "--sync--"
 787.4 "Slap Happy 2" #Ability { id: "BAE8", source: "Kefka" }
 788.1 "Slap Happy 3" #Ability { id: "BAE8", source: "Kefka" }
 789.3 "Slap Happy 4" Ability { id: "BAE9", source: "Kefka" }
+789.3 "Shocking Impact/Shockwave" #Ability { id: ["BAEA", "BAEB"], source: "Kefka" }
 792.5 "Black Spark" Ability { id: "BCCD", source: ["Black Hole", "Kefka"] } # Supposed to be from Black Hole, but can bug
 796.5 "Nothingness" Ability { id: "BAFC", source: "Black Hole" }
 802.2 "Look upon Me and Despair (castbar)" Ability { id: "BAED", source: "Kefka" }
@@ -531,7 +532,6 @@ hideall "--sync--"
 # BAF9 Stray Earth: Some sort of failed P3 mechanic
 # C572 Earthquake: VFX
 # BAFA Earthquake: Cast when Accretion or Primordial Crust are cleansed
-# BAEA Shocking Impact: Getting hit by BAE9 Slap Happy center slam
 # BAF1 Unmitigated Impact: P3 Failing to soak a tower
 # BB06 Big Bang: 2 Circle AOEs that target locations where BB03 Knock Down stacks occurred
 
@@ -599,8 +599,8 @@ hideall "--sync--"
 # BAE7 Slap Happy: Boss slaps his left 3 times (role cleaves) + right once
 # BAE8 Slap Happy: 3 slaps on one side
 # BAE9 Slap Happy: Last slap that flips sides
-# BAEA Shocking Impact: Getting hit by BAE9 Slap Happy center slam
-# BAEB Shockwave
+# BAEA Shocking Impact: Party Cleave at end of BAE6 Slap Happy
+# BAEB Shockwave: Role Cleaves at end of BAE7 Slap Happy
 # BAEC Look upon Me and Despair: Kefka falls on his right side across center of arena
 # BAED Look upon Me and Despair: Kefka falls on his left side across center of arena
 # BAEE Look upon Me and Despair: Gives a 3-min damage down if hit

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.txt
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.txt
@@ -151,12 +151,12 @@ hideall "--sync--"
 537.3 "Definition of Insanity" Ability { id: "BAE2", source: "Kefka" }
 540.3 "--both targetable--"
 543.5 "The Decisive Battle" Ability { id: ["C2E2", "C2E3"], source: ["Chaos", "Exdeath"] }
-543.5 "--single target--" #GainsEffect { effectId: ['1061', '1063'] } # Epic Villain (Chaos)/Fated Villian (Exdeath)
+543.5 "--single target--" #GainsEffect { effectId: ['1061', '1063'] } # Epic Villain (Chaos)/Fated Villain (Exdeath)
 547.7 "--sync--" Ability { id: "C554", source: "Kefka" }
 
 # Fire, Water, and Wind Elements
 562.9 "Bowels of Agony" Ability { id: "BAF2", source: "Chaos" }
-575.0 "--both targetable--" LosesEffect { effectId: ['1061', '1063'] } # Epic Villain (Chaos)/Fated Villian (Exdeath)
+575.0 "--both targetable--" LosesEffect { effectId: ['1061', '1063'] } # Epic Villain (Chaos)/Fated Villain (Exdeath)
 582.0 "Stray Flames/Stray Spray" Ability { id: ["BAF3", "BAF6"], source: ["Chaos", "Kefka"] }
 582.0 "Thunder III" #Ability { id: "BB12", source: "Exdeath" }
 583.0 "Inferno/Tsunami" Ability { id: ["BAF4", "BAF5"], source: ["Chaos", "Kefka"] } # Supposed to be from Chaos, but can bug
@@ -201,7 +201,7 @@ hideall "--sync--"
 649.7 "Thunder III 1" #Ability { id: "BB0C", source: "Exdeath" }
 652.7 "Thunder III 2" #Ability { id: "BB0C", source: "Exdeath" }
 657.7 "The Decisive Battle" Ability { id: ["C2E2", "C2E3"], source: ["Chaos", "Exdeath"] }
-657.7 "--single target--" #GainsEffect { effectId: ['1061', '1063'] } # Epic Villain (Chaos)/Fated Villian (Exdeath)
+657.7 "--single target--" #GainsEffect { effectId: ['1061', '1063'] } # Epic Villain (Chaos)/Fated Villain (Exdeath)
 666.8 "--sync--" Ability { id: "BB09", source: "Exdeath" }
 666.8 "Thunder III 1" #Ability { id: "BB0C", source: "Exdeath" }
 
@@ -294,7 +294,7 @@ hideall "--sync--"
 823.3 "Knock Down 2" Ability { id: "BB03", source: "Chaos" }
 826.4 "Blizzard III" Ability { id: "BB11", source: "Exdeath" }
 827.4 "Big Bang" Ability { id: "BB05", source: "Chaos" }
-830.3 "--both targetable--" LosesEffect { effectId: ['1061', '1063'] } # Epic Villain (Chaos)/Fated Villian (Exdeath)
+830.3 "--both targetable--" LosesEffect { effectId: ['1061', '1063'] } # Epic Villain (Chaos)/Fated Villain (Exdeath)
 
 840.7 "--sync--" StartsUsing { id: "C61F", source: "Chaos" } window 840,5 jump "p3-chaos-enrage" # This starts when Exdeath dies
 840.7 "--sync--" StartsUsing { id: "C61E", source: "Exdeath" } window 840,5 jump "p3-exdeath-enrage" # This starts when Chaos dies


### PR DESCRIPTION
Removes BAEA Shocking Impact which only happens if a player erroneously stands in the center BAE9 Slap Happy.
Timing adjustment up to Ultima Blaster HeadMarkers.