### PR TITLE
raidboss: r8s fix towerDirs assignment

### DIFF
--- a/ui/raidboss/data/07-dt/raid/r8s.ts
+++ b/ui/raidboss/data/07-dt/raid/r8s.ts
@@ -907,9 +907,9 @@ const triggerSet: TriggerSet<Data> = {
         // Assume towerDirs from Fang if received bad coords for towers
         if (data.towerDirs === undefined) {
           if (y > 99 && y < 100)
-            data.towerDirs === 'NS';
+            data.towerDirs = 'NS';
           else if (x > 99 && x < 101)
-            data.towerDirs === 'EW';
+            data.towerDirs = 'EW';
           else
             return;
         }


### PR DESCRIPTION
This was unlikely to be encountered as it would have required some missing data elswehere, but these should be fixed.

Thanks to @valarnin for finding and reporting this in discord.