### PR TITLE
raidboss: DMU P4 Initial Triggers

### DIFF
--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -72,6 +72,7 @@ export interface Data extends RaidbossData {
   grandCrossCount: number;
   shortShriekPlayers: string[];
   longShriekPlayers: string[];
+  isFirstDebuffShort?: boolean;
   shortForkedPlayers: string[];
   longForkedPlayers: string[];
   shortCompressedPlayers: string[];
@@ -4016,6 +4017,68 @@ const triggerSet: TriggerSet<Data> = {
         // has unique cast ids for true/fake
       },
     },
+/*
+    {
+      id: 'DMU P4 Chaos and Neo Exdeath Debuff Info',
+      // In the count field of Effect 808, the bosses receive these values:
+      // Fake Chaos: 45F
+      // True Chaos: 460
+      // Fake Neo Exdeath: 461
+      // True Neo Exdeath: 462
+      type: 'GainsEffect',
+      netRegex: {
+        effectId: '808',
+        count: ['45F', '460', '461', '462'],
+        capture: true,
+      },
+      infoText: (data, matches, output) => {
+        const count = matches.count;
+        if (count === '45F' || count === '460') {
+          const chaosLocaleNames: LocaleText = {
+            en: 'Chaos',
+            de: 'Chaos',
+            fr: 'Chaos',
+            ja: 'カオス',
+            cn: '卡奥斯',
+            ko: '카오스',
+            tc: '卡奧斯',
+          };
+          const chaosName = chaosLocaleNames[data.parserLang];
+          return count === '45F'
+            ? output.fakeChaos!({ chaos: chaosName })
+            : output.trueChaos!({ chaos: chaosName });
+        }
+
+        const exdeathLocaleNames: LocaleText = {
+          en: 'Exdeath',
+          de: 'Exdeath',
+          fr: 'Exdeath',
+          ja: 'エクスデス',
+          cn: '艾克斯迪司',
+          ko: '엑스데스',
+          tc: '艾克斯迪司',
+        };
+        const exdeathName = exdeathLocaleNames[data.parserLang];
+        return count === '461'
+          ? output.fakeExdeath!({ exdeath: exdeathName })
+          : output.trueExdeath!({ exdeath: exdeathName });
+      },
+      outputStrings: {
+        fakeExdeath: {
+          en: 'Fake ${exdeath}',
+        },
+        fakeChaos: {
+          en: 'Fake ${chaos}',
+        },
+        trueExdeath: {
+          en: 'True ${exdeath}',
+        },
+        trueChaos: {
+          en: 'True ${chaos}',
+        },
+      },
+    },
+*/
     {
       id: 'DMU P4 Tsunami/Inferno',
       // BB14 Grand Cross AoE also happens ~4s after this cast starts
@@ -4044,15 +4107,15 @@ const triggerSet: TriggerSet<Data> = {
       id: 'DMU P4 Debuff Collect',
       // Neo Exdeath Debuffs Cast 1: (12:28.672)
       // 15A7 Cursed Shriek x2 60s                        =>          13:28.672
-      // 15A8 Forked Lightning x2 76s                     =>                    13:44.672
-      // 15A9 Compressed Water x2 76s                     =>                    13:44.672
+      // 15A8 Forked Lightning x2 76s or 51s              => 13:19.578          13:44.672
+      // 15A9 Compressed Water x2 76s or 51s              => 13:19.578          13:44.672
       // 15AA Acceleration Bomb (2 Long 76s, 2 Short 51s) => 13:19.672          13:44.672
       // Chaos Debuffs 1: (12:34.341)
       // 15AC Dynamic Fluid x8 84s                        => 13:48.672
       // Neo Exdeath Debuffs Cast 2: (12:43.578)
-      // 15A8 Forked Lightning x2 36s                     => 13:19.578
+      // 15A8 Forked Lightning x2 36s or 61s              => 13:19.578          13.44.578
       // 15A7 Cursed Shriek x2 69s                        => 13:52.578
-      // 15A9 Compressed Water x2 36s                     => 13:19.578
+      // 15A9 Compressed Water x2 36s or 61s              => 13:19.578          13.44.578
       // 15AA Acceleration Bomb (2 Long 61s, 2 Short 36s) => 13:19.578          13:44.578
       // Chaos Debuffs 2: 12:50.485
       // 15AB Entroy x8 45s                               => 13:35.485
@@ -4072,6 +4135,7 @@ const triggerSet: TriggerSet<Data> = {
       // 1 Support, 1 DPS with Long Gaze (Cursed Shriek or Fake Cursed Shriek)
       // 2 Support, 2 DPS with Short Stillness (Acceleration Bomb or Fake Acceleration Bomb)
       // 2 Support, 2 DPS with Long Stillness (Acceleration Bomb or Fake Acceleration Bomb)
+      // 1st and 2nd set debuffs can swap Forked + Compressed Timings
       // For 3rd set of debuffs we do not need to know real/fake:
       // Allagan Field players swap their color by getting hit with opposite color Angilight
       // Beyond Death field players keep their color by getting hit with same colore Antilight
@@ -4106,15 +4170,19 @@ const triggerSet: TriggerSet<Data> = {
             data.longShriekPlayers.push(target);
         } else if (id === '15A8') {
           // Forked Lightning
-          if (duration < 37)
+          if (duration < 52) { // Capture both 51s and 36s
+            if (data.isFirstDebuffShort === undefined)
+              data.isFirstDebuffShort = duration > 37 ? true : false;
             data.shortForkedPlayers.push(target);
-          else
+          } else
             data.longForkedPlayers.push(target);
         } else if (id === '15A9') {
           // Compressed Water
-          if (duration < 37)
+          if (duration < 52) { // Capture both 51s and 36s
+            if (data.isFirstDebuffShort === undefined)
+              data.isFirstDebuffShort = duration > 37 ? true : false;
             data.shortCompressedPlayers.push(target);
-          else
+          } else
             data.longCompressedPlayers.push(target);
         } else if (id === '15AA') {
           // Acceleration Bomb
@@ -4139,8 +4207,8 @@ const triggerSet: TriggerSet<Data> = {
       id: 'DMU P4 First Debuffs (Early)',
       // Cast 1:
       // 15A7 Cursed Shriek x2 60s
-      // 15A8 Forked Lightning x2 76s
-      // 15A9 Compressed Water x2 76s
+      // 15A8 Forked Lightning x2 76s or 51s
+      // 15A9 Compressed Water x2 76s or 51s
       // 15AA Acceleration Bomb (2 Long 76s, 2 Short 51s)
       type: 'GainsEffect',
       netRegex: { effectId: ['15A7', '15A8', '15A9', '15AA'], capture: true },
@@ -4148,14 +4216,21 @@ const triggerSet: TriggerSet<Data> = {
       delaySeconds: 0.1,
       suppressSeconds: 99999,
       infoText: (data, _matches, output) => {
-        const hasShreik = data.shortShriekPlayers.includes(data.me);
-        const hasFork = data.longForkedPlayers.includes(data.me);
-        const hasCompressed = data.longCompressedPlayers.includes(data.me);
-        const hasBomb = data.longBombPlayers.includes(data.me);
         const isTrue = data.areFirstDebuffsTrue;
+        const isShort = data.isFirstDebuffShort;
 
-        if (isTrue === undefined)
+        if (isTrue === undefined || isShort === undefined)
           return;
+
+        const hasShreik = data.shortShriekPlayers.includes(data.me);
+        const hasFork = isShort
+          ? data.shortForkedPlayers.includes(data.me)
+          : data.longForkedPlayers.includes(data.me);
+        const hasCompressed = isShort
+          ? data.shortForkedPlayers.includes(data.me)
+          : data.longForkedPlayers.includes(data.me);
+        const hasBomb = data.longBombPlayers.includes(data.me);
+
 
         // Shriek players always are short bomb
         // This will be two players
@@ -4167,13 +4242,22 @@ const triggerSet: TriggerSet<Data> = {
 
         // Remaing 6 players will get one debuff
         if ((hasFork && isTrue) || (hasCompressed && !isTrue))
-          return output.spreadSecond!({ mech: output.spread!() });
+          return isShort
+            ? output.spreadFirst!({ mech: output.spread!() })
+            : output.spreadSecond!({ mech: output.spread!() });
         if ((hasFork && !isTrue) || (hasCompressed && isTrue))
-          return output.stackSecond!({ mech: output.stack!() });
+          return isShort
+            ? output.stackFirst!({ mech: output.stack!() })
+            : output.stackSecond!({ mech: output.stack!() });
         if (hasBomb)
           return output.bombSecond!({
             mech: isTrue ? output.bomb!() : output.fakeBomb!(),
           });
+
+        // No debuff, they will be a stack player
+        return isShort
+          ? output.stackFirstNoDebuff!({ mech: output.stack!() })
+          : output.stackSecondNoDebuff!({ mech: output.stack!() });
       },
       outputStrings: {
         firstGazeAndBomb: {
@@ -4185,10 +4269,22 @@ const triggerSet: TriggerSet<Data> = {
         fakeGaze: {
           en: 'Look At',
         },
-        spreadSecond: {
-          en: '${mech} on YOU Second',
+        spreadFirst: {
+          en: '${mech} on YOU First',
+        },
+        stackFirst: {
+          en: '${mech} on YOU First',
+        },
+        stackFirstNoDebuff: {
+          en: 'No Debuff, ${mech} First',
+        },
+        stackSecondNoDebuff: {
+          en: 'No Debuff, ${mech} Second',
         },
         stackSecond: {
+          en: '${mech} on YOU Second',
+        },
+        spreadSecond: {
           en: '${mech} on YOU Second',
         },
         bombSecond: {
@@ -4230,9 +4326,9 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'DMU P4 Second Debuffs (Early)',
       // Cast 2:
-      // 15A8 Forked Lightning x2 36s
+      // 15A8 Forked Lightning x2 36s or 61s
       // 15A7 Cursed Shriek x2 69s
-      // 15A9 Compressed Water x2 36s
+      // 15A9 Compressed Water x2 36s or 61s
       // 15AA Acceleration Bomb (2 Long 61s, 2 Short 36s)
       type: 'GainsEffect',
       netRegex: { effectId: ['15A7', '15A8', '15A9', '15AA'], capture: true },
@@ -4242,14 +4338,20 @@ const triggerSet: TriggerSet<Data> = {
       delaySeconds: 0.1,
       suppressSeconds: 99999,
       infoText: (data, _matches, output) => {
-        const hasShreik = data.longShriekPlayers.includes(data.me);
-        const hasFork = data.shortForkedPlayers.includes(data.me);
-        const hasCompressed = data.shortCompressedPlayers.includes(data.me);
-        const hasBomb = data.shortBombPlayers.includes(data.me);
         const isTrue = data.areSecondDebuffsTrue;
+        const isShort = data.isFirstDebuffShort;
 
-        if (isTrue === undefined)
+        if (isTrue === undefined || isShort === undefined)
           return;
+
+        const hasShreik = data.longShriekPlayers.includes(data.me);
+        const hasFork = isShort
+          ? data.longForkedPlayers.includes(data.me)
+          : data.shortForkedPlayers.includes(data.me);
+        const hasCompressed = isShort
+          ? data.longForkedPlayers.includes(data.me)
+          : data.shortForkedPlayers.includes(data.me);
+        const hasBomb = data.shortBombPlayers.includes(data.me);
 
         // Shriek players always are short bomb
         // This will be two players
@@ -4261,13 +4363,22 @@ const triggerSet: TriggerSet<Data> = {
 
         // Remaing 6 players will get one debuff
         if ((hasFork && isTrue) || (hasCompressed && !isTrue))
-          return output.spreadFirst!({ mech: output.spread!() });
+          return isShort
+            ? output.spreadSecond!({ mech: output.spread!() })
+            : output.spreadFirst!({ mech: output.spread!() });
         if ((hasFork && !isTrue) || (hasCompressed && isTrue))
-          return output.stackFirst!({ mech: output.stack!() });
+          return isShort
+            ? output.stackSecond!({ mech: output.stack!() })
+            : output.stackFirst!({ mech: output.stack!() });
         if (hasBomb)
           return output.bombFirst!({
             mech: isTrue ? output.bomb!() : output.fakeBomb!(),
           });
+
+        // No debuff, they will be a stack player
+        return isShort
+          ? output.stackSecondNoDebuff!({ mech: output.stack!() })
+          : output.stackFirstNoDebuff!({ mech: output.stack!() });
       },
       outputStrings: {
         secondGazeAndBomb: {
@@ -4287,6 +4398,18 @@ const triggerSet: TriggerSet<Data> = {
         },
         bombFirst: {
           en: '${mech} on YOU First',
+        },
+        stackFirstNoDebuff: {
+          en: 'No Debuff, ${mech} First',
+        },
+        stackSecondNoDebuff: {
+          en: 'No Debuff, ${mech} Second',
+        },
+        spreadSecond: {
+          en: '${mech} on YOU Second',
+        },
+        stackSecond: {
+          en: '${mech} on YOU Second',
         },
         stack: Outputs.stackMarker,
         spread: Outputs.spread,
@@ -4396,13 +4519,13 @@ const triggerSet: TriggerSet<Data> = {
             : output.left!(),
         });
 
+        const isTrue = data.areSecondDebuffsTrue;
+        if (isTrue === undefined)
+          return laser;
+
         const hasFork = data.shortForkedPlayers.includes(data.me);
         const hasCompressed = data.shortCompressedPlayers.includes(data.me);
         const hasBomb = data.shortBombPlayers.includes(data.me);
-        const isTrue = data.areSecondDebuffsTrue;
-
-        if (isTrue === undefined)
-          return laser;
 
         const hasSpread = (hasFork && isTrue) || (hasCompressed && !isTrue);
         const hasStack = (hasFork && !isTrue) || (hasCompressed && isTrue);
@@ -4489,14 +4612,14 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { id: ['C394', 'C395'], source: 'Neo Exdeath', capture: false },
       suppressSeconds: 99999,
       alertText: (data, _matches, output) => {
+        const is2ndTrue = data.areSecondDebuffsTrue;
+        const is1stTrue = data.areFirstDebuffsTrue;
+        if (is2ndTrue === undefined || is1stTrue === undefined)
+          return;
+
         const hasFork = data.shortForkedPlayers.includes(data.me);
         const hasCompressed = data.shortCompressedPlayers.includes(data.me);
         const hasBomb = data.shortBombPlayers.includes(data.me);
-        const is2ndTrue = data.areSecondDebuffsTrue;
-        const is1stTrue = data.areFirstDebuffsTrue;
-
-        if (is2ndTrue === undefined || is1stTrue === undefined)
-          return;
 
         const players = data.shortShriekPlayers.map(
           (player) => {
@@ -4717,14 +4840,14 @@ const triggerSet: TriggerSet<Data> = {
       },
       suppressSeconds: 99999,
       alertText: (data, _matches, output) => {
+        const is1stTrue = data.areFirstDebuffsTrue;
+        const is2ndTrue = data.areSecondDebuffsTrue;
+        if (is2ndTrue === undefined || is1stTrue === undefined)
+          return;
+
         const hasFork = data.longForkedPlayers.includes(data.me);
         const hasCompressed = data.longCompressedPlayers.includes(data.me);
         const hasBomb = data.longBombPlayers.includes(data.me);
-        const is1stTrue = data.areFirstDebuffsTrue;
-        const is2ndTrue = data.areSecondDebuffsTrue;
-
-        if (is2ndTrue === undefined || is1stTrue === undefined)
-          return;
 
         const players = data.longShriekPlayers.map(
           (player) => {

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -739,12 +739,12 @@ const triggerSet: TriggerSet<Data> = {
       // BA94 Myster Magic
       // BA95 Blizzard III Blowout
       // C5DE Thrumming Thunder III
-      // BAA5 Mana Release
+      // BAA5 Mana Release (6.7s castTime, but there is additional ~0.382 delay until tells
       type: 'StartsUsing',
       netRegex: { id: ['BA94', 'BA95', 'C5DE', 'BAA5'], source: 'Kefka', capture: true },
       delaySeconds: (_data, matches) => {
         if (matches.id === 'BAA5')
-          return parseFloat(matches.castTime); // Mana Release happens before the tells
+          return parseFloat(matches.castTime) + 0.4;
         return 0;
       },
       infoText: (data, matches, output) => {

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4546,7 +4546,7 @@ const triggerSet: TriggerSet<Data> = {
       // 5CD Thunder Charged: Store the value of isThunderTrue for later
       // 5CC Blizzard Charged: Store the value of isIceTrue for later
       type: 'GainsEffect',
-      netRegex: { effectId: ['5CD', '5CC'], capture: false },
+      netRegex: { effectId: ['5CD', '5CC'], capture: true },
       run: (data, matches) => {
         if (matches.effectId === '5CD')
           data.isThunderChargedTrue = data.isThunderTrue;

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4833,7 +4833,7 @@ const triggerSet: TriggerSet<Data> = {
         if (is2ndTrue === undefined || isFluidTrue === undefined)
           return;
 
-        const players = data.shortShriekPlayers.map(
+        const players = data.longShriekPlayers.map(
           (player) => {
             if (player === data.me)
               return output.you!();

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4649,6 +4649,7 @@ const triggerSet: TriggerSet<Data> = {
       // 5CC Blizzard Charged: Store the value of isIceTrue for later
       type: 'GainsEffect',
       netRegex: { effectId: ['5CD', '5CC'], capture: true },
+      delaySeconds: 0.1, // Delay for headmarker collect
       run: (data, matches) => {
         if (matches.effectId === '5CD')
           data.isThunderChargedTrue = data.isThunderTrue;

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4721,15 +4721,30 @@ const triggerSet: TriggerSet<Data> = {
         );
         const msg = players?.join(', ');
 
+        // Seperate configurable output if you have it
+        if (shriekPlayers.includes(data.me)) {
+          return isTrue
+            ? output.lookAwayFromPlayerYou!({ players: msg })
+            : output.lookAtPlayerYou!({ players: msg });
+        }
         return isTrue
           ? output.lookAwayFromPlayers!({ players: msg })
           : output.lookAtPlayers!({ players: msg });
       },
       outputStrings: {
+        you: {
+          en: 'YOU',
+        },
         lookAtPlayers: {
           en: 'Face ${players} (later)',
         },
         lookAwayFromPlayers: {
+          en: 'Look Away from ${players} (later)',
+        },
+        lookAtPlayerYou: {
+          en: 'Face ${players} (later)',
+        },
+        lookAwayFromPlayerYou: {
           en: 'Look Away from ${players} (later)',
         },
       },

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4038,14 +4038,38 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'DMU P4 Tsunami/Inferno',
-      // BB14 Grand Cross AoE also happens ~4s after this cast starts
-      // BB20 Inferno / BB21 Tsunami are 8.7s castTime
+      id: 'DMU P4 Second and Fourth Debuffs (Early)',
+      // Using BB20 Inferno / BB21 Tsunami
       // Source can be innaccurate
       type: 'StartsUsing',
       netRegex: { id: ['BB20', 'BB21'], capture: true },
-      delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 5,
-      response: Responses.aoe(),
+      delaySeconds: 1, // Delay for boss true/false effect and avoid TTS AoE conflict
+      infoText: (data, matches, output) => {
+        const isTrue = data.areFourthDebuffsTrue !== undefined
+          ? data.areFourthDebuffsTrue
+          : data.areSecondDebuffsTrue;
+        if (isTrue === undefined)
+          return; // Failed to capture true/false
+
+        const isInferno = matches.id === 'BB20';
+        if (isInferno)
+          return isTrue ? output.puddlesFirst!() : output.donutsFirst!();
+        return isTrue ? output.donutsSecond!() : output.puddlesSecond!();
+      },
+      outputStrings: {
+        puddlesFirst: {
+          en: 'Puddles First',
+        },
+        puddlesSecond: {
+          en: 'Puddles Second',
+        },
+        donutsFirst: {
+          en: 'Donuts First',
+        },
+        donutsSecond: {
+          en: 'Donuts Second',
+        },
+      },
     },
     {
       id: 'DMU P4 Grand Cross Counter',
@@ -4163,7 +4187,9 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'DMU P4 First Debuffs (Early)',
+      id: 'DMU P4 Tsunami/Inferno and First Debuffs (Early)',
+      // Tsunami/Inferno are 8.7s castTime, but a delay of 5s leads to TTS overlap
+      // The two are merged resulting in a delay of ~4.7s
       // Cast 1:
       // 15A7 Cursed Shriek x2 60s
       // 15A8 Forked Lightning x2 76s or 51s
@@ -4178,7 +4204,7 @@ const triggerSet: TriggerSet<Data> = {
         const isTrue = data.areFirstDebuffsTrue;
         const isShort = data.isFirstDebuffShort;
         if (isTrue === undefined || isShort === undefined)
-          return;
+          return output.aoe!();
 
         const hasShreik = data.shortShriekPlayers.includes(data.me);
         const hasFork = isShort
@@ -4192,31 +4218,50 @@ const triggerSet: TriggerSet<Data> = {
         // Shriek players always are short bomb
         // This will be two players
         if (hasShreik)
-          return output.firstGazeAndBomb!({
-            gaze: isTrue ? output.gaze!() : output.fakeGaze!(),
-            bomb: isTrue ? output.bomb!() : output.fakeBomb!(),
+          return output.aoeDebuff!({
+            aoe: output.aoe!(),
+            debuff: output.firstGazeAndBomb!({
+              gaze: isTrue ? output.gaze!() : output.fakeGaze!(),
+              bomb: isTrue ? output.bomb!() : output.fakeBomb!(),
+            }),
           });
 
         // Remaing 6 players will get one debuff
         if ((hasFork && isTrue) || (hasCompressed && !isTrue))
-          return isShort
-            ? output.spreadFirst!({ mech: output.spread!() })
-            : output.spreadSecond!({ mech: output.spread!() });
+          return output.aoeDebuff!({
+            aoe: output.aoe!(),
+            debuff: isShort
+              ? output.spreadFirst!({ mech: output.spread!() })
+              : output.spreadSecond!({ mech: output.spread!() }),
+          });
         if ((hasFork && !isTrue) || (hasCompressed && isTrue))
-          return isShort
-            ? output.stackFirst!({ mech: output.stack!() })
-            : output.stackSecond!({ mech: output.stack!() });
+          return output.aoeDebuff!({
+            aoe: output.aoe!(),
+            debuff: isShort
+              ? output.stackFirst!({ mech: output.stack!() })
+              : output.stackSecond!({ mech: output.stack!() }),
+          });
         if (hasBomb)
-          return output.bombSecond!({
-            mech: isTrue ? output.bomb!() : output.fakeBomb!(),
+          return output.aoeDebuff!({
+            aoe: output.aoe!(),
+            debuff: output.bombSecond!({
+              mech: isTrue ? output.bomb!() : output.fakeBomb!(),
+            }),
           });
 
         // No debuff, they will be a stack player
-        return isShort
-          ? output.stackFirstNoDebuff!({ mech: output.stack!() })
-          : output.stackSecondNoDebuff!({ mech: output.stack!() });
+        return output.aoeDebuff!({
+            aoe: output.aoe!(),
+            debuff: isShort
+              ? output.stackFirstNoDebuff!({ mech: output.stack!() })
+              : output.stackSecondNoDebuff!({ mech: output.stack!() }),
+        });
       },
       outputStrings: {
+        aoe: Outputs.aoe,
+        aoeDebuff: {
+          en: '${aoe} + ${debuff}',
+        },
         firstGazeAndBomb: {
           en: '${gaze} + ${bomb} on YOU First',
         },
@@ -4259,12 +4304,11 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'DMU P4 Entropy/Dynamic Fluid Collect',
-      // Separate trigger as we only need to capture one
       // 15AB Entropy
       // 15AC Dynamic Fluid
       type: 'GainsEffect',
       netRegex: { effectId: ['15AB', '15AC'], capture: true },
-      condition: Conditions.targetIsYou(),
+      suppressSeconds: 1,
       run: (data, matches) => {
         const duration = parseFloat(matches.duration);
         // These could be undefined if the true/false trigger fails to collect
@@ -4282,38 +4326,7 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'DMU P4 Second Debuffs (Early)',
-      type: 'GainsEffect',
-      netRegex: { effectId: ['15AB', '15AC'], capture: true },
-      condition: (data) => data.grandCrossCount === 1,
-      delaySeconds: 0.1,
-      suppressSeconds: 99999,
-      infoText: (data, matches, output) => {
-        const areSecondDebuffsTrue = data.areSecondDebuffsTrue;
-        if (areSecondDebuffsTrue === undefined)
-          return;
-        const isEntropy = matches.id === '15AB';
-        if (isEntropy)
-          return areSecondDebuffsTrue ? output.puddlesFirst!() : output.donutsFirst!();
-        return areSecondDebuffsTrue ? output.donutsSecond!() : output.puddlesSecond!();
-      },
-      outputStrings: {
-        puddlesFirst: {
-          en: 'Puddles First',
-        },
-        puddlesSecond: {
-          en: 'Puddles Second',
-        },
-        donutsFirst: {
-          en: 'Donuts First',
-        },
-        donutsSecond: {
-          en: 'Donuts Second',
-        },
-      },
-    },
-    {
-      id: 'DMU P4 Third Debuffs (Early)',
+      id: 'DMU P4 Tsunami/Inferno and Third Debuffs (Early)',
       // Cast 2:
       // 15A8 Forked Lightning x2 36s or 61s
       // 15A7 Cursed Shriek x2 69s
@@ -4330,7 +4343,7 @@ const triggerSet: TriggerSet<Data> = {
         const isTrue = data.areThirdDebuffsTrue;
         const isShort = data.isFirstDebuffShort;
         if (isTrue === undefined || isShort === undefined)
-          return;
+          return output.aoe!();
 
         const hasShreik = data.longShriekPlayers.includes(data.me);
         const hasFork = isShort
@@ -4344,31 +4357,50 @@ const triggerSet: TriggerSet<Data> = {
         // Shriek players always are short bomb
         // This will be two players
         if (hasShreik)
-          return output.secondGazeAndBomb!({
-            gaze: isTrue ? output.gaze!() : output.fakeGaze!(),
-            bomb: isTrue ? output.bomb!() : output.fakeBomb!(),
+          return output.aoeDebuff!({
+            aoe: output.aoe!(),
+            debuff: output.secondGazeAndBomb!({
+              gaze: isTrue ? output.gaze!() : output.fakeGaze!(),
+              bomb: isTrue ? output.bomb!() : output.fakeBomb!(),
+            }),
           });
 
         // Remaing 6 players will get one debuff
         if ((hasFork && isTrue) || (hasCompressed && !isTrue))
-          return isShort
-            ? output.spreadSecond!({ mech: output.spread!() })
-            : output.spreadFirst!({ mech: output.spread!() });
+          return output.aoeDebuff!({
+            aoe: output.aoe!(),
+            debuff: isShort
+              ? output.spreadSecond!({ mech: output.spread!() })
+              : output.spreadFirst!({ mech: output.spread!() }),
+          });
         if ((hasFork && !isTrue) || (hasCompressed && isTrue))
-          return isShort
-            ? output.stackSecond!({ mech: output.stack!() })
-            : output.stackFirst!({ mech: output.stack!() });
+          return output.aoeDebuff!({
+            aoe: output.aoe!(),
+            debuff: isShort
+              ? output.stackSecond!({ mech: output.stack!() })
+              : output.stackFirst!({ mech: output.stack!() }),
+          });
         if (hasBomb)
-          return output.bombFirst!({
-            mech: isTrue ? output.bomb!() : output.fakeBomb!(),
+          return output.aoeDebuff!({
+            aoe: output.aoe!(),
+            debuff: output.bombFirst!({
+              mech: isTrue ? output.bomb!() : output.fakeBomb!(),
+            }),
           });
 
         // No debuff, they will be a stack player
-        return isShort
-          ? output.stackSecondNoDebuff!({ mech: output.stack!() })
-          : output.stackFirstNoDebuff!({ mech: output.stack!() });
+        return output.aoeDebuff!({
+            aoe: output.aoe!(),
+            debuff: isShort
+              ? output.stackSecondNoDebuff!({ mech: output.stack!() })
+              : output.stackFirstNoDebuff!({ mech: output.stack!() }),
+        });
       },
       outputStrings: {
+        aoe: Outputs.aoe,
+        aoeDebuff: {
+          en: '${aoe} + ${debuff}',
+        },
         secondGazeAndBomb: {
           en: '${gaze} + ${bomb} on YOU Second',
         },
@@ -4406,37 +4438,6 @@ const triggerSet: TriggerSet<Data> = {
         },
         fakeBomb: {
           en: 'Motion',
-        },
-      },
-    },
-    {
-      id: 'DMU P4 Fourth Debuffs (Early)',
-      type: 'GainsEffect',
-      netRegex: { effectId: ['15AB', '15AC'], capture: true },
-      condition: (data) => data.grandCrossCount === 2,
-      delaySeconds: 0.1,
-      suppressSeconds: 99999,
-      infoText: (data, matches, output) => {
-        const areFourthDebuffsTrue = data.areFourthDebuffsTrue;
-        if (areFourthDebuffsTrue === undefined)
-          return;
-        const isEntropy = matches.id === '15AB';
-        if (isEntropy)
-          return areFourthDebuffsTrue ? output.puddlesFirst!() : output.donutsFirst!();
-        return areFourthDebuffsTrue ? output.donutsSecond!() : output.puddlesSecond!();
-      },
-      outputStrings: {
-        puddlesFirst: {
-          en: 'Puddles First',
-        },
-        puddlesSecond: {
-          en: 'Puddles Second',
-        },
-        donutsFirst: {
-          en: 'Donuts First',
-        },
-        donutsSecond: {
-          en: 'Donuts Second',
         },
       },
     },
@@ -4877,7 +4878,6 @@ const triggerSet: TriggerSet<Data> = {
       id: 'DMU P4 Entropy',
       // Using the following as possible matches:
       // 15A7 Cursed Shriek x2 60s
-      // TODO: Merge this with Mana Charge (stored fake/real thunder)
       type: 'GainsEffect',
       netRegex: { effectId: '15A7', capture: true },
       condition: (_data, matches) => parseFloat(matches.duration) < 61,

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4859,6 +4859,7 @@ const triggerSet: TriggerSet<Data> = {
         puddles: Outputs.baitPuddles,
       },
     },
+    {
       id: 'DMU P4 Mana Release',
       // 5CA Mana Charged falls off ~5.4s prior to startsUsing
       // 5CD Thunder Charged and 5CC Blizzard Charged fall off after subsequent

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4251,10 +4251,10 @@ const triggerSet: TriggerSet<Data> = {
 
         // No debuff, they will be a stack player
         return output.aoeDebuff!({
-            aoe: output.aoe!(),
-            debuff: isShort
-              ? output.stackFirstNoDebuff!({ mech: output.stack!() })
-              : output.stackSecondNoDebuff!({ mech: output.stack!() }),
+          aoe: output.aoe!(),
+          debuff: isShort
+            ? output.stackFirstNoDebuff!({ mech: output.stack!() })
+            : output.stackSecondNoDebuff!({ mech: output.stack!() }),
         });
       },
       outputStrings: {
@@ -4390,10 +4390,10 @@ const triggerSet: TriggerSet<Data> = {
 
         // No debuff, they will be a stack player
         return output.aoeDebuff!({
-            aoe: output.aoe!(),
-            debuff: isShort
-              ? output.stackSecondNoDebuff!({ mech: output.stack!() })
-              : output.stackFirstNoDebuff!({ mech: output.stack!() }),
+          aoe: output.aoe!(),
+          debuff: isShort
+            ? output.stackSecondNoDebuff!({ mech: output.stack!() })
+            : output.stackFirstNoDebuff!({ mech: output.stack!() }),
         });
       },
       outputStrings: {

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4377,7 +4377,7 @@ const triggerSet: TriggerSet<Data> = {
 
         const id = matches.id;
         const isFloodTrue = id === 'C392' || id === 'C393';
-        const isBlueLeft = id === 'C3A1' || id === 'C393'; // Our left
+        const isBlueLeft = id === 'C3A2' || id === 'C393'; // Our left
         const keep = (deathOrField === 'death' && isFloodTrue) ||
           (deathOrField === 'field' && !isFloodTrue);
 

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -1917,7 +1917,7 @@ const triggerSet: TriggerSet<Data> = {
         source: ['Kefka', 'Neo Exdeath'],
         capture: false,
       },
-      delaySeconds: 0.1, // BB14 could trigger delete prior to P4's BA94 output
+      delaySeconds: 0.2, // BB14 could trigger delete prior to P4's BA94 output
       run: (data) => {
         delete data.isFireTrue;
         delete data.isIceTrue;

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4696,6 +4696,45 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
+      id: 'DMU P4 Cursed Shriek (Early)',
+      // This may be more important for those that have it to get into position
+      // Not defining source due to possibility of source being incorrect
+      // Using BB18, BB19 Death Wave or BB1A, BB1B Death Bolt
+      // This occurs roughly 5-6s before the alert version
+      type: 'Ability',
+      netRegex: { id: ['BB18', 'BB19', 'BB1A', 'BB1B'], capture: false },
+      suppressSeconds: 1,
+      infoText: (data, _matches, output) => {
+        // Check Mana Charge related value to see if first shriek
+        const isShortDebuffs = data.isThunderChargedTrue === undefined;
+        const isTrue = isShortDebuffs ? data.areFirstDebuffsTrue : data.areSecondDebuffsTrue;
+        if (isTrue === undefined)
+          return;
+
+        const shriekPlayers = isShortDebuffs ? data.shortShriekPlayers : data.longShriekPlayers;
+        const players = shriekPlayers.map(
+          (player) => {
+            if (player === data.me)
+              return output.you!();
+            return data.party.member(player);
+          },
+        );
+        const msg = players?.join(', ');
+
+        return isTrue
+          ? output.lookAwayFromPlayers!({ players: msg })
+          : output.lookAtPlayers!({ players: msg });
+      },
+      outputStrings: {
+        lookAtPlayers: {
+          en: 'Face ${players} (later)',
+        },
+        lookAwayFromPlayers: {
+          en: 'Look Away from ${players} (later)',
+        },
+      },
+    },
+    {
       id: 'DMU P4 Mana Charge Collect',
       // 5CD Thunder Charged: Store the value of isThunderTrue for later
       // 5CC Blizzard Charged: Store the value of isIceTrue for later

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -100,7 +100,8 @@ export interface Data extends RaidbossData {
   isSecondPuddle: boolean;
   knockDownTarget?: string;
   isKnockDown2: boolean;
-  blizzardStarted: boolean;  // Phase 4
+  blizzardStarted: boolean;
+  // Phase 4
   grandCrossCount: number;
   shortShriekPlayers: string[];
   longShriekPlayers: string[];

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -1917,6 +1917,7 @@ const triggerSet: TriggerSet<Data> = {
         source: ['Kefka', 'Neo Exdeath'],
         capture: false,
       },
+      delaySeconds: 0.1, // Possible for this to delete on BA94 before output
       run: (data) => {
         delete data.isFireTrue;
         delete data.isIceTrue;

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -8072,7 +8072,7 @@ const triggerSet: TriggerSet<Data> = {
       // This will need to be done while stacking donuts if Dynamic Fluid is true
       // 6.7s castTime, but there is additional ~0.382 delay until tells
       type: 'StartsUsing',
-      netRegex: { id: 'BAA5', source: 'Kefka', capture: false },
+      netRegex: { id: 'BAA5', source: 'Kefka', capture: true },
       condition: (data) => {
         return data.isIceTrue !== undefined && data.isThunderTrue !== undefined;
       },

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4542,17 +4542,6 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'DMU P4 Thrumming Thunder III',
-      // BAA4 Mana Charge signifies that the true/fake will be stored for later
-      // Indicated with boss buff 5CA Mana Charged and 5CD Thunder Charged
-      type: 'StartsUsing',
-      netRegex: { id: 'C5DE', source: 'Kefka', capture: false },
-      infoText: (data, _matches, output) => {
-        return data.isThunderTrue ? output.trueThunder!() : output.fakeThunder!();
-      },
-      outputStrings: mysteryMagicOutputStrings,
-    },
-    {
       id: 'DMU P4 Mana Charge Collect',
       // 5CD Thunder Charged: Store the value of isThunderTrue for later
       // 5CC Blizzard Charged: Store the value of isIceTrue for later
@@ -4564,6 +4553,17 @@ const triggerSet: TriggerSet<Data> = {
         else
           data.isBlizzardChargedTrue = data.isIceTrue;
       },
+    },
+    {
+      id: 'DMU P4 Thrumming Thunder III',
+      // BAA4 Mana Charge signifies that the true/fake will be stored for later
+      // Indicated with boss buff 5CA Mana Charged and 5CD Thunder Charged
+      type: 'StartsUsing',
+      netRegex: { id: 'C5DE', source: 'Kefka', capture: false },
+      infoText: (data, _matches, output) => {
+        return data.isThunderTrue ? output.trueThunder!() : output.fakeThunder!();
+      },
+      outputStrings: mysteryMagicOutputStrings,
     },
     {
       id: 'DMU P4 First Cursed Shriek',

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -3873,7 +3873,11 @@ const triggerSet: TriggerSet<Data> = {
       // Fake Neo Exdeath: 461
       // True Neo Exdeath: 462
       type: 'GainsEffect',
-      netRegex: { effectId: '808', capture: true },
+      netRegex: {
+        effectId: '808',
+        count: ['45F', '460', '461', '462'],
+        capture: true,
+      },
       run: (data, matches) => {
         const count = matches.count;
         const grandCrossCount = data.grandCrossCount;

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4770,14 +4770,6 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: mysteryMagicOutputStrings,
     },
     {
-      id: 'DMU P4 Blizzard Charge Collect',
-      // Store the value of the isIceTrue for later
-      type: 'StartsUsing',
-      netRegex: { id: 'BA95', source: 'Kefka', capture: false },
-      condition: (data) => data.grandCrossCount === 3,
-      run: (data) => data.chargeBlizzardTrue = data.isIceTrue,
-    },
-    {
       id: 'DMU P4 Second Cursed Shriek',
       type: 'GainsEffect',
       netRegex: { effectId: '15A7', capture: true },

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -1042,7 +1042,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: trapOutputStrings,
     },
     {
-      id: 'DMU P1 Mystery Magic Ice and Thunder',
+      id: 'DMU P1 and P4 Mystery Magic Ice and Thunder',
       // Set 2: Only Ice and Thunder should be set
       type: 'StartsUsing',
       netRegex: { id: 'BA94', source: 'Kefka', capture: false },
@@ -1078,8 +1078,8 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'DMU P1 Mystery Magic Ice, and Gravitas and Vitrophyre Tethers 1',
-      // Occurs between Set 2 and Set 3
-      // BA95 Blizzard Blowout III cast
+      // Occurs between Graven Image Set 2 and Set 3
+      // BA95 Blizzard III Blowout cast
       type: 'StartsUsing',
       netRegex: { id: 'BA95', source: 'Kefka', capture: false },
       condition: (data) => {
@@ -1649,7 +1649,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'DMU P1 Ave Maria / Indolent Will Collect',
-      // Collect for reminder with Myster Magic
+      // Collect for reminder with Mystery Magic
       type: 'ActorControlExtra',
       netRegex: { category: '019D', param1: '40', param2: '80', capture: true },
       run: (data, matches) => {
@@ -1745,56 +1745,15 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: mysteryMagicOutputStrings,
     },
     {
-      id: 'DMU P4 Mystery Magic Fire and Thunder',
-      type: 'StartsUsing',
-      netRegex: { id: 'BA94', source: 'Kefka', capture: false },
-      condition: (data) => {
-        if (
-          data.isFireTrue !== undefined &&
-          data.isThunderTrue !== undefined &&
-          data.phase === 'p4'
-        )
-          return true;
-        return false;
-      },
-      infoText: (data, _matches, output) => {
-        const fireMarker = data.fireMarker;
-        if (
-          (fireMarker === headMarkerData['dorito'] && data.isFireTrue) ||
-          (fireMarker === headMarkerData['stack'] && !data.isFireTrue)
-        )
-          return data.isThunderTrue
-            ? output.spreadTrueThunder!({
-              mech: output.spread!(),
-              thunder: output.trueThunder!(),
-            })
-            : output.spreadFakeThunder!({
-              mech: output.spread!(),
-              thunder: output.fakeThunder!(),
-            });
-
-        if (
-          (fireMarker === headMarkerData['dorito'] && !data.isFireTrue) ||
-          (fireMarker === headMarkerData['stack'] && data.isFireTrue)
-        ) {
-          return data.isThunderTrue
-            ? output.stackTrueThunder!({
-              mech: output.stack!(),
-              thunder: output.trueThunder!(),
-            })
-            : output.stackFakeThunder!({
-              mech: output.stack!(),
-              thunder: output.fakeThunder!(),
-            });
-        }
-      },
-      outputStrings: mysteryMagicOutputStrings,
-    },
-    {
-      id: 'DMU P1 Mystery Magic Cleanup',
+      id: 'DMU P1 and P4 Mystery Magic Cleanup',
       // C622 Light of Judgment to reset for the Graven Image 2
+      // BB14 Grand Cross to reset between Myster Magic casts
       type: 'StartsUsing',
-      netRegex: { id: ['BA94', 'C622'], source: 'Kefka', capture: false },
+      netRegex: {
+        id: ['BA94', 'C622', 'BB14'],
+        source: ['Kefka', 'Neo Exdeath'],
+        capture: false,
+      },
       run: (data) => {
         delete data.isFireTrue;
         delete data.isIceTrue;
@@ -4403,6 +4362,17 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
+      id: 'DMU P4 Thrumming Thunder III',
+      // BAA4 Mana Charge signifies that the true/fake will be stored for later
+      // Indicated with boss buff 5CA Mana Charged and 5CD Thunder Charged
+      type: 'StartsUsing',
+      netRegex: { id: 'C5DE', source: 'Kefka', capture: false },
+      infoText: (data, _matches, output) => {
+        return data.isThunderTrue ? output.trueThunder!() : output.fakeThunder!();
+      },
+      outputStrings: mysteryMagicOutputStrings,
+    },
+    {
       id: 'DMU P4 First Cursed Shriek',
       // TODO: Merge this with Mana Charge (stored fake/real thunder)
       type: 'GainsEffect',
@@ -4610,6 +4580,19 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
+      id: 'DMU P4 Blizzard III Blowout',
+      // BAA4 Mana Charge signifies that the true/fake will be stored for later
+      // Indicated with boss buff 5CA Mana Charged and 5CC Blizzard Charged
+      type: 'StartsUsing',
+      netRegex: { id: 'BA95', source: 'Kefka', capture: false },
+      // Prevent triggering on earlier P1 or P4 triggers
+      condition: (data) => data.grandCrossCount === 3,
+      infoText: (data, _matches, output) => {
+        return data.isIceTrue ? output.trueIce!() : output.fakeIce!();
+      },
+      outputStrings: mysteryMagicOutputStrings,
+    },
+    {
       id: 'DMU P4 Second Cursed Shriek',
       type: 'GainsEffect',
       netRegex: { effectId: '15A7', capture: true },
@@ -4706,6 +4689,28 @@ const triggerSet: TriggerSet<Data> = {
           tc: '旋風',
         },
       },
+    },
+    {
+      id: 'DMU P4 Mana Release',
+      // 5CA Mana Charged falls off ~5.4s prior to startsUsing
+      // 5CD Thunder Charged and 5CC Blizzard Charged fall off after subsequent
+      // Thrumming Thunder III and Blizzard III Blowout startsUsing
+      type: 'StartsUsing',
+      netRegex: { id: 'BAA5', source: 'Kefka', capture: false },
+      condition: (data) => {
+        return data.isIceTrue !== undefined && data.isThunderTrue !== undefined;
+      },
+      infoText: (data, _matches, output) => {
+        if (data.isThunderTrue) {
+          return data.isIceTrue
+            ? output.trueIceTrueThunder!()
+            : output.fakeIceTrueThunder!();
+        }
+        return data.isIceTrue
+          ? output.trueIceFakeThunder!()
+          : output.fakeIceFakeThunder!();
+      },
+      outputStrings: mysteryMagicOutputStrings,
     },
   ],
   timelineReplace: [

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4017,68 +4017,6 @@ const triggerSet: TriggerSet<Data> = {
         // has unique cast ids for true/fake
       },
     },
-/*
-    {
-      id: 'DMU P4 Chaos and Neo Exdeath Debuff Info',
-      // In the count field of Effect 808, the bosses receive these values:
-      // Fake Chaos: 45F
-      // True Chaos: 460
-      // Fake Neo Exdeath: 461
-      // True Neo Exdeath: 462
-      type: 'GainsEffect',
-      netRegex: {
-        effectId: '808',
-        count: ['45F', '460', '461', '462'],
-        capture: true,
-      },
-      infoText: (data, matches, output) => {
-        const count = matches.count;
-        if (count === '45F' || count === '460') {
-          const chaosLocaleNames: LocaleText = {
-            en: 'Chaos',
-            de: 'Chaos',
-            fr: 'Chaos',
-            ja: 'カオス',
-            cn: '卡奥斯',
-            ko: '카오스',
-            tc: '卡奧斯',
-          };
-          const chaosName = chaosLocaleNames[data.parserLang];
-          return count === '45F'
-            ? output.fakeChaos!({ chaos: chaosName })
-            : output.trueChaos!({ chaos: chaosName });
-        }
-
-        const exdeathLocaleNames: LocaleText = {
-          en: 'Exdeath',
-          de: 'Exdeath',
-          fr: 'Exdeath',
-          ja: 'エクスデス',
-          cn: '艾克斯迪司',
-          ko: '엑스데스',
-          tc: '艾克斯迪司',
-        };
-        const exdeathName = exdeathLocaleNames[data.parserLang];
-        return count === '461'
-          ? output.fakeExdeath!({ exdeath: exdeathName })
-          : output.trueExdeath!({ exdeath: exdeathName });
-      },
-      outputStrings: {
-        fakeExdeath: {
-          en: 'Fake ${exdeath}',
-        },
-        fakeChaos: {
-          en: 'Fake ${chaos}',
-        },
-        trueExdeath: {
-          en: 'True ${exdeath}',
-        },
-        trueChaos: {
-          en: 'True ${chaos}',
-        },
-      },
-    },
-*/
     {
       id: 'DMU P4 Tsunami/Inferno',
       // BB14 Grand Cross AoE also happens ~4s after this cast starts

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4554,13 +4554,13 @@ const triggerSet: TriggerSet<Data> = {
           return output.laserThenForkBomb!({
             mech1: laser,
             mech2: output.spread!(),
-            mech3: isShortTrue ? output.bomb!() : output.fakeBomb!(),
+            mech3: is1stTrue ? output.bomb!() : output.fakeBomb!(),
           });
         if (hasStack && hasBomb)
           return output.laserThenCompressedBomb!({
             mech1: laser,
             mech2: output.stack!(),
-            mech3: isShortTrue ? output.bomb!() : output.fakeBomb!(),
+            mech3: is1stTrue ? output.bomb!() : output.fakeBomb!(),
           });
         if (hasSpread)
           return output.laserThenSpread!({
@@ -4575,7 +4575,7 @@ const triggerSet: TriggerSet<Data> = {
         if (hasBomb)
           return output.laserThenBomb!({
             mech1: laser,
-            mech2: isShortTrue ? output.bomb!() : output.fakeBomb!(),
+            mech2: is1stTrue ? output.bomb!() : output.fakeBomb!(),
             mech3: output.stack!(),
           });
         // Has either nothing or long debuffs
@@ -4653,12 +4653,12 @@ const triggerSet: TriggerSet<Data> = {
         if (hasSpread && hasBomb)
           return output.forkBomb!({
             mech1: output.spread!(),
-            mech2: isShortTrue ? output.bomb!() : output.fakeBomb!(),
+            mech2: is1stTrue ? output.bomb!() : output.fakeBomb!(),
           });
         if (hasStack && hasBomb)
           return output.compressedBomb!({
             mech1: output.stack!(),
-            mech2: isShortTrue ? output.bomb!() : output.fakeBomb!(),
+            mech2: is1stTrue ? output.bomb!() : output.fakeBomb!(),
           });
         if (hasSpread)
           return output.spread!();
@@ -4666,7 +4666,7 @@ const triggerSet: TriggerSet<Data> = {
           return output.stack!();
         if (hasBomb)
           return output.bombStack!({
-            mech1: isShortTrue ? output.bomb!() : output.fakeBomb!(),
+            mech1: is1stTrue ? output.bomb!() : output.fakeBomb!(),
             mech2: output.stack!(),
           });
         // Has either nothing or long debuffs
@@ -4955,14 +4955,14 @@ const triggerSet: TriggerSet<Data> = {
           return {
             [severity]: output.forkBomb!({
               mech1: output.spread!(),
-              mech2: isLongTrue ? output.bomb!() : output.fakeBomb!(),
+              mech2: is2ndTrue ? output.bomb!() : output.fakeBomb!(),
             }),
           };
         if (hasStack && hasBomb)
           return {
             [severity]: output.compressedBomb!({
               mech1: output.stack!(),
-              mech2: isLongTrue ? output.bomb!() : output.fakeBomb!(),
+              mech2: is2ndTrue ? output.bomb!() : output.fakeBomb!(),
             }),
           };
         if (hasSpread)
@@ -4972,7 +4972,7 @@ const triggerSet: TriggerSet<Data> = {
         if (hasBomb)
           return {
             [severity]: output.bombStack!({
-              mech1: isLongTrue ? output.bomb!() : output.fakeBomb!(),
+              mech1: is2ndTrue ? output.bomb!() : output.fakeBomb!(),
               mech2: output.stack!(),
             }),
           };

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -3873,7 +3873,7 @@ const triggerSet: TriggerSet<Data> = {
       // Fake Neo Exdeath: 461
       // True Neo Exdeath: 462
       type: 'GainsEffect',
-      netRegex: { effectId: '808', source: ['Chaos', 'Neo Exdeath'], capture: true },
+      netRegex: { effectId: '808', capture: true },
       run: (data, matches) => {
         const count = matches.count;
         const grandCrossCount = data.grandCrossCount;

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4559,9 +4559,9 @@ const triggerSet: TriggerSet<Data> = {
             mech3: output.stack!(),
           });
         // Has either nothing or long debuffs
-        return output.laserThenStack!({
+        return output.laserThenNoDebuff!({
           mech1: laser,
-          mech2: output.stack!(),
+          mech2: output.noDebuff!(),
         });
       },
       outputStrings: {
@@ -4594,6 +4594,10 @@ const triggerSet: TriggerSet<Data> = {
         laserThenCompressedBomb: {
           en: '${mech1} => ${mech2} + ${mech3}',
         },
+        laserThenNoDebuff: {
+          en: '${mech1} => ${mech2}',
+        },
+        noDebuff: Outputs.stackMarker,
         stack: Outputs.stackMarker,
         spread: Outputs.spread,
         bomb: {
@@ -4622,81 +4626,46 @@ const triggerSet: TriggerSet<Data> = {
         const hasCompressed = data.shortCompressedPlayers.includes(data.me);
         const hasBomb = data.shortBombPlayers.includes(data.me);
 
-        const shriekPlayers = data.shortShriekPlayers;
-        const shriekOnYou = shriekPlayers.includes(data.me);
-        const players = shriekPlayers.map(
-          (player) => {
-            if (player === data.me)
-              return output.you!();
-            return data.party.member(player);
-          },
-        );
-        const msg = players?.join(', ');
-
-        const gaze = (is1stTrue && shriekOnYou)
-          ? output.gazeOnPlayersYou!({ players: msg })
-          : (!is2ndTrue && shriekOnYou)
-          ? output.fakeGazeOnPlayersYou!({ players: msg })
-          : is1stTrue
-          ? output.gazeOnPlayers!({ players: msg })
-          : output.fakeGazeOnPlayers!({ players: msg });
         const hasSpread = (hasFork && isShortTrue) || (hasCompressed && !isShortTrue);
         const hasStack = (hasFork && !isShortTrue) || (hasCompressed && isShortTrue);
 
         // Handle 2 Mechs
         if (hasSpread && hasBomb)
-          return output.forkBombThenGaze!({
+          return output.forkBomb!({
             mech1: output.spread!(),
             mech2: isShortTrue ? output.bomb!() : output.fakeBomb!(),
-            mech3: gaze,
           });
         if (hasStack && hasBomb)
-          return output.compressedBombThenGaze!({
+          return output.compressedBomb!({
             mech1: output.stack!(),
             mech2: isShortTrue ? output.bomb!() : output.fakeBomb!(),
-            mech3: gaze,
           });
         if (hasSpread)
-          return output.spreadThenGaze!({
-            mech1: output.spread!(),
-            mech2: gaze,
-          });
+          return output.spread!();
         if (hasStack)
-          return output.stackThenGaze!({
-            mech1: output.stack!(),
-            mech2: gaze,
-          });
+          return output.stack!();
         if (hasBomb)
-          return output.bombThenGaze!({
+          return output.bombStack!({
             mech1: isShortTrue ? output.bomb!() : output.fakeBomb!(),
             mech2: output.stack!(),
-            mech3: gaze,
           });
         // Has either nothing or long debuffs
-        return output.stackThenGaze!({
-          mech1: output.stack!(),
-          mech2: gaze,
-        });
+        return output.noDebuff!();
       },
       outputStrings: {
         you: {
           en: 'YOU',
         },
-        spreadThenGaze: {
-          en: '${mech1} => ${mech2}',
+        bombStack: {
+          en: '${mech1} + ${mech2}',
         },
-        stackThenGaze: {
-          en: '${mech1} => ${mech2}',
+        forkBomb: {
+          en: '${mech1} + ${mech2}',
         },
-        bombThenGaze: {
-          en: '${mech1} + ${mech2} => ${mech3}',
+        compressedBomb: {
+          en: '${mech1} + ${mech2}',
         },
-        forkBombThenGaze: {
-          en: '${mech1} + ${mech2} => ${mech3}',
-        },
-        compressedBombThenGaze: {
-          en: '${mech1} + ${mech2} => ${mech3}',
-        },
+        noDebuff: Outputs.stackMarker,
         stack: Outputs.stackMarker,
         spread: Outputs.spread,
         bomb: {
@@ -4704,18 +4673,6 @@ const triggerSet: TriggerSet<Data> = {
         },
         fakeBomb: {
           en: 'Motion',
-        },
-        fakeGazeOnPlayers: {
-          en: 'Face ${players}',
-        },
-        gazeOnPlayers: {
-          en: 'Look Away from ${players}',
-        },
-        fakeGazeOnPlayersYou: {
-          en: 'Face ${players}',
-        },
-        gazeOnPlayersYou: {
-          en: 'Look Away from ${players}',
         },
       },
     },
@@ -4939,81 +4896,46 @@ const triggerSet: TriggerSet<Data> = {
         const hasCompressed = data.longCompressedPlayers.includes(data.me);
         const hasBomb = data.longBombPlayers.includes(data.me);
 
-        const shriekPlayers = data.longShriekPlayers;
-        const shriekOnYou = shriekPlayers.includes(data.me);
-        const players = shriekPlayers.map(
-          (player) => {
-            if (player === data.me)
-              return output.you!();
-            return data.party.member(player);
-          },
-        );
-        const msg = players?.join(', ');
-
-        const gaze = (is2ndTrue && shriekOnYou)
-          ? output.gazeOnPlayersYou!({ players: msg })
-          : (!is2ndTrue && shriekOnYou)
-          ? output.fakeGazeOnPlayersYou!({ players: msg })
-          : is2ndTrue
-          ? output.gazeOnPlayers!({ players: msg })
-          : output.fakeGazeOnPlayers!({ players: msg });
         const hasSpread = (hasFork && isLongTrue) || (hasCompressed && !isLongTrue);
         const hasStack = (hasFork && !isLongTrue) || (hasCompressed && isLongTrue);
 
         // Handle 2 Mechs
         if (hasSpread && hasBomb)
-          return output.forkBombThenGaze!({
+          return output.forkBomb!({
             mech1: output.spread!(),
             mech2: isLongTrue ? output.bomb!() : output.fakeBomb!(),
-            mech3: gaze,
           });
         if (hasStack && hasBomb)
-          return output.compressedBombThenGaze!({
+          return output.compressedBomb!({
             mech1: output.stack!(),
             mech2: isLongTrue ? output.bomb!() : output.fakeBomb!(),
-            mech3: gaze,
           });
         if (hasSpread)
-          return output.spreadThenGaze!({
-            mech1: output.spread!(),
-            mech2: gaze,
-          });
+          return output.spread!();
         if (hasStack)
-          return output.stackThenGaze!({
-            mech1: output.stack!(),
-            mech2: gaze,
-          });
+          return output.stack!();
         if (hasBomb)
-          return output.bombThenGaze!({
+          return output.bombStack!({
             mech1: isLongTrue ? output.bomb!() : output.fakeBomb!(),
             mech2: output.stack!(),
-            mech3: gaze,
           });
         // Has nothing
-        return output.stackThenGaze!({
-          mech1: output.stack!(),
-          mech2: gaze,
-        });
+        return output.noDebuff!();
       },
       outputStrings: {
         you: {
           en: 'YOU',
         },
-        spreadThenGaze: {
-          en: '${mech1} => ${mech2}',
+        bombStack: {
+          en: '${mech1} + ${mech2}',
         },
-        stackThenGaze: {
-          en: '${mech1} => ${mech2}',
+        forkBomb: {
+          en: '${mech1} + ${mech2}',
         },
-        bombThenGaze: {
-          en: '${mech1} + ${mech2} => ${mech3}',
+        compressedBomb: {
+          en: '${mech1} + ${mech2}',
         },
-        forkBombThenGaze: {
-          en: '${mech1} + ${mech2} => ${mech3}',
-        },
-        compressedBombThenGaze: {
-          en: '${mech1} + ${mech2} => ${mech3}',
-        },
+        noDebuff: Outputs.stackMarker,
         stack: Outputs.stackMarker,
         spread: Outputs.spread,
         bomb: {
@@ -5021,18 +4943,6 @@ const triggerSet: TriggerSet<Data> = {
         },
         fakeBomb: {
           en: 'Motion',
-        },
-        fakeGazeOnPlayers: {
-          en: 'Face ${players}',
-        },
-        gazeOnPlayers: {
-          en: 'Look Away from ${players}',
-        },
-        fakeGazeOnPlayersYou: {
-          en: 'Face ${players}',
-        },
-        gazeOnPlayersYou: {
-          en: 'Look Away from ${players}',
         },
       },
     },

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4161,12 +4161,15 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'DMU P4 Third Debuffs',
       // Neo Exdeath Debuffs Cast 3
-      // 1317 White Wound
-      // 1318 Black Wound
-      // 1558 Beyond Death x4 15s
-      // 1C6 Allagan Field x4 15s
+      // 1317 White Wound (Fake) or 15A5 White Wound
+      // 1318 Black Wound (Fake) or 15A6 Black Wound
+      // 566 Beyond Death (Fake) or 1558 Beyond Death
+      // 1C6 Allagan Field
       type: 'GainsEffect',
-      netRegex: { effectId: ['1317', '1318', '1558', '1C6'], capture: true },
+      netRegex: {
+        effectId: ['1317', '15A5', '1318', '15A6', '566', '1558', '1C6'],
+        capture: true,
+      },
       condition: Conditions.targetIsYou(),
       delaySeconds: 0.1,
       durationSeconds: 9,
@@ -4193,28 +4196,28 @@ const triggerSet: TriggerSet<Data> = {
         if (isTrue === undefined)
           return laser;
 
-        const isSpread = (hasFork && isTrue) || (hasCompressed && !isTrue);
-        const isStack = (hasFork && !isTrue) || (hasCompressed && isTrue);
+        const hasSpread = (hasFork && isTrue) || (hasCompressed && !isTrue);
+        const hasStack = (hasFork && !isTrue) || (hasCompressed && isTrue);
 
         // Handle 2 Mechs
-        if (isSpread && hasBomb)
+        if (hasSpread && hasBomb)
           return output.laserThenForkBomb!({
             mech1: laser,
             mech2: output.spread!(),
             mech3: isTrue ? output.bomb!() : output.fakeBomb!(),
           });
-        if (isStack && hasBomb)
+        if (hasStack && hasBomb)
           return output.laserThenCompressedBomb!({
             mech1: laser,
             mech2: output.stack!(),
             mech3: isTrue ? output.bomb!() : output.fakeBomb!(),
           });
-        if (isSpread)
+        if (hasSpread)
           return output.laserThenSpread!({
             mech1: laser,
             mech2: output.spread!(),
           });
-        if (isStack)
+        if (hasStack)
           return output.laserThenStack!({
             mech1: laser,
             mech2: output.stack!(),
@@ -4225,6 +4228,11 @@ const triggerSet: TriggerSet<Data> = {
             mech2: isTrue ? output.bomb!() : output.fakeBomb!(),
             mech3: output.stack!(),
           });
+        // Has either nothing or long debuffs
+        return output.laserThenStack!({
+          mech1: laser,
+          mech2: output.stack!(),
+        });
       },
       outputStrings: {
         death: {
@@ -4267,11 +4275,11 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'DMU P4 Short Debuffs',
       // Using the following as possible matches:
-      // 1558 Beyond Death x4 15s
-      // 1C6 Allagan Field x4 15s
+      // 566 Beyond Death (Fake) or 1558 Beyond Death
+      // 1C6 Allagan Field
       // The spells/abilities or losesEffect could be triggered from early deaths
       type: 'GainsEffect',
-      netRegex: { effectId: ['1558', '1C6'], capture: true },
+      netRegex: { effectId: ['566', '1558', '1C6'], capture: true },
       delaySeconds: (_data, matches) => parseFloat(matches.duration),
       suppressSeconds: 99999,
       alertText: (data, _matches, output) => {
@@ -4296,28 +4304,28 @@ const triggerSet: TriggerSet<Data> = {
         const gaze = is1stTrue
           ? output.lookAwayFromPlayers!({ players: msg })
           : output.lookAtPlayers!({ players: msg });
-        const isSpread = (hasFork && is2ndTrue) || (hasCompressed && !is2ndTrue);
-        const isStack = (hasFork && !is2ndTrue) || (hasCompressed && is2ndTrue);
+        const hasSpread = (hasFork && is2ndTrue) || (hasCompressed && !is2ndTrue);
+        const hasStack = (hasFork && !is2ndTrue) || (hasCompressed && is2ndTrue);
 
         // Handle 2 Mechs
-        if (isSpread && hasBomb)
+        if (hasSpread && hasBomb)
           return output.forkBombThenGaze!({
             mech1: output.spread!(),
             mech2: is2ndTrue ? output.bomb!() : output.fakeBomb!(),
             mech3: gaze,
           });
-        if (isStack && hasBomb)
+        if (hasStack && hasBomb)
           return output.compressedBombThenGaze!({
             mech1: output.stack!(),
             mech2: is2ndTrue ? output.bomb!() : output.fakeBomb!(),
             mech3: gaze,
           });
-        if (isSpread)
+        if (hasSpread)
           return output.spreadThenGaze!({
             mech1: output.spread!(),
             mech2: gaze,
           });
-        if (isStack)
+        if (hasStack)
           return output.stackThenGaze!({
             mech1: output.stack!(),
             mech2: gaze,
@@ -4328,6 +4336,11 @@ const triggerSet: TriggerSet<Data> = {
             mech2: output.stack!(),
             mech3: gaze,
           });
+        // Has either nothing or long debuffs
+        return output.stackThenGaze!({
+          mech1: output.stack!(),
+          mech2: gaze,
+        });
       },
       outputStrings: {
         you: {
@@ -4514,28 +4527,28 @@ const triggerSet: TriggerSet<Data> = {
         const gaze = is2ndTrue
           ? output.lookAwayFromPlayers!({ players: msg })
           : output.lookAtPlayers!({ players: msg });
-        const isSpread = (hasFork && is1stTrue) || (hasCompressed && !is1stTrue);
-        const isStack = (hasFork && !is1stTrue) || (hasCompressed && is1stTrue);
+        const hasSpread = (hasFork && is1stTrue) || (hasCompressed && !is1stTrue);
+        const hasStack = (hasFork && !is1stTrue) || (hasCompressed && is1stTrue);
 
         // Handle 2 Mechs
-        if (isSpread && hasBomb)
+        if (hasSpread && hasBomb)
           return output.forkBombThenGaze!({
             mech1: output.spread!(),
             mech2: is1stTrue ? output.bomb!() : output.fakeBomb!(),
             mech3: gaze,
           });
-        if (isStack && hasBomb)
+        if (hasStack && hasBomb)
           return output.compressedBombThenGaze!({
             mech1: output.stack!(),
             mech2: is1stTrue ? output.bomb!() : output.fakeBomb!(),
             mech3: gaze,
           });
-        if (isSpread)
+        if (hasSpread)
           return output.spreadThenGaze!({
             mech1: output.spread!(),
             mech2: gaze,
           });
-        if (isStack)
+        if (hasStack)
           return output.stackThenGaze!({
             mech1: output.stack!(),
             mech2: gaze,

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4026,11 +4026,11 @@ const triggerSet: TriggerSet<Data> = {
         if (data.areFirstDebuffsTrue === undefined)
           data.areFirstDebuffsTrue = isTrue;
         else if (data.isEntropyTrue === undefined)
-          data.isEntropyTrue = isTrue;
+          data.isDynamicFluidTrue = isTrue;
         else if (data.areSecondDebuffsTrue === undefined)
           data.areSecondDebuffsTrue = isTrue;
         else if (data.isDynamicFluidTrue === undefined)
-          data.isDynamicFluidTrue = isTrue;
+          data.isEntropyTrue = isTrue;
         // Last two are not needed as the next is a double negative and last
         // has unique cast ids for true/fake
       },

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4170,7 +4170,6 @@ const triggerSet: TriggerSet<Data> = {
       infoText: (data, _matches, output) => {
         const isTrue = data.areFirstDebuffsTrue;
         const isShort = data.isFirstDebuffShort;
-
         if (isTrue === undefined || isShort === undefined)
           return;
 
@@ -4291,7 +4290,6 @@ const triggerSet: TriggerSet<Data> = {
       infoText: (data, _matches, output) => {
         const isTrue = data.areSecondDebuffsTrue;
         const isShort = data.isFirstDebuffShort;
-
         if (isTrue === undefined || isShort === undefined)
           return;
 
@@ -4446,7 +4444,6 @@ const triggerSet: TriggerSet<Data> = {
       alertText: (data, matches, output) => {
         const wound = data.wound;
         const deathOrField = data.deathOrField;
-
         if (wound === undefined || deathOrField === undefined)
           return;
 
@@ -4470,29 +4467,32 @@ const triggerSet: TriggerSet<Data> = {
             : output.left!(),
         });
 
-        const isTrue = data.areSecondDebuffsTrue;
-        if (isTrue === undefined)
+        const is1stTrue = data.areFirstDebuffsTrue;
+        const is2ndTrue = data.areSecondDebuffsTrue;
+        const isFirstShort = data.isFirstDebuffShort;
+        if (is1stTrue === undefined || is2ndTrue === undefined || isFirstShort === undefined)
           return laser;
+        const isShortTrue = isFirstShort ? is1stTrue : is2ndTrue;
 
         const hasFork = data.shortForkedPlayers.includes(data.me);
         const hasCompressed = data.shortCompressedPlayers.includes(data.me);
         const hasBomb = data.shortBombPlayers.includes(data.me);
 
-        const hasSpread = (hasFork && isTrue) || (hasCompressed && !isTrue);
-        const hasStack = (hasFork && !isTrue) || (hasCompressed && isTrue);
+        const hasSpread = (hasFork && isShortTrue) || (hasCompressed && !isShortTrue);
+        const hasStack = (hasFork && !isShortTrue) || (hasCompressed && isShortTrue);
 
         // Handle 2 Mechs
         if (hasSpread && hasBomb)
           return output.laserThenForkBomb!({
             mech1: laser,
             mech2: output.spread!(),
-            mech3: isTrue ? output.bomb!() : output.fakeBomb!(),
+            mech3: isShortTrue ? output.bomb!() : output.fakeBomb!(),
           });
         if (hasStack && hasBomb)
           return output.laserThenCompressedBomb!({
             mech1: laser,
             mech2: output.stack!(),
-            mech3: isTrue ? output.bomb!() : output.fakeBomb!(),
+            mech3: isShortTrue ? output.bomb!() : output.fakeBomb!(),
           });
         if (hasSpread)
           return output.laserThenSpread!({
@@ -4507,7 +4507,7 @@ const triggerSet: TriggerSet<Data> = {
         if (hasBomb)
           return output.laserThenBomb!({
             mech1: laser,
-            mech2: isTrue ? output.bomb!() : output.fakeBomb!(),
+            mech2: isShortTrue ? output.bomb!() : output.fakeBomb!(),
             mech3: output.stack!(),
           });
         // Has either nothing or long debuffs
@@ -4563,10 +4563,12 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { id: ['C394', 'C395'], source: 'Neo Exdeath', capture: false },
       suppressSeconds: 99999,
       alertText: (data, _matches, output) => {
-        const is2ndTrue = data.areSecondDebuffsTrue;
         const is1stTrue = data.areFirstDebuffsTrue;
-        if (is2ndTrue === undefined || is1stTrue === undefined)
+        const is2ndTrue = data.areSecondDebuffsTrue;
+        const isFirstShort = data.isFirstDebuffShort;
+        if (is1stTrue === undefined || is2ndTrue === undefined || isFirstShort === undefined)
           return;
+        const isShortTrue = isFirstShort ? is1stTrue : is2ndTrue;
 
         const hasFork = data.shortForkedPlayers.includes(data.me);
         const hasCompressed = data.shortCompressedPlayers.includes(data.me);
@@ -4584,20 +4586,20 @@ const triggerSet: TriggerSet<Data> = {
         const gaze = is1stTrue
           ? output.lookAwayFromPlayers!({ players: msg })
           : output.lookAtPlayers!({ players: msg });
-        const hasSpread = (hasFork && is2ndTrue) || (hasCompressed && !is2ndTrue);
-        const hasStack = (hasFork && !is2ndTrue) || (hasCompressed && is2ndTrue);
+        const hasSpread = (hasFork && isShortTrue) || (hasCompressed && !isShortTrue);
+        const hasStack = (hasFork && !isShortTrue) || (hasCompressed && isShortTrue);
 
         // Handle 2 Mechs
         if (hasSpread && hasBomb)
           return output.forkBombThenGaze!({
             mech1: output.spread!(),
-            mech2: is2ndTrue ? output.bomb!() : output.fakeBomb!(),
+            mech2: isShortTrue ? output.bomb!() : output.fakeBomb!(),
             mech3: gaze,
           });
         if (hasStack && hasBomb)
           return output.compressedBombThenGaze!({
             mech1: output.stack!(),
-            mech2: is2ndTrue ? output.bomb!() : output.fakeBomb!(),
+            mech2: isShortTrue ? output.bomb!() : output.fakeBomb!(),
             mech3: gaze,
           });
         if (hasSpread)
@@ -4612,7 +4614,7 @@ const triggerSet: TriggerSet<Data> = {
           });
         if (hasBomb)
           return output.bombThenGaze!({
-            mech1: is2ndTrue ? output.bomb!() : output.fakeBomb!(),
+            mech1: isShortTrue ? output.bomb!() : output.fakeBomb!(),
             mech2: output.stack!(),
             mech3: gaze,
           });
@@ -4858,8 +4860,10 @@ const triggerSet: TriggerSet<Data> = {
       alertText: (data, _matches, output) => {
         const is1stTrue = data.areFirstDebuffsTrue;
         const is2ndTrue = data.areSecondDebuffsTrue;
-        if (is2ndTrue === undefined || is1stTrue === undefined)
+        const isFirstShort = data.isFirstDebuffShort;
+        if (is1stTrue === undefined || is2ndTrue === undefined || isFirstShort === undefined)
           return;
+        const isLongTrue = isFirstShort ? is2ndTrue : is1stTrue;
 
         const hasFork = data.longForkedPlayers.includes(data.me);
         const hasCompressed = data.longCompressedPlayers.includes(data.me);
@@ -4877,20 +4881,20 @@ const triggerSet: TriggerSet<Data> = {
         const gaze = is2ndTrue
           ? output.lookAwayFromPlayers!({ players: msg })
           : output.lookAtPlayers!({ players: msg });
-        const hasSpread = (hasFork && is1stTrue) || (hasCompressed && !is1stTrue);
-        const hasStack = (hasFork && !is1stTrue) || (hasCompressed && is1stTrue);
+        const hasSpread = (hasFork && isLongTrue) || (hasCompressed && !isLongTrue);
+        const hasStack = (hasFork && !isLongTrue) || (hasCompressed && isLongTrue);
 
         // Handle 2 Mechs
         if (hasSpread && hasBomb)
           return output.forkBombThenGaze!({
             mech1: output.spread!(),
-            mech2: is1stTrue ? output.bomb!() : output.fakeBomb!(),
+            mech2: isLongTrue ? output.bomb!() : output.fakeBomb!(),
             mech3: gaze,
           });
         if (hasStack && hasBomb)
           return output.compressedBombThenGaze!({
             mech1: output.stack!(),
-            mech2: is1stTrue ? output.bomb!() : output.fakeBomb!(),
+            mech2: isLongTrue ? output.bomb!() : output.fakeBomb!(),
             mech3: gaze,
           });
         if (hasSpread)
@@ -4905,7 +4909,7 @@ const triggerSet: TriggerSet<Data> = {
           });
         if (hasBomb)
           return output.bombThenGaze!({
-            mech1: is1stTrue ? output.bomb!() : output.fakeBomb!(),
+            mech1: isLongTrue ? output.bomb!() : output.fakeBomb!(),
             mech2: output.stack!(),
             mech3: gaze,
           });

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -1917,7 +1917,7 @@ const triggerSet: TriggerSet<Data> = {
         source: ['Kefka', 'Neo Exdeath'],
         capture: false,
       },
-      delaySeconds: 0.1, // Possible for this to delete on BA94 before output
+      delaySeconds: 0.1, // BB14 could trigger delete prior to P4's BA94 output
       run: (data) => {
         delete data.isFireTrue;
         delete data.isIceTrue;

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -7,6 +7,7 @@ import { RaidbossData } from '../../../../../types/data';
 import { OutputStrings, TriggerSet } from '../../../../../types/trigger';
 
 // TODO: P2 Old AAAABBBB plan was found at https://raidplan.io/plan/kj2d734d36es2ugs, would like to find replacement
+// TODO: P4 Add detection for Fake Chaos and Fake Neo Exdeath debuffs
 // TODO: Earlier phase tracking for P5 (counting the jumps to middle?)
 
 type Phase = 'p1' | 'p2' | 'p3' | 'p4' | 'p5';
@@ -68,6 +69,18 @@ export interface Data extends RaidbossData {
   forsakenGroupB: string[]; // List of players in Group B
   trineDirNums: number[];
   middleTrineFacing?: 'east' | 'west';
+  // Phase 4
+  grandCrossCount: number;
+  shortShriekPlayers: string[];
+  longShriekPlayers: string[];
+  shortForkedPlayers: string[];
+  longForkedPlayers: string[];
+  shortCompressedPlayers: string[];
+  longCompressedPlayers: string[];
+  shortBombPlayers: string[];
+  longBombPlayers: string[];
+  deathOrField?: 'death' | 'field';
+  wound?: 'white' | 'black';
 }
 
 const headMarkerData = {
@@ -587,6 +600,16 @@ const triggerSet: TriggerSet<Data> = {
       forsakenGroupA: [],
       forsakenGroupB: [],
       trineDirNums: [],
+      // Phase 4
+      grandCrossCount: 0,
+      shortShriekPlayers: [],
+      longShriekPlayers: [],
+      shortForkedPlayers: [],
+      longForkedPlayers: [],
+      shortCompressedPlayers: [],
+      longCompressedPlayers: [],
+      shortBombPlayers: [],
+      longBombPlayers: [],
     };
   },
   triggers: [
@@ -3836,6 +3859,636 @@ const triggerSet: TriggerSet<Data> = {
         getBehindTarget: {
           en: 'Get Behind ${target}',
           ko: '${target} 뒤로',
+        },
+      },
+    },
+    {
+      id: 'DMU P4 Tsunami/Inferno',
+      // BB14 Grand Cross AoE also happens ~4s after this cast starts
+      // BB20 Inferno / BB21 Tsunami are 9s castTime
+      type: 'StartsUsing',
+      netRegex: { id: ['BB20', 'BB21'], source: 'Chaos', capture: true },
+      delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 6,
+      response: Responses.aoe(),
+    },
+    {
+      id: 'DMU P4 Grand Cross Counter',
+      type: 'StartsUsing',
+      netRegex: { id: 'BB14', source: 'Neo Exdeath', capture: false },
+      run: (data) => data.grandCrossCount = data.grandCrossCount + 1,
+    },
+    {
+      id: 'DMU P4 Grand Cross',
+      // 9s castTime
+      type: 'StartsUsing',
+      netRegex: { id: 'BB14', source: 'Neo Exdeath', capture: true },
+      delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 6,
+      response: Responses.aoe(),
+    },
+    {
+      id: 'DMU P4 Debuff Collect',
+      // Neo Exdeath Debuffs Cast 1: (12:28.672)
+      // 15A7 Cursed Shriek x2 60s                        =>          13:28.672
+      // 15A8 Forked Lightning x2 76s                     =>                    13:44.672
+      // 15A9 Compressed Water x2 76s                     =>                    13:44.672
+      // 15AA Acceleration Bomb (2 Long 76s, 2 Short 51s) => 13:19.672          13:44.672
+      // Chaos Debuffs 1: (12:34.341)
+      // 15AC Dynamic Fluid x8 84s                        => 13:48.672
+      // Neo Exdeath Debuffs Cast 2: (12:43.578)
+      // 15A8 Forked Lightning x2 36s                     => 13:19.578
+      // 15A7 Cursed Shriek x2 69s                        => 13:52.578
+      // 15A9 Compressed Water x2 36s                     => 13:19.578
+      // 15AA Acceleration Bomb (2 Long 61s, 2 Short 36s) => 13:19.578          13:44.578
+      // Chaos Debuffs 2: 12:50.485
+      // 15AB Entroy x8 45s                               => 13:35.485
+      // Neo Exdeath Debuffs Cast 3: (13:00.002)
+      // 1317 White Wound
+      // 1318 Black Wound
+      // 1558 Beyond Death x4 15s                         => 13:15.002
+      // 1C6 Allagan Field x4 15s                         => 13:15.002
+      // Neo Exdeath Final: (13:11.383)
+      // 1317 or 15A5 White Wound
+      // 1318 or 15A6 Black Wound
+      //
+      // For Neo Exdeath, after the second Grand Cross cast there will be:
+      // 1 Support, 1 DPS with Short 3-Person Stack (Compressed Water and/or Fake Forked Lightning)
+      // 1 Support, 1 DPS with Long 3-Person Stack (Compressed Water and/or Fake Forked Lightning)
+      // 1 Support, 1 DPS with Short Gaze (Cursed Shriek or Fake Cursed Shriek)
+      // 1 Support, 1 DPS with Long Gaze (Cursed Shriek or Fake Cursed Shriek)
+      // 2 Support, 2 DPS with Short Stillness (Acceleration Bomb or Fake Acceleration Bomb)
+      // 2 Support, 2 DPS with Long Stillness (Acceleration Bomb or Fake Acceleration Bomb)
+      // For 3rd set of debuffs we do not need to know real/fake:
+      // Allagan Field players swap their color by getting hit with opposite color Angilight
+      // Beyond Death field players keep their color by getting hit with same colore Antilight
+      // Entropy and Dynamic Fluids will be handled seperately
+      type: 'GainsEffect',
+      netRegex: {
+        effectId: [
+        '15A7',
+        '15A8',
+        '15A9',
+        '15AA',
+        '1317',
+        '1318',
+        '1558',
+        '1C6'
+        ],
+        capture: true,
+      },
+      run: (data, matches) => {
+        const target = matches.target;
+        const id = matches.effectId;
+        const duration = parseFloat(matches.duration);
+
+        // Cursed Shriek
+        if (id === '15A7') {
+          if (duration < 61)
+            data.shortShriekPlayers.push(target);
+          else
+            data.longShriekPlayers.push(target);
+        } else if (id === '15A8') {
+          // Forked Lightning
+          if (duration < 37)
+            data.shortForkedPlayers.push(target);
+          else
+            data.longForkedPlayers.push(target);
+        } else if (id === '15A9') {
+          // Compressed Water
+          if (duration < 37)
+            data.shortCompressedPlayers.push(target);
+          else
+            data.longCompressedPlayers.push(target);
+        } else if (id === '15AA') {
+          // Acceleration Bomb
+          if (duration < 52)
+            data.shortBombPlayers.push(target);
+          else
+            data.longBombPlayers.push(target);
+        } else if (data.me === target) {
+          // Cast 5 / 6 Debuffs
+          if (id === '1558')
+            data.deathOrField = 'death';
+          else if (id === '1C6')
+            data.deathOrField = 'field';
+          else if (id === '1317' || id === '15A5')
+            data.wound = 'white';
+          else if (id === '1318' || id === '15A6')
+            data.wound = 'black';
+        }
+      },
+    },
+    {
+      id: 'DMU P4 First Debuffs (Early)',
+      // Cast 1:
+      // 15A7 Cursed Shriek x2 60s
+      // 15A8 Forked Lightning x2 76s
+      // 15A9 Compressed Water x2 76s
+      // 15AA Acceleration Bomb (2 Long 76s, 2 Short 51s)
+      // TODO: Detect if fake
+      type: 'GainsEffect',
+      netRegex: { effectId: ['15A7', '15A8', '15A9', '15AA'], capture: true },
+      condition: Conditions.targetIsYou(),
+      delaySeconds: 0.1,
+      suppressSeconds: 99999,
+      infoText: (data, _matches, output) => {
+        const hasShreik = data.shortShriekPlayers.includes(data.me);
+        const hasFork = data.longForkedPlayers.includes(data.me);
+        const hasCompressed = data.longCompressedPlayers.includes(data.me);
+        const hasBomb = data.longBombPlayers.includes(data.me);
+
+        // Shriek players always are short bomb
+        // This will be two players
+        if (hasShreik)
+          return output.firstGazeAndBomb!({
+            gaze: output.gaze!(),
+            bomb: output.bomb!(),
+          });
+
+        // Remaing 6 players will get one debuff
+        if (hasFork)
+          return output.spreadSecond!({ mech: output.spread!() });
+        if (hasCompressed)
+          return output.stackSecond!({ mech: output.stack!() });
+        if (hasBomb)
+          return output.bombSecond!({ mech: output.bomb!() });
+      },
+      outputStrings: {
+        firstGazeAndBomb: {
+          en: '${gaze} + ${bomb} on YOU First',
+        },
+        gaze: {
+          en: 'Look Away',
+        },
+        fakeGaze: {
+          en: 'Look At',
+        },
+        spreadSecond: {
+          en: '${mech} on YOU Second',
+        },
+        stackSecond: {
+          en: '${mech} on YOU Second',
+        },
+        bombSecond: {
+          en: '${mech} on YOU Second',
+        },
+        stack: Outputs.stackMarker,
+        fakeStack: Outputs.spread,
+        spread: Outputs.spread,
+        fakeSpread: Outputs.stackMarker,
+        bomb: {
+          en: 'Stillness',
+        },
+        fakeBomb: {
+          en: 'Motion',
+        },
+      },
+    },
+    {
+      id: 'DMU P4 Dynamic Fluid (Early)',
+      // TODO: Detect if fake
+      type: 'GainsEffect',
+      netRegex: { effectId: '15AC', capture: false },
+      delaySeconds: 0.1,
+      suppressSeconds: 99999,
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Donuts or Twisters (later)',
+        },
+      },
+    },
+    {
+      id: 'DMU P4 Second Debuffs (Early)',
+      // Cast 2:
+      // 15A8 Forked Lightning x2 36s
+      // 15A7 Cursed Shriek x2 69s
+      // 15A9 Compressed Water x2 36s
+      // 15AA Acceleration Bomb (2 Long 61s, 2 Short 36s)
+      // TODO: Detect if fake
+      type: 'GainsEffect',
+      netRegex: { effectId: ['15A7', '15A8', '15A9', '15AA'], capture: true },
+      condition: (data, matches) => {
+        return data.me === matches.target && data.grandCrossCount === 2;
+      },
+      delaySeconds: 0.1,
+      suppressSeconds: 99999,
+      infoText: (data, _matches, output) => {
+        const hasShreik = data.longShriekPlayers.includes(data.me);
+        const hasFork = data.shortForkedPlayers.includes(data.me);
+        const hasCompressed = data.shortCompressedPlayers.includes(data.me);
+        const hasBomb = data.shortBombPlayers.includes(data.me);
+
+        // Shriek players always are short bomb
+        // This will be two players
+        if (hasShreik)
+          return output.secondGazeAndBomb!({
+            gaze: output.gaze!(),
+            bomb: output.bomb!(),
+          });
+
+        // Remaing 6 players will get one debuff
+        if (hasFork)
+          return output.spreadFirst!({ mech: output.spread!() });
+        if (hasCompressed)
+          return output.stackFirst!({ mech: output.stack!() });
+        if (hasBomb)
+          return output.bombFirst!({ mech: output.bomb!() });
+      },
+      outputStrings: {
+        secondGazeAndBomb: {
+          en: '${gaze} + ${bomb} on YOU Second',
+        },
+        gaze: {
+          en: 'Look Away',
+        },
+        fakeGaze: {
+          en: 'Look At',
+        },
+        spreadFirst: {
+          en: '${mech} on YOU First',
+        },
+        stackFirst: {
+          en: '${mech} on YOU First',
+        },
+        bombFirst: {
+          en: '${mech} on YOU First',
+        },
+        stack: Outputs.stackMarker,
+        fakeStack: Outputs.spread,
+        spread: Outputs.spread,
+        fakeSpread: Outputs.stackMarker,
+        bomb: {
+          en: 'Stillness',
+        },
+        fakeBomb: {
+          en: 'Motion',
+        },
+      },
+    },
+    {
+      id: 'DMU P4 Entropy (Early)',
+      // TODO: Detect if fake
+      type: 'GainsEffect',
+      netRegex: { effectId: '15AB', capture: false },
+      delaySeconds: 0.1,
+      suppressSeconds: 99999,
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Twisters or Donuts (later)',
+        },
+      },
+    },
+    {
+      id: 'DMU P4 Third Debuffs',
+      // Neo Exdeath Debuffs Cast 3
+      // 1317 White Wound
+      // 1318 Black Wound
+      // 1558 Beyond Death x4 15s
+      // 1C6 Allagan Field x4 15s
+      // TODO: Detect if short debuffs fake
+      type: 'GainsEffect',
+      netRegex: { effectId: ['1317', '1318', '1558', '1C6'], capture: true },
+      condition: Conditions.targetIsYou(),
+      delaySeconds: 0.1,
+      durationSeconds: 9,
+      suppressSeconds: 99999,
+      infoText: (data, _matches, output) => {
+        const wound = data.wound;
+        const deathOrField = data.deathOrField;
+
+        if (wound === undefined || deathOrField === undefined)
+          return;
+        const laser = output[deathOrField]!({
+          color: deathOrField === 'death'
+            ? output[wound]!()
+            : wound === 'white'
+            ? output.black!()
+            : output.white!(),
+        });
+
+        const hasFork = data.shortForkedPlayers.includes(data.me);
+        const hasCompressed = data.shortCompressedPlayers.includes(data.me);
+        const hasBomb = data.shortBombPlayers.includes(data.me);
+
+        // Handle 2 Mechs
+        if (hasFork && hasBomb)
+          return output.laserThenForkBomb!({
+            mech1: laser,
+            mech2: output.spread!(),
+            mech3: output.bomb!(),
+          });
+        if (hasCompressed && hasBomb)
+          return output.laserThenCompressedBomb!({
+            mech1: laser,
+            mech2: output.stack!(),
+            mech3: output.bomb!(),
+          });
+        if (hasFork)
+          return output.laserThenSpread!({
+            mech1: laser,
+            mech2: output.spread!(),
+          });
+        if (hasCompressed)
+          return output.laserThenStack!({
+            mech1: laser,
+            mech2: output.stack!(),
+          });
+        if (hasBomb)
+          return output.laserThenBomb!({
+            mech1: laser,
+            mech2: output.bomb!(),
+            mech3: output.stack!(),
+          });
+      },
+      outputStrings: {
+        death: {
+          en: 'Stand in ${color}',
+        },
+        field: {
+          en: 'Stand in ${color}',
+        },
+        white: {
+          en: 'Purple',
+        },
+        black: {
+          en: 'Blue',
+        },
+        laserThenSpread: {
+          en: '${mech1} => ${mech2}',
+        },
+        laserThenStack: {
+          en: '${mech1} => ${mech2}',
+        },
+        laserThenBomb: {
+          en: '${mech1} => ${mech2} + ${mech3}',
+        },
+        laserThenForkBomb: {
+          en: '${mech1} => ${mech2} + ${mech3}',
+        },
+        laserThenCompressedBomb: {
+          en: '${mech1} => ${mech2} + ${mech3}',
+        },
+        stack: Outputs.stackMarker,
+        fakeStack: Outputs.spread,
+        spread: Outputs.spread,
+        fakeSpread: Outputs.stackMarker,
+        bomb: {
+          en: 'Stillness',
+        },
+        fakeBomb: {
+          en: 'Motion',
+        },
+      },
+    },
+    {
+      id: 'DMU P4 Short Debuffs',
+      // Using the following as possible matches:
+      // 1558 Beyond Death x4 15s
+      // 1C6 Allagan Field x4 15s
+      // The spells/abilities or losesEffect could be triggered from early deaths
+      // TODO: Detect if short debuffs fake
+      type: 'GainsEffect',
+      netRegex: { effectId: ['1558', '1C6'], capture: true },
+      delaySeconds: (_data, matches) => parseFloat(matches.duration),
+      suppressSeconds: 99999,
+      alertText: (data, _matches, output) => {
+        const hasFork = data.shortForkedPlayers.includes(data.me);
+        const hasCompressed = data.shortCompressedPlayers.includes(data.me);
+        const hasBomb = data.shortBombPlayers.includes(data.me);
+
+        const players = data.shortShriekPlayers.map(
+          (player) => {
+            if (player === data.me)
+              return output.you!();
+            return data.party.member(player);
+          },
+        );
+        const msg = players?.join(', ');
+
+        // Handle 2 Mechs
+        if (hasFork && hasBomb)
+          return output.forkBombThenGaze!({
+            mech1: output.spread!(),
+            mech2: output.bomb!(),
+            mech3: output.lookAwayFromPlayers!({ players: msg }),
+          });
+        if (hasCompressed && hasBomb)
+          return output.compressedBombThenGaze!({
+            mech1: output.stack!(),
+            mech2: output.bomb!(),
+            mech3: output.lookAwayFromPlayers!({ players: msg }),
+          });
+        if (hasFork)
+          return output.spreadThenGaze!({
+            mech1: output.spread!(),
+            mech2: output.lookAwayFromPlayers!({ players: msg }),
+          });
+        if (hasCompressed)
+          return output.stackThenGaze!({
+            mech1: output.stack!(),
+            mech2: output.lookAwayFromPlayers!({ players: msg }),
+          });
+        if (hasBomb)
+          return output.bombThenGaze!({
+            mech1: output.bomb!(),
+            mech2: output.stack!(),
+            mech3: output.lookAwayFromPlayers!({ players: msg }),
+          });
+      },
+      outputStrings: {
+        you: {
+          en: 'YOU',
+        },
+        spreadThenGaze: {
+          en: '${mech1} => ${mech2}',
+        },
+        stackThenGaze: {
+          en: '${mech1} => ${mech2}',
+        },
+        bombThenGaze: {
+          en: '${mech1} + ${mech2} => ${mech3}',
+        },
+        forkBombThenGaze: {
+          en: '${mech1} + ${mech2} => ${mech3}',
+        },
+        compressedBombThenGaze: {
+          en: '${mech1} + ${mech2} => ${mech3}',
+        },
+        stack: Outputs.stackMarker,
+        fakeStack: Outputs.spread,
+        spread: Outputs.spread,
+        fakeSpread: Outputs.stackMarker,
+        bomb: {
+          en: 'Stillness',
+        },
+        fakeBomb: {
+          en: 'Motion',
+        },
+        lookAtPlayers: {
+          en: 'Face ${players}',
+        },
+        lookAwayFromPlayers: {
+          en: 'Look Away from ${players}',
+        },
+      },
+    },
+    {
+      id: 'DMU P4 First Cursed Shriek',
+      // TODO: Detect if short debuffs fake
+      // TODO: Merge this with Mana Charge (stored fake/real thunder)
+      type: 'GainsEffect',
+      netRegex: { effectId: '15A7', capture: true },
+      condition: (_data, matches) => parseFloat(matches.duration) < 61,
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 6,
+      suppressSeconds: 99999,
+      infoText: (data, _matches, output) => {
+        const players = data.shortShriekPlayers.map(
+          (player) => {
+            if (player === data.me)
+              return output.you!();
+            return data.party.member(player);
+          },
+        );
+        const msg = players?.join(', ');
+
+        return output.shriekThenEntropy!({
+          mech1: msg,
+          mech2: output.twistersOrDonuts!(),
+        });
+      },
+      outputStrings: {
+        you: {
+          en: 'YOU',
+        },
+        shriekThenEntropy: {
+          en: '${mech1} => ${mech2}',
+        },
+        lookAtPlayers: {
+          en: 'Face ${players}',
+        },
+        lookAwayFromPlayers: {
+          en: 'Look Away from ${players}',
+        },
+        twistersOrDonuts: {
+          en: 'Twisters or Donuts',
+        },
+      },
+    },
+    {
+      id: 'DMU P4 Entropy',
+      // Using the following as possible matches:
+      // 15A7 Cursed Shriek x2 60s
+      // TODO: Detect if shriek debuffs fake
+      // TODO: Merge this with Mana Charge (stored fake/real thunder)
+      type: 'GainsEffect',
+      netRegex: { effectId: '15A7', capture: true },
+      condition: (_data, matches) => parseFloat(matches.duration) < 61,
+      delaySeconds: (_data, matches) => parseFloat(matches.duration),
+      suppressSeconds: 99999,
+      alertText: (_data, _matches, output) => output.twistersOrDonuts!(),
+      outputStrings: {
+        twistersOrDonuts: {
+          en: 'Twisters or Donuts',
+        },
+      },
+    },
+    {
+      id: 'DMU P4/P5 Ultima Upsurge',
+      type: 'StartsUsing',
+      netRegex: { id: 'C24A', source: 'Kefka', capture: false },
+      response: Responses.bigAoe(),
+    },
+    {
+      id: 'DMU P4 Long Debuffs',
+      // Using the following as possible matches:
+      // 15A8 Forked Lightning x2 76s
+      // 15A9 Compressed Water x2 76s
+      // 15AA Acceleration Bomb (2 Long 76s)
+      // TODO: Detect if long debuffs fake
+      type: 'GainsEffect',
+      netRegex: { effectId: ['15A8', '15A9', '15AA'], capture: true },
+      condition: (_data, matches) => parseFloat(matches.duration) > 75,
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 6,
+      suppressSeconds: 99999,
+      alertText: (data, _matches, output) => {
+        const hasFork = data.longForkedPlayers.includes(data.me);
+        const hasCompressed = data.longCompressedPlayers.includes(data.me);
+        const hasBomb = data.longBombPlayers.includes(data.me);
+
+        const players = data.longShriekPlayers.map(
+          (player) => {
+            if (player === data.me)
+              return output.you!();
+            return data.party.member(player);
+          },
+        );
+        const msg = players?.join(', ');
+
+        // Handle 2 Mechs
+        if (hasFork && hasBomb)
+          return output.forkBombThenGaze!({
+            mech1: output.spread!(),
+            mech2: output.bomb!(),
+            mech3: output.lookAwayFromPlayers!({ players: msg }),
+          });
+        if (hasCompressed && hasBomb)
+          return output.compressedBombThenGaze!({
+            mech1: output.stack!(),
+            mech2: output.bomb!(),
+            mech3: output.lookAwayFromPlayers!({ players: msg }),
+          });
+        if (hasFork)
+          return output.spreadThenGaze!({
+            mech1: output.spread!(),
+            mech2: output.lookAwayFromPlayers!({ players: msg }),
+          });
+        if (hasCompressed)
+          return output.stackThenGaze!({
+            mech1: output.stack!(),
+            mech2: output.lookAwayFromPlayers!({ players: msg }),
+          });
+        if (hasBomb)
+          return output.bombThenGaze!({
+            mech1: output.bomb!(),
+            mech2: output.stack!(),
+            mech3: output.lookAwayFromPlayers!({ players: msg }),
+          });
+      },
+      outputStrings: {
+        you: {
+          en: 'YOU',
+        },
+        spreadThenGaze: {
+          en: '${mech1} => ${mech2}',
+        },
+        stackThenGaze: {
+          en: '${mech1} => ${mech2}',
+        },
+        bombThenGaze: {
+          en: '${mech1} + ${mech2} => ${mech3}',
+        },
+        forkBombThenGaze: {
+          en: '${mech1} + ${mech2} => ${mech3}',
+        },
+        compressedBombThenGaze: {
+          en: '${mech1} + ${mech2} => ${mech3}',
+        },
+        stack: Outputs.stackMarker,
+        fakeStack: Outputs.spread,
+        spread: Outputs.spread,
+        fakeSpread: Outputs.stackMarker,
+        bomb: {
+          en: 'Stillness',
+        },
+        fakeBomb: {
+          en: 'Motion',
+        },
+        lookAtPlayers: {
+          en: 'Face ${players}',
+        },
+        lookAwayFromPlayers: {
+          en: 'Look Away from ${players}',
         },
       },
     },

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4020,8 +4020,9 @@ const triggerSet: TriggerSet<Data> = {
       id: 'DMU P4 Tsunami/Inferno',
       // BB14 Grand Cross AoE also happens ~4s after this cast starts
       // BB20 Inferno / BB21 Tsunami are 8.7s castTime
+      // Source can be innaccurate
       type: 'StartsUsing',
-      netRegex: { id: ['BB20', 'BB21'], source: 'Chaos', capture: true },
+      netRegex: { id: ['BB20', 'BB21'], capture: true },
       delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 5,
       response: Responses.aoe(),
     },

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4700,114 +4700,21 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'DMU P4 Stray Flames and Long Debuffs',
-      // Puddles have been baited, these will be going off next:
+      // BB22 Stray Flames: Puddles have been baited, these will be going off next
+      // BB23 Fake Stray Flames: Wait until Donuts happen
       // 15A8 Forked Lightning x2 76s
       // 15A9 Compressed Water x2 76s
       // 15AA Acceleration Bomb (2 Long 76s)
+      // Thes have a 4.7s castTime
       type: 'StartsUsing',
-      netRegex: { id: 'BB22', source: 'Chaos', capture: false },
-      durationSeconds: 9, // Time until debuffs expire
-      suppressSeconds: 99999,
-      alertText: (data, _matches, output) => {
-        const hasFork = data.longForkedPlayers.includes(data.me);
-        const hasCompressed = data.longCompressedPlayers.includes(data.me);
-        const hasBomb = data.longBombPlayers.includes(data.me);
-        const is1stTrue = data.areFirstDebuffsTrue;
-        const is2ndTrue = data.areSecondDebuffsTrue;
-
-        if (is2ndTrue === undefined || is1stTrue === undefined)
-          return;
-
-        const players = data.longShriekPlayers.map(
-          (player) => {
-            if (player === data.me)
-              return output.you!();
-            return data.party.member(player);
-          },
-        );
-        const msg = players?.join(', ');
-
-        const gaze = is2ndTrue
-          ? output.lookAwayFromPlayers!({ players: msg })
-          : output.lookAtPlayers!({ players: msg });
-        const hasSpread = (hasFork && is1stTrue) || (hasCompressed && !is1stTrue);
-        const hasStack = (hasFork && !is1stTrue) || (hasCompressed && is1stTrue);
-
-        // Handle 2 Mechs
-        if (hasSpread && hasBomb)
-          return output.forkBombThenGaze!({
-            mech1: output.spread!(),
-            mech2: is1stTrue ? output.bomb!() : output.fakeBomb!(),
-            mech3: gaze,
-          });
-        if (hasStack && hasBomb)
-          return output.compressedBombThenGaze!({
-            mech1: output.stack!(),
-            mech2: is1stTrue ? output.bomb!() : output.fakeBomb!(),
-            mech3: gaze,
-          });
-        if (hasSpread)
-          return output.spreadThenGaze!({
-            mech1: output.spread!(),
-            mech2: gaze,
-          });
-        if (hasStack)
-          return output.stackThenGaze!({
-            mech1: output.stack!(),
-            mech2: gaze,
-          });
-        if (hasBomb)
-          return output.bombThenGaze!({
-            mech1: is1stTrue ? output.bomb!() : output.fakeBomb!(),
-            mech2: output.stack!(),
-            mech3: gaze,
-          });
+      netRegex: { id: ['BB22', 'BB23'], source: 'Chaos', capture: true },
+      delaySeconds: (_data, matches) => {
+        return matches.id === 'BB23' ? parseFloat(matches.castTime) : 0;
       },
-      outputStrings: {
-        you: {
-          en: 'YOU',
-        },
-        spreadThenGaze: {
-          en: '${mech1} => ${mech2}',
-        },
-        stackThenGaze: {
-          en: '${mech1} => ${mech2}',
-        },
-        bombThenGaze: {
-          en: '${mech1} + ${mech2} => ${mech3}',
-        },
-        forkBombThenGaze: {
-          en: '${mech1} + ${mech2} => ${mech3}',
-        },
-        compressedBombThenGaze: {
-          en: '${mech1} + ${mech2} => ${mech3}',
-        },
-        stack: Outputs.stackMarker,
-        spread: Outputs.spread,
-        bomb: {
-          en: 'Stillness',
-        },
-        fakeBomb: {
-          en: 'Motion',
-        },
-        lookAtPlayers: {
-          en: 'Face ${players}',
-        },
-        lookAwayFromPlayers: {
-          en: 'Look Away from ${players}',
-        },
+      durationSeconds: (_data, matches) => {
+        // Time until debuffs expire
+        return matches.id === 'BB22' ? 9 : 9 - parseFloat(matches.castTime);
       },
-    },
-    {
-      id: 'DMU P4 Fake Stray Flames and Long Debuffs',
-      // Need to wait for the donut then these will be going off next:
-      // 15A8 Forked Lightning x2 76s
-      // 15A9 Compressed Water x2 76s
-      // 15AA Acceleration Bomb (2 Long 76s)
-      type: 'StartsUsing',
-      netRegex: { id: 'BB23', source: 'Chaos', capture: true },
-      delaySeconds: (_data, matches) => parseFloat(matches.castTime), // 4.7s
-      durationSeconds: (_data, matches) => 9 - parseFloat(matches.castTime),
       suppressSeconds: 99999,
       alertText: (data, _matches, output) => {
         const hasFork = data.longForkedPlayers.includes(data.me);

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4703,7 +4703,7 @@ const triggerSet: TriggerSet<Data> = {
       // This occurs roughly 5-6s before the alert version
       type: 'Ability',
       netRegex: { id: ['BB18', 'BB19', 'BB1A', 'BB1B'], capture: false },
-      suppressSeconds: 1,
+      suppressSeconds: 24,
       infoText: (data, _matches, output) => {
         // Check Mana Charge related value to see if first shriek
         const isShortDebuffs = data.isThunderChargedTrue === undefined;

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -114,6 +114,91 @@ const headMarkerData = {
   'spreadPath': '02CC', // When standing in Path of Light tower, causes BAC1 Spellscatter (small aoe on the player)
 } as const;
 
+const mysteryMagicIceOutputStrings: OutputStrings = {
+  trueIce: {
+    en: 'Avoid Tell',
+    cn: '躲避扇形',
+    ko: '예고 피하기',
+  },
+  fakeIce: {
+    en: 'In Cone',
+    cn: '进入扇形',
+    ko: '부채꼴 안으로',
+  },
+};
+
+const mysteryMagicFireOutputStrings: OutputStrings = {
+  spread: Outputs.spread,
+  stack: {
+    en: 'Stack',
+    de: 'Stacken',
+    fr: 'Packez-vous',
+    ja: 'スタック',
+    cn: '分摊',
+    ko: '쉐어',
+    tc: '集合',
+  },
+};
+
+const mysteryMagicThunderOutputStrings: OutputStrings = {
+  trueThunder: {
+    en: 'Avoid Tell',
+    cn: '躲避直线',
+    ko: '예고 피하기',
+  },
+  fakeThunder: {
+    en: 'In Line',
+    cn: '进入直线',
+    ko: '직선 안으로',
+  },
+};
+
+const mysteryMagicIceThunderOutputStrings: OutputStrings = {
+  ...mysteryMagicIceOutputStrings,
+  ...mysteryMagicThunderOutputStrings,
+  trueIceTrueThunder: {
+    en: 'Avoid Tells',
+    cn: '躲避扇形+直线',
+    ko: '예고 다 피하기',
+  },
+  fakeIceTrueThunder: {
+    en: 'Cone (only)',
+    cn: '仅扇形',
+    ko: '부채꼴만',
+  },
+  trueIceFakeThunder: {
+    en: 'Line (only)',
+    cn: '仅直线',
+    ko: '직선만',
+  },
+  fakeIceFakeThunder: {
+    en: 'Cone + Line',
+    cn: '扇形+直线',
+    ko: '부채꼴 + 직선',
+  },
+};
+
+const mysteryMagicLookOutputStrings: OutputStrings = {
+  lookAway: {
+    en: 'Look Away From Statue',
+    de: 'Von Statue wegschauen',
+    fr: 'Ne regardez pas la statue',
+    ja: '塔を見ない！',
+    cn: '背对神像',
+    ko: '시선 피하기',
+    tc: '背對神像',
+  },
+  lookAt: {
+    en: 'Look At Statue',
+    de: 'Statue anschauen',
+    fr: 'Regardez la statue',
+    ja: '像を見る！',
+    cn: '面对神像',
+    ko: '시선 바라보기',
+    tc: '面對神像',
+  },
+};
+
 const trapOutputStrings: OutputStrings = {
   you: {
     en: 'YOU',
@@ -741,219 +826,35 @@ const triggerSet: TriggerSet<Data> = {
       run: (data, matches) => data.fireMarker = matches.id,
     },
     {
-      id: 'DMU P1 and P4 Mystery Magic',
-      // BA94 Myster Magic
-      // BA95 Blizzard III Blowout
-      // C5DE Thrumming Thunder III
-      // BAA5 Mana Release (6.7s castTime, but there is additional ~0.382 delay until tells
+      id: 'DMU P1 Mystery Magic Ice and Fire',
+      // Set 1: Only Ice and Fire should be set
       type: 'StartsUsing',
-      netRegex: { id: ['BA94', 'BA95', 'C5DE', 'BAA5'], source: 'Kefka', capture: true },
-      delaySeconds: (_data, matches) => {
-        if (matches.id === 'BAA5')
-          return parseFloat(matches.castTime) + 0.3;
-        return 0;
+      netRegex: { id: 'BA94', source: 'Kefka', capture: false },
+      condition: (data) => {
+        return data.isIceTrue !== undefined && data.isFireTrue !== undefined;
       },
-      infoText: (data, matches, output) => {
-        const id = matches.id;
-        if (id === 'BA94') {
-          // Set 1: P1 Ice and Fire
-          if (data.isIceTrue !== undefined && data.isFireTrue !== undefined) {
-            const fireMarker = data.fireMarker;
-            if (
-              (fireMarker === headMarkerData['dorito'] && data.isFireTrue) ||
-              (fireMarker === headMarkerData['stack'] && !data.isFireTrue)
-            )
-              return data.isIceTrue
-                ? output.spreadTrueIce!({ mech: output.spread!(), ice: output.trueIce!() })
-                : output.spreadFakeIce!({ mech: output.spread!(), ice: output.fakeIce!() });
+      infoText: (data, _matches, output) => {
+        const fireMarker = data.fireMarker;
+        if (
+          (fireMarker === headMarkerData['dorito'] && data.isFireTrue) ||
+          (fireMarker === headMarkerData['stack'] && !data.isFireTrue)
+        )
+          return data.isIceTrue
+            ? output.spreadTrueIce!({ mech: output.spread!(), ice: output.trueIce!() })
+            : output.spreadFakeIce!({ mech: output.spread!(), ice: output.fakeIce!() });
 
-            if (
-              (fireMarker === headMarkerData['dorito'] && !data.isFireTrue) ||
-              (fireMarker === headMarkerData['stack'] && data.isFireTrue)
-            ) {
-              return data.isIceTrue
-                ? output.stackTrueIce!({ mech: output.stack!(), ice: output.trueIce!() })
-                : output.stackFakeIce!({ mech: output.stack!(), ice: output.fakeIce!() });
-            }
-          }
-
-          // Set 2 and P4: Ice and Thunder
-          if (data.isIceTrue !== undefined && data.isThunderTrue !== undefined) {
-            if (data.isThunderTrue) {
-              return data.isIceTrue
-                ? output.trueIceTrueThunder!()
-                : output.fakeIceTrueThunder!();
-            }
-            return data.isIceTrue
-              ? output.trueIceFakeThunder!()
-              : output.fakeIceFakeThunder!();
-          }
-
-          // Set 4: P1 Fire and Thunder
-          if (
-            data.isFireTrue !== undefined &&
-            data.isThunderTrue !== undefined &&
-            data.phase === 'p1'
-          ) {
-            const fireMarker = data.fireMarker;
-            const look = data.isTowerLookAway ? output.lookAway!() : output.lookAt!();
-            if (
-              (fireMarker === headMarkerData['dorito'] && data.isFireTrue) ||
-              (fireMarker === headMarkerData['stack'] && !data.isFireTrue)
-            )
-              return data.isThunderTrue
-                ? output.spreadTrueThunderLook!({
-                  mech: output.spread!(),
-                  thunder: output.trueThunder!(),
-                  look: look,
-                })
-                : output.spreadFakeThunderLook!({
-                  mech: output.spread!(),
-                  thunder: output.fakeThunder!(),
-                  look: look,
-                });
-
-            if (
-              (fireMarker === headMarkerData['dorito'] && !data.isFireTrue) ||
-              (fireMarker === headMarkerData['stack'] && data.isFireTrue)
-            ) {
-              return data.isThunderTrue
-                ? output.stackTrueThunderLook!({
-                  mech: output.stack!(),
-                  thunder: output.trueThunder!(),
-                  look: look,
-                })
-                : output.stackFakeThunderLook!({
-                  mech: output.stack!(),
-                  thunder: output.fakeThunder!(),
-                  look: look,
-                });
-            }
-          }
-        }
-
-        if (id === 'BA95') {
-          // Set 3: P1 Ice Only, and Gravitas and Vitrophyre Tethers
-          // Occurs between Graven Image Set 2 and Set 3
-          if (
-            data.isIceTrue !== undefined &&
-            data.isThunderTrue === undefined &&
-            data.isFireTrue === undefined
-          ) {
-            const hasVitrophyre = data.gravenImageTether === 'vitrophyre';
-            return data.isIceTrue
-              ? output.trueIcePuddle!({
-                mech1: output.trueIce!(),
-                mech2: output.puddle!(),
-                mech3: hasVitrophyre ? output.spread!() : output.middle!(),
-              })
-              : output.fakeIcePuddle!({
-                mech1: output.fakeIce!(),
-                mech2: output.puddle!(),
-                mech3: hasVitrophyre ? output.spread!() : output.middle!(),
-              });
-          }
-
-          // P4 Only
-          // BAA4 Mana Charge signifies that the true/fake will be stored for later
-          // Indicated with boss buff 5CA Mana Charged and 5CC Blizzard Charged
-          // Prevent triggering on earlier P1 or P4 triggers
-          if (data.grandCrossCount === 3)
-            return data.isIceTrue ? output.trueIce!() : output.fakeIce!();
-        }
-
-        // P4 Only
-        // BAA4 Mana Charge signifies that the true/fake will be stored for later
-        // Indicated with boss buff 5CA Mana Charged and 5CD Thunder Charged
-        if (id === 'C5DE')
-          return data.isThunderTrue ? output.trueThunder!() : output.fakeThunder!();
-
-        // P4 Only
-        // 5CA Mana Charged falls off ~5.4s prior to startsUsing
-        // 5CD Thunder Charged and 5CC Blizzard Charged fall off after subsequent
-        // This will need to be done while stacking donuts if Dynamic Fluid is true
-        if (id === 'BAA5' && data.isIceTrue !== undefined && data.isThunderTrue !== undefined) {
-          const isThunderCharged = data.isThunderChargedTrue;
-          const isBlizzardCharged = data.isBlizzardChargedTrue;
-          const isFluidTrue = data.isFluidTrue;
-          const trueThunder = (isThunderCharged && data.isThunderTrue) ||
-            (!isThunderCharged && !data.isThunderTrue);
-          const trueIce = (isBlizzardCharged && data.isIceTrue) ||
-            (!isBlizzardCharged && !data.isIceTrue);
-
-          if (trueThunder) {
-            const tells = trueIce
-              ? output.trueIceTrueThunder!()
-              : output.fakeIceTrueThunder!();
-            return isFluidTrue
-              ? output.tellsDonut!({
-                tells: tells,
-                donut: output.inDonut!(),
-              })
-              : tells;
-          }
-          const tells = trueIce
-            ? output.trueIceFakeThunder!()
-            : output.fakeIceFakeThunder!();
-          return isFluidTrue
-            ? output.tellsDonut!({
-              tells: tells,
-              donut: output.inDonut!(),
-            })
-            : tells;
+        if (
+          (fireMarker === headMarkerData['dorito'] && !data.isFireTrue) ||
+          (fireMarker === headMarkerData['stack'] && data.isFireTrue)
+        ) {
+          return data.isIceTrue
+            ? output.stackTrueIce!({ mech: output.stack!(), ice: output.trueIce!() })
+            : output.stackFakeIce!({ mech: output.stack!(), ice: output.fakeIce!() });
         }
       },
       outputStrings: {
-        puddle: {
-          en: 'Bait Puddle',
-          de: 'Fläche ködern',
-          fr: 'Déposez',
-          ja: 'AOE誘導',
-          cn: '诱导AOE',
-          ko: '장판 유도',
-          tc: '誘導AOE',
-        },
-        spread: Outputs.spread,
-        middle: Outputs.goIntoMiddle,
-        stack: {
-          en: 'Stack',
-          de: 'Stacken',
-          fr: 'Packez-vous',
-          ja: 'スタック',
-          cn: '分摊',
-          ko: '쉐어',
-          tc: '集合',
-        },
-        trueThunder: {
-          en: 'Avoid Tell',
-          cn: '躲避直线',
-          ko: '예고 피하기',
-        },
-        fakeThunder: {
-          en: 'In Line',
-          cn: '进入直线',
-          ko: '직선 안으로',
-        },
-        trueIce: {
-          en: 'Avoid Tell',
-          cn: '躲避扇形',
-          ko: '예고 피하기',
-        },
-        fakeIce: {
-          en: 'In Cone',
-          cn: '进入扇形',
-          ko: '부채꼴 안으로',
-        },
-        trueIcePuddle: {
-          en: '${mech1} + ${mech2} => ${mech3}',
-          cn: '${mech1} + ${mech2} => ${mech3}',
-          ko: '${mech1} + ${mech2} => ${mech3}',
-        },
-        fakeIcePuddle: {
-          en: '${mech1} + ${mech2} => ${mech3}',
-          cn: '${mech1} + ${mech2} => ${mech3}',
-          ko: '${mech1} + ${mech2} => ${mech3}',
-        },
+        ...mysteryMagicIceOutputStrings,
+        ...mysteryMagicFireOutputStrings,
         stackTrueIce: {
           en: '${mech} + ${ice}',
           cn: '${mech} + ${ice}',
@@ -973,90 +874,6 @@ const triggerSet: TriggerSet<Data> = {
           en: '${mech} + ${ice}',
           cn: '${mech} + ${ice}',
           ko: '${mech} + ${ice}',
-        },
-        trueIceTrueThunder: {
-          en: 'Avoid Tells',
-          cn: '躲避扇形+直线',
-          ko: '예고 다 피하기',
-        },
-        fakeIceTrueThunder: {
-          en: 'Cone (only)',
-          cn: '仅扇形',
-          ko: '부채꼴만',
-        },
-        trueIceFakeThunder: {
-          en: 'Line (only)',
-          cn: '仅直线',
-          ko: '직선만',
-        },
-        fakeIceFakeThunder: {
-          en: 'Cone + Line',
-          cn: '扇形+直线',
-          ko: '부채꼴 + 직선',
-        },
-        stackTrueThunderLook: {
-          en: '${mech} + ${thunder} + ${look}',
-          cn: '${mech} + ${thunder} + ${look}',
-          ko: '${mech} + ${thunder} + ${look}',
-        },
-        stackFakeThunderLook: {
-          en: '${mech} + ${thunder} + ${look}',
-          cn: '${mech} + ${thunder} + ${look}',
-          ko: '${mech} + ${thunder} + ${look}',
-        },
-        spreadTrueThunderLook: {
-          en: '${mech} + ${thunder} + ${look}',
-          cn: '${mech} + ${thunder} + ${look}',
-          ko: '${mech} + ${thunder} + ${look}',
-        },
-        spreadFakeThunderLook: {
-          en: '${mech} + ${thunder} + ${look}',
-          cn: '${mech} + ${thunder} + ${look}',
-          ko: '${mech} + ${thunder} + ${look}',
-        },
-        stackTrueThunder: {
-          en: '${mech} + ${thunder}',
-          cn: '${mech} + ${thunder}',
-          ko: '${mech} + ${thunder}',
-        },
-        stackFakeThunder: {
-          en: '${mech} + ${thunder}',
-          cn: '${mech} + ${thunder}',
-          ko: '${mech} + ${thunder}',
-        },
-        spreadTrueThunder: {
-          en: '${mech} + ${thunder}',
-          cn: '${mech} + ${thunder}',
-          ko: '${mech} + ${thunder}',
-        },
-        spreadFakeThunder: {
-          en: '${mech} + ${thunder}',
-          cn: '${mech} + ${thunder}',
-          ko: '${mech} + ${thunder}',
-        },
-        lookAway: {
-          en: 'Look Away From Statue',
-          de: 'Von Statue wegschauen',
-          fr: 'Ne regardez pas la statue',
-          ja: '塔を見ない！',
-          cn: '背对神像',
-          ko: '시선 피하기',
-          tc: '背對神像',
-        },
-        lookAt: {
-          en: 'Look At Statue',
-          de: 'Statue anschauen',
-          fr: 'Regardez la statue',
-          ja: '像を見る！',
-          cn: '面对神像',
-          ko: '시선 바라보기',
-          tc: '面對神像',
-        },
-        inDonut: {
-          en: 'In Donut',
-        },
-        tellsDonut: {
-          en: '${tells} + ${donut}',
         },
       },
     },
@@ -1280,6 +1097,27 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: trapOutputStrings,
     },
     {
+      id: 'DMU P1 and P4 Mystery Magic Ice and Thunder',
+      // P1 Set 2: Only Ice and Thunder should be set
+      // P4 All BA94 Mystery Magic casts
+      type: 'StartsUsing',
+      netRegex: { id: 'BA94', source: 'Kefka', capture: false },
+      condition: (data) => {
+        return data.isIceTrue !== undefined && data.isThunderTrue !== undefined;
+      },
+      infoText: (data, _matches, output) => {
+        if (data.isThunderTrue) {
+          return data.isIceTrue
+            ? output.trueIceTrueThunder!()
+            : output.fakeIceTrueThunder!();
+        }
+        return data.isIceTrue
+          ? output.trueIceFakeThunder!()
+          : output.fakeIceFakeThunder!();
+      },
+      outputStrings: mysteryMagicIceThunderOutputStrings,
+    },
+    {
       id: 'DMU P1 Light of Judgment',
       type: 'StartsUsing',
       netRegex: { id: 'C622', source: 'Kefka', capture: false },
@@ -1293,6 +1131,63 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { id: 'C622', source: 'Kefka', capture: true },
       delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 2, // Result in ~5.1s warning
       response: Responses.tankBuster(),
+    },
+    {
+      id: 'DMU P1 Mystery Magic Ice, and Gravitas and Vitrophyre Tethers 1',
+      // BA95 Blizzard III Blowout
+      // Set 3: P1 Ice Only, and Gravitas and Vitrophyre Tethers
+      // Occurs between Graven Image Set 2 and Set 3
+      type: 'StartsUsing',
+      netRegex: { id: 'BA95', source: 'Kefka', capture: false },
+      condition: (data) => {
+        if (
+          data.isIceTrue !== undefined &&
+          data.isThunderTrue === undefined &&
+          data.isFireTrue === undefined &&
+          data.phase === 'p1'
+        )
+          return true;
+        return false;
+      },
+      infoText: (data, _matches, output) => {
+        const hasVitrophyre = data.gravenImageTether === 'vitrophyre';
+        return data.isIceTrue
+          ? output.trueIcePuddle!({
+            mech1: output.trueIce!(),
+            mech2: output.puddle!(),
+            mech3: hasVitrophyre ? output.spread!() : output.middle!(),
+          })
+          : output.fakeIcePuddle!({
+            mech1: output.fakeIce!(),
+            mech2: output.puddle!(),
+            mech3: hasVitrophyre ? output.spread!() : output.middle!(),
+          });
+      },
+      outputStrings: {
+        ...mysteryMagicIceOutputStrings,
+        ...mysteryMagicLookOutputStrings,
+        puddle: {
+          en: 'Bait Puddle',
+          de: 'Fläche ködern',
+          fr: 'Déposez',
+          ja: 'AOE誘導',
+          cn: '诱导AOE',
+          ko: '장판 유도',
+          tc: '誘導AOE',
+        },
+        middle: Outputs.goIntoMiddle,
+        spread: Outputs.spread,
+        trueIcePuddle: {
+          en: '${mech1} + ${mech2} => ${mech3}',
+          cn: '${mech1} + ${mech2} => ${mech3}',
+          ko: '${mech1} + ${mech2} => ${mech3}',
+        },
+        fakeIcePuddle: {
+          en: '${mech1} + ${mech2} => ${mech3}',
+          cn: '${mech1} + ${mech2} => ${mech3}',
+          ko: '${mech1} + ${mech2} => ${mech3}',
+        },
+      },
     },
     {
       id: 'DMU P1 Vitrophyre',
@@ -1908,6 +1803,124 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Look Away From Statue (later)',
           cn: '背对神像(稍后)',
           ko: '시선 피하기 (나중에)',
+        },
+      },
+    },
+    {
+      id: 'DMU P1 Mystery Magic Fire and Thunder',
+      // Set 3: Only Fire and Thunder should be set
+      type: 'StartsUsing',
+      netRegex: { id: 'BA94', source: 'Kefka', capture: false },
+      condition: (data) => {
+        if (
+          data.isFireTrue !== undefined &&
+          data.isThunderTrue !== undefined &&
+          data.phase === 'p1'
+        )
+          return true;
+        return false;
+      },
+      infoText: (data, _matches, output) => {
+        const fireMarker = data.fireMarker;
+        const isTowerLookAway = data.isTowerLookAway;
+        const look = isTowerLookAway ? output.lookAway!() : output.lookAt!();
+        if (
+          (fireMarker === headMarkerData['dorito'] && data.isFireTrue) ||
+          (fireMarker === headMarkerData['stack'] && !data.isFireTrue)
+        ) {
+          if (isTowerLookAway !== undefined)
+            return data.isThunderTrue
+              ? output.spreadTrueThunderLook!({
+                mech: output.spread!(),
+                thunder: output.trueThunder!(),
+                look: look,
+              })
+              : output.spreadFakeThunderLook!({
+                mech: output.spread!(),
+                thunder: output.fakeThunder!(),
+                look: look,
+              });
+          return data.isThunderTrue
+            ? output.spreadTrueThunder!({
+              mech: output.spread!(),
+              thunder: output.trueThunder!(),
+            })
+            : output.spreadFakeThunder!({
+              mech: output.spread!(),
+              thunder: output.fakeThunder!(),
+            });
+        }
+
+        if (
+          (fireMarker === headMarkerData['dorito'] && !data.isFireTrue) ||
+          (fireMarker === headMarkerData['stack'] && data.isFireTrue)
+        ) {
+          if (isTowerLookAway !== undefined)
+            return data.isThunderTrue
+              ? output.stackTrueThunderLook!({
+                mech: output.stack!(),
+                thunder: output.trueThunder!(),
+                look: look,
+              })
+              : output.stackFakeThunderLook!({
+                mech: output.stack!(),
+                thunder: output.fakeThunder!(),
+                look: look,
+              });
+          return data.isThunderTrue
+            ? output.stackTrueThunder!({
+              mech: output.stack!(),
+              thunder: output.trueThunder!(),
+            })
+            : output.stackFakeThunder!({
+              mech: output.stack!(),
+              thunder: output.fakeThunder!(),
+            });
+        }
+      },
+      outputStrings: {
+        ...mysteryMagicFireOutputStrings,
+        ...mysteryMagicThunderOutputStrings,
+        ...mysteryMagicLookOutputStrings,
+        stackTrueThunderLook: {
+          en: '${mech} + ${thunder} + ${look}',
+          cn: '${mech} + ${thunder} + ${look}',
+          ko: '${mech} + ${thunder} + ${look}',
+        },
+        stackFakeThunderLook: {
+          en: '${mech} + ${thunder} + ${look}',
+          cn: '${mech} + ${thunder} + ${look}',
+          ko: '${mech} + ${thunder} + ${look}',
+        },
+        spreadTrueThunderLook: {
+          en: '${mech} + ${thunder} + ${look}',
+          cn: '${mech} + ${thunder} + ${look}',
+          ko: '${mech} + ${thunder} + ${look}',
+        },
+        spreadFakeThunderLook: {
+          en: '${mech} + ${thunder} + ${look}',
+          cn: '${mech} + ${thunder} + ${look}',
+          ko: '${mech} + ${thunder} + ${look}',
+        },
+        stackTrueThunder: {
+          en: '${mech} + ${thunder}',
+          cn: '${mech} + ${thunder}',
+          ko: '${mech} + ${thunder}',
+        },
+        stackFakeThunder: {
+          en: '${mech} + ${thunder}',
+          cn: '${mech} + ${thunder}',
+          ko: '${mech} + ${thunder}',
+        },
+        spreadTrueThunder: {
+          en: '${mech} + ${thunder}',
+          cn: '${mech} + ${thunder}',
+          ko: '${mech} + ${thunder}',
+        },
+        spreadFakeThunder: {
+          en: '${mech} + ${thunder}',
+          cn: '${mech} + ${thunder}',
+          ko: '${mech} + ${thunder}',
         },
       },
     },
@@ -4839,6 +4852,18 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
+      id: 'DMU P4 Thrumming Thunder III',
+      // BAA4 Mana Charge signifies that the true/fake will be stored for later
+      // Indicated with boss buff 5CA Mana Charged and 5CD Thunder Charged
+      type: 'StartsUsing',
+      netRegex: { id: 'C5DE', source: 'Kefka', capture: false },
+      condition: (data) => data.isThunderTrue !== undefined,
+      infoText: (data, _matches, output) => {
+        return data.isThunderTrue ? output.trueThunder!() : output.fakeThunder!();
+      },
+      outputStrings: mysteryMagicThunderOutputStrings,
+    },
+    {
       id: 'DMU P4 First Cursed Shriek',
       type: 'GainsEffect',
       netRegex: { effectId: '15A7', capture: true },
@@ -5020,6 +5045,19 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
+      id: 'DMU P4 Blizzard III Blowout',
+      // BAA4 Mana Charge signifies that the true/fake will be stored for later
+      // Indicated with boss buff 5CA Mana Charged and 5CC Blizzard Charged
+      type: 'StartsUsing',
+      netRegex: { id: 'BA95', source: 'Kefka', capture: false },
+      // Prevent triggering on earlier P1 or P4 triggers
+      condition: (data) => (data.grandCrossCount === 3 && data.isIceTrue !== undefined),
+      infoText: (data, _matches, output) => {
+        return data.isIceTrue ? output.trueIce!() : output.fakeIce!();
+      },
+      outputStrings: mysteryMagicIceOutputStrings,
+    },
+    {
       id: 'DMU P4 Second Cursed Shriek',
       type: 'GainsEffect',
       netRegex: { effectId: '15A7', capture: true },
@@ -5095,6 +5133,59 @@ const triggerSet: TriggerSet<Data> = {
           tc: '集合放月環',
         },
         puddles: Outputs.baitPuddles,
+      },
+    },
+    {
+      id: 'DMU P4 Mana Release',
+      // 5CA Mana Charged falls off ~5.4s prior to startsUsing
+      // 5CD Thunder Charged and 5CC Blizzard Charged fall off after subsequent
+      // Thrumming Thunder III and Blizzard III Blowout startsUsing
+      // This will need to be done while stacking donuts if Dynamic Fluid is true
+      // 6.7s castTime, but there is additional ~0.382 delay until tells
+      type: 'StartsUsing',
+      netRegex: { id: 'BAA5', source: 'Kefka', capture: false },
+      condition: (data) => {
+        return data.isIceTrue !== undefined && data.isThunderTrue !== undefined;
+      },
+      delaySeconds: (_data, matches) => parseFloat(matches.castTime) + 0.3,
+      infoText: (data, _matches, output) => {
+        const isThunderCharged = data.isThunderChargedTrue;
+        const isBlizzardCharged = data.isBlizzardChargedTrue;
+        const isFluidTrue = data.isFluidTrue;
+        const trueThunder = (isThunderCharged && data.isThunderTrue) ||
+          (!isThunderCharged && !data.isThunderTrue);
+        const trueIce = (isBlizzardCharged && data.isIceTrue) ||
+          (!isBlizzardCharged && !data.isIceTrue);
+
+        if (trueThunder) {
+          const tells = trueIce
+            ? output.trueIceTrueThunder!()
+            : output.fakeIceTrueThunder!();
+          return isFluidTrue
+            ? output.tellsDonut!({
+              tells: tells,
+              donut: output.inDonut!(),
+            })
+            : tells;
+        }
+        const tells = trueIce
+          ? output.trueIceFakeThunder!()
+          : output.fakeIceFakeThunder!();
+        return isFluidTrue
+          ? output.tellsDonut!({
+            tells: tells,
+            donut: output.inDonut!(),
+          })
+          : tells;
+      },
+      outputStrings: {
+        ...mysteryMagicIceThunderOutputStrings,
+        inDonut: {
+          en: 'In Donut',
+        },
+        tellsDonut: {
+          en: '${tells} + ${donut}',
+        },
       },
     },
     {

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4179,8 +4179,8 @@ const triggerSet: TriggerSet<Data> = {
           ? data.shortForkedPlayers.includes(data.me)
           : data.longForkedPlayers.includes(data.me);
         const hasCompressed = isShort
-          ? data.shortForkedPlayers.includes(data.me)
-          : data.longForkedPlayers.includes(data.me);
+          ? data.shortCompressedPlayers.includes(data.me)
+          : data.longCompressedPlayers.includes(data.me);
         const hasBomb = data.longBombPlayers.includes(data.me);
 
         // Shriek players always are short bomb
@@ -4300,8 +4300,8 @@ const triggerSet: TriggerSet<Data> = {
           ? data.longForkedPlayers.includes(data.me)
           : data.shortForkedPlayers.includes(data.me);
         const hasCompressed = isShort
-          ? data.longForkedPlayers.includes(data.me)
-          : data.shortForkedPlayers.includes(data.me);
+          ? data.longCompressedPlayers.includes(data.me)
+          : data.shortCompressedPlayers.includes(data.me);
         const hasBomb = data.shortBombPlayers.includes(data.me);
 
         // Shriek players always are short bomb

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4706,7 +4706,7 @@ const triggerSet: TriggerSet<Data> = {
       },
       suppressSeconds: 1,
       infoText: (data, matches, output) => {
-        const isShortDebuffs =  parseFloat(matches.duration) < 61;
+        const isShortDebuffs = parseFloat(matches.duration) < 61;
         const isTrue = isShortDebuffs ? data.areFirstDebuffsTrue : data.areSecondDebuffsTrue;
         if (isTrue === undefined)
           return;

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4441,7 +4441,7 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'DMU P4 Third Debuffs',
+      id: 'DMU P4 Fifth Debuffs',
       // Neo Exdeath Debuffs Cast 3
       // 1317 White Wound (Fake) or 15A5 White Wound
       // 1318 Black Wound (Fake) or 15A6 Black Wound

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4701,7 +4701,7 @@ const triggerSet: TriggerSet<Data> = {
       // Using the debuff as a timer as player deaths would cause early trigger
       type: 'GainsEffect',
       netRegex: { effectId: '15A7', capture: true },
-      delaySeconds: (_data, matches, output) => {
+      delaySeconds: (_data, matches) => {
         return parseFloat(matches.duration) < 61 ? 51.1 : 61.1;
       },
       suppressSeconds: 1,

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4621,7 +4621,9 @@ const triggerSet: TriggerSet<Data> = {
         const hasCompressed = data.shortCompressedPlayers.includes(data.me);
         const hasBomb = data.shortBombPlayers.includes(data.me);
 
-        const players = data.shortShriekPlayers.map(
+        const shriekPlayers = data.shortShriekPlayers;
+        const shriekOnYou = shriekPlayers.includes(data.me);
+        const players = shriekPlayers.map(
           (player) => {
             if (player === data.me)
               return output.you!();
@@ -4630,9 +4632,13 @@ const triggerSet: TriggerSet<Data> = {
         );
         const msg = players?.join(', ');
 
-        const gaze = is1stTrue
-          ? output.fakeGazeOnPlayers!({ players: msg })
-          : output.gazeOnPlayers!({ players: msg });
+        const gaze = (is1stTrue && shriekOnYou)
+          ? output.gazeOnPlayersYou!({ players: msg })
+          : (!is2ndTrue && shriekOnYou)
+          ? output.fakeGazeOnPlayersYou!({ players: msg })
+          : is1stTrue
+          ? output.gazeOnPlayers!({ players: msg })
+          : output.fakeGazeOnPlayers!({ players: msg });
         const hasSpread = (hasFork && isShortTrue) || (hasCompressed && !isShortTrue);
         const hasStack = (hasFork && !isShortTrue) || (hasCompressed && isShortTrue);
 
@@ -4698,10 +4704,16 @@ const triggerSet: TriggerSet<Data> = {
         fakeBomb: {
           en: 'Motion',
         },
-        gazeOnPlayers: {
+        fakeGazeOnPlayers: {
           en: 'Face ${players}',
         },
-        fakeGazeOnPlayers: {
+        gazeOnPlayers: {
+          en: 'Look Away from ${players}',
+        },
+        fakeGazeOnPlayersYou: {
+          en: 'Face ${players}',
+        },
+        gazeOnPlayersYou: {
           en: 'Look Away from ${players}',
         },
       },
@@ -4773,27 +4785,27 @@ const triggerSet: TriggerSet<Data> = {
         // Seperate configurable output if you have it
         if (shriekPlayers.includes(data.me)) {
           return isTrue
-            ? output.fakeGazeOnYou!({ players: msg })
-            : output.gazeOnYou!({ players: msg });
+            ? output.gazeOnYou!({ players: msg })
+            : output.fakeGazeOnYou!({ players: msg });
         }
         return isTrue
-          ? output.fakeGazeOnPlayers!({ players: msg })
-          : output.gazeOnPlayers!({ players: msg });
+          ? output.gazeOnPlayers!({ players: msg })
+          : output.fakeGazeOnPlayers!({ players: msg });
       },
       outputStrings: {
         you: {
           en: 'YOU',
         },
-        gazeOnPlayers: {
+        fakeGazeOnPlayers: {
           en: 'Face ${players} (later)',
         },
-        fakeGazeOnPlayers: {
+        gazeOnPlayers: {
           en: 'Look Away from ${players} (later)',
         },
-        gazeOnYou: {
+        fakeGazeOnYou: {
           en: 'Face ${players} (later)',
         },
-        fakeGazeOnYou: {
+        gazeOnYou: {
           en: 'Look Away from ${players} (later)',
         },
       },
@@ -4825,7 +4837,8 @@ const triggerSet: TriggerSet<Data> = {
         if (is1stTrue === undefined)
           return;
 
-        const players = data.shortShriekPlayers.map(
+        const shriekPlayers = data.shortShriekPlayers;
+        const players = shriekPlayers.map(
           (player) => {
             if (player === data.me)
               return output.you!();
@@ -4834,18 +4847,28 @@ const triggerSet: TriggerSet<Data> = {
         );
         const msg = players?.join(', ');
 
+        if (shriekPlayers.includes(data.me))
+          return is1stTrue
+            ? output.gazeOnPlayersYou!({ players: msg })
+            : output.fakeGazeOnPlayersYou!({ players: msg });
         return is1stTrue
-          ? output.fakeGazeOnPlayers!({ players: msg })
-          : output.gazeOnPlayers!({ players: msg });
+          ? output.gazeOnPlayers!({ players: msg })
+          : output.fakeGazeOnPlayers!({ players: msg });
       },
       outputStrings: {
         you: {
           en: 'YOU',
         },
-        gazeOnPlayers: {
+        fakeGazeOnPlayers: {
           en: 'Face ${players}',
         },
-        fakeGazeOnPlayers: {
+        gazeOnPlayers: {
+          en: 'Look Away from ${players}',
+        },
+        fakeGazeOnPlayersYou: {
+          en: 'Face ${players}',
+        },
+        gazeOnPlayersYou: {
           en: 'Look Away from ${players}',
         },
       },
@@ -4916,7 +4939,9 @@ const triggerSet: TriggerSet<Data> = {
         const hasCompressed = data.longCompressedPlayers.includes(data.me);
         const hasBomb = data.longBombPlayers.includes(data.me);
 
-        const players = data.longShriekPlayers.map(
+        const shriekPlayers = data.longShriekPlayers;
+        const shriekOnYou = shriekPlayers.includes(data.me);
+        const players = shriekPlayers.map(
           (player) => {
             if (player === data.me)
               return output.you!();
@@ -4925,9 +4950,13 @@ const triggerSet: TriggerSet<Data> = {
         );
         const msg = players?.join(', ');
 
-        const gaze = is2ndTrue
-          ? output.fakeGazeOnPlayers!({ players: msg })
-          : output.gazeOnPlayers!({ players: msg });
+        const gaze = (is2ndTrue && shriekOnYou)
+          ? output.gazeOnPlayersYou!({ players: msg })
+          : (!is2ndTrue && shriekOnYou)
+          ? output.fakeGazeOnPlayersYou!({ players: msg })
+          : is2ndTrue
+          ? output.gazeOnPlayers!({ players: msg })
+          : output.fakeGazeOnPlayers!({ players: msg });
         const hasSpread = (hasFork && isLongTrue) || (hasCompressed && !isLongTrue);
         const hasStack = (hasFork && !isLongTrue) || (hasCompressed && isLongTrue);
 
@@ -4993,10 +5022,16 @@ const triggerSet: TriggerSet<Data> = {
         fakeBomb: {
           en: 'Motion',
         },
-        gazeOnPlayers: {
+        fakeGazeOnPlayers: {
           en: 'Face ${players}',
         },
-        fakeGazeOnPlayers: {
+        gazeOnPlayers: {
+          en: 'Look Away from ${players}',
+        },
+        fakeGazeOnPlayersYou: {
+          en: 'Face ${players}',
+        },
+        gazeOnPlayersYou: {
           en: 'Look Away from ${players}',
         },
       },
@@ -5014,7 +5049,8 @@ const triggerSet: TriggerSet<Data> = {
         if (is2ndTrue === undefined)
           return;
 
-        const players = data.longShriekPlayers.map(
+        const shriekPlayers = data.longShriekPlayers;
+        const players = shriekPlayers.map(
           (player) => {
             if (player === data.me)
               return output.you!();
@@ -5023,18 +5059,28 @@ const triggerSet: TriggerSet<Data> = {
         );
         const msg = players?.join(', ');
 
+        if (shriekPlayers.includes(data.me))
+          return is2ndTrue
+            ? output.gazeOnPlayersYou!({ players: msg })
+            : output.fakeGazeOnPlayersYou!({ players: msg });
         return is2ndTrue
-          ? output.fakeGazeOnPlayers!({ players: msg })
-          : output.gazeOnPlayers!({ players: msg });
+          ? output.gazeOnPlayers!({ players: msg })
+          : output.fakeGazeOnPlayers!({ players: msg });
       },
       outputStrings: {
         you: {
           en: 'YOU',
         },
-        gazeOnPlayers: {
+        fakeGazeOnPlayers: {
           en: 'Face ${players}',
         },
-        fakeGazeOnPlayers: {
+        gazeOnPlayers: {
+          en: 'Look Away from ${players}',
+        },
+        fakeGazeOnPlayersYou: {
+          en: 'Face ${players}',
+        },
+        gazeOnPlayersYou: {
           en: 'Look Away from ${players}',
         },
       },

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -3937,14 +3937,14 @@ const triggerSet: TriggerSet<Data> = {
       type: 'GainsEffect',
       netRegex: {
         effectId: [
-        '15A7',
-        '15A8',
-        '15A9',
-        '15AA',
-        '1317',
-        '1318',
-        '1558',
-        '1C6'
+          '15A7',
+          '15A8',
+          '15A9',
+          '15AA',
+          '1317',
+          '1318',
+          '1558',
+          '1C6',
         ],
         capture: true,
       },

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4698,15 +4698,15 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'DMU P4 Cursed Shriek (Early)',
       // This may be more important for those that have it to get into position
-      // Not defining source due to possibility of source being incorrect
-      // Using BB18, BB19 Death Wave or BB1A, BB1B Death Bolt
-      // This occurs roughly 5-6s before the alert version
-      type: 'Ability',
-      netRegex: { id: ['BB18', 'BB19', 'BB1A', 'BB1B'], capture: false },
-      suppressSeconds: 24,
-      infoText: (data, _matches, output) => {
-        // Check Mana Charge related value to see if first shriek
-        const isShortDebuffs = data.isThunderChargedTrue === undefined;
+      // Using the debuff as a timer as player deaths would cause early trigger
+      type: 'GainsEffect',
+      netRegex: { effectId: '15A7', capture: true },
+      delaySeconds: (_data, matches, output) => {
+        return parseFloat(matches.duration) < 61 ? 51.1 : 61.1;
+      },
+      suppressSeconds: 1,
+      infoText: (data, matches, output) => {
+        const isShortDebuffs =  parseFloat(matches.duration) < 61;
         const isTrue = isShortDebuffs ? data.areFirstDebuffsTrue : data.areSecondDebuffsTrue;
         if (isTrue === undefined)
           return;
@@ -4755,7 +4755,7 @@ const triggerSet: TriggerSet<Data> = {
       // 5CC Blizzard Charged: Store the value of isIceTrue for later
       type: 'GainsEffect',
       netRegex: { effectId: ['5CD', '5CC'], capture: true },
-      delaySeconds: 0.1, // Delay for headmarker collect
+      delaySeconds: 0.2, // Delay for headmarker collect
       run: (data, matches) => {
         if (matches.effectId === '5CD')
           data.isThunderChargedTrue = data.isThunderTrue;

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -77,8 +77,10 @@ export interface Data extends RaidbossData {
   longForkedPlayers: string[];
   shortCompressedPlayers: string[];
   longCompressedPlayers: string[];
-  shortBombPlayers: string[];
-  longBombPlayers: string[];
+  firstShortBombPlayers: string[];
+  firstLongBombPlayers: string[];
+  secondShortBombPlayers: string[];
+  secondLongBombPlayers: string[];
   areFirstDebuffsTrue?: boolean;
   areSecondDebuffsTrue?: boolean;
   areThirdDebuffsTrue?: boolean;
@@ -550,8 +552,10 @@ const triggerSet: TriggerSet<Data> = {
       longForkedPlayers: [],
       shortCompressedPlayers: [],
       longCompressedPlayers: [],
-      shortBombPlayers: [],
-      longBombPlayers: [],
+      firstShortBombPlayers: [],
+      firstLongBombPlayers: [],
+      secondShortBombPlayers: [],
+      secondLongBombPlayers: [],
     };
   },
   triggers: [
@@ -4189,10 +4193,14 @@ const triggerSet: TriggerSet<Data> = {
             data.longCompressedPlayers.push(target);
         } else if (id === '15AA') {
           // Acceleration Bomb
-          if (duration < 52)
-            data.shortBombPlayers.push(target);
+          if (duration < 37)
+            data.secondShortBombPlayers.push(target);
+          else if (duration < 52)
+            data.firstShortBombPlayers.push(target);
+          else if (duration < 62)
+            data.secondLongBombPlayers.push(target);
           else
-            data.longBombPlayers.push(target);
+            data.firstLongBombPlayers.push(target);
         } else if (data.me === target) {
           // Cast 5 / 6 Debuffs
           if (id === '1558' || id === '566')
@@ -4233,7 +4241,8 @@ const triggerSet: TriggerSet<Data> = {
         const hasCompressed = isShort
           ? data.shortCompressedPlayers.includes(data.me)
           : data.longCompressedPlayers.includes(data.me);
-        const hasBomb = data.longBombPlayers.includes(data.me);
+        const hasFirstBomb = data.firstShortBombPlayers.includes(data.me);
+        const hasSecondBomb = data.firstLongBombPlayers.includes(data.me);
 
         // Shriek players always are short bomb
         // This will be two players
@@ -4261,7 +4270,14 @@ const triggerSet: TriggerSet<Data> = {
               ? output.stackFirst!({ mech: output.stack!() })
               : output.stackSecond!({ mech: output.stack!() }),
           });
-        if (hasBomb)
+        if (hasFirstBomb)
+          return output.aoeDebuff!({
+            aoe: output.aoe!(),
+            debuff: output.bombFirst!({
+              mech: isTrue ? output.bomb!() : output.fakeBomb!(),
+            }),
+          });
+        if (hasSecondBomb)
           return output.aoeDebuff!({
             aoe: output.aoe!(),
             debuff: output.bombSecond!({
@@ -4299,6 +4315,9 @@ const triggerSet: TriggerSet<Data> = {
         },
         stackFirstNoDebuff: {
           en: 'No Debuff, ${mech} First',
+        },
+        bombFirst: {
+          en: '${mech} on YOU First',
         },
         stackSecondNoDebuff: {
           en: 'No Debuff, ${mech} Second',
@@ -4372,7 +4391,8 @@ const triggerSet: TriggerSet<Data> = {
         const hasCompressed = isShort
           ? data.longCompressedPlayers.includes(data.me)
           : data.shortCompressedPlayers.includes(data.me);
-        const hasBomb = data.shortBombPlayers.includes(data.me);
+        const hasFirstBomb = data.secondShortBombPlayers.includes(data.me);
+        const hasSecondBomb = data.secondLongBombPlayers.includes(data.me);
 
         // Shriek players always are short bomb
         // This will be two players
@@ -4400,10 +4420,17 @@ const triggerSet: TriggerSet<Data> = {
               ? output.stackSecond!({ mech: output.stack!() })
               : output.stackFirst!({ mech: output.stack!() }),
           });
-        if (hasBomb)
+        if (hasFirstBomb)
           return output.aoeDebuff!({
             aoe: output.aoe!(),
             debuff: output.bombFirst!({
+              mech: isTrue ? output.bomb!() : output.fakeBomb!(),
+            }),
+          });
+        if (hasSecondBomb)
+          return output.aoeDebuff!({
+            aoe: output.aoe!(),
+            debuff: output.bombSecond!({
               mech: isTrue ? output.bomb!() : output.fakeBomb!(),
             }),
           });
@@ -4449,6 +4476,9 @@ const triggerSet: TriggerSet<Data> = {
           en: '${mech} on YOU Second',
         },
         stackSecond: {
+          en: '${mech} on YOU Second',
+        },
+        bombSecond: {
           en: '${mech} on YOU Second',
         },
         stack: Outputs.stackMarker,
@@ -4544,23 +4574,26 @@ const triggerSet: TriggerSet<Data> = {
 
         const hasFork = data.shortForkedPlayers.includes(data.me);
         const hasCompressed = data.shortCompressedPlayers.includes(data.me);
-        const hasBomb = data.shortBombPlayers.includes(data.me);
+        const hasFirstBomb = data.firstShortBombPlayers.includes(data.me);
+        const hasSecondBomb = data.secondShortBombPlayers.includes(data.me);
+        const isBombTrue = hasFirstBomb ? is1stTrue : is2ndTrue;
 
         const hasSpread = (hasFork && isShortTrue) || (hasCompressed && !isShortTrue);
         const hasStack = (hasFork && !isShortTrue) || (hasCompressed && isShortTrue);
+        const hasBomb = hasFirstBomb || hasSecondBomb;
 
         // Handle 2 Mechs
         if (hasSpread && hasBomb)
           return output.laserThenForkBomb!({
             mech1: laser,
             mech2: output.spread!(),
-            mech3: is1stTrue ? output.bomb!() : output.fakeBomb!(),
+            mech3: isBombTrue ? output.bomb!() : output.fakeBomb!(),
           });
         if (hasStack && hasBomb)
           return output.laserThenCompressedBomb!({
             mech1: laser,
             mech2: output.stack!(),
-            mech3: is1stTrue ? output.bomb!() : output.fakeBomb!(),
+            mech3: isBombTrue ? output.bomb!() : output.fakeBomb!(),
           });
         if (hasSpread)
           return output.laserThenSpread!({
@@ -4575,7 +4608,7 @@ const triggerSet: TriggerSet<Data> = {
         if (hasBomb)
           return output.laserThenBomb!({
             mech1: laser,
-            mech2: is1stTrue ? output.bomb!() : output.fakeBomb!(),
+            mech2: isBombTrue ? output.bomb!() : output.fakeBomb!(),
             mech3: output.stack!(),
           });
         // Has either nothing or long debuffs
@@ -4644,21 +4677,24 @@ const triggerSet: TriggerSet<Data> = {
 
         const hasFork = data.shortForkedPlayers.includes(data.me);
         const hasCompressed = data.shortCompressedPlayers.includes(data.me);
-        const hasBomb = data.shortBombPlayers.includes(data.me);
+        const hasFirstBomb = data.firstShortBombPlayers.includes(data.me);
+        const hasSecondBomb = data.secondShortBombPlayers.includes(data.me);
+        const isBombTrue = hasFirstBomb ? is1stTrue : is2ndTrue;
 
         const hasSpread = (hasFork && isShortTrue) || (hasCompressed && !isShortTrue);
         const hasStack = (hasFork && !isShortTrue) || (hasCompressed && isShortTrue);
+        const hasBomb = hasFirstBomb || hasSecondBomb;
 
         // Handle 2 Mechs
         if (hasSpread && hasBomb)
           return output.forkBomb!({
             mech1: output.spread!(),
-            mech2: is1stTrue ? output.bomb!() : output.fakeBomb!(),
+            mech2: isBombTrue ? output.bomb!() : output.fakeBomb!(),
           });
         if (hasStack && hasBomb)
           return output.compressedBomb!({
             mech1: output.stack!(),
-            mech2: is1stTrue ? output.bomb!() : output.fakeBomb!(),
+            mech2: isBombTrue ? output.bomb!() : output.fakeBomb!(),
           });
         if (hasSpread)
           return output.spread!();
@@ -4666,7 +4702,7 @@ const triggerSet: TriggerSet<Data> = {
           return output.stack!();
         if (hasBomb)
           return output.bombStack!({
-            mech1: is1stTrue ? output.bomb!() : output.fakeBomb!(),
+            mech1: isBombTrue ? output.bomb!() : output.fakeBomb!(),
             mech2: output.stack!(),
           });
         // Has either nothing or long debuffs
@@ -4945,24 +4981,27 @@ const triggerSet: TriggerSet<Data> = {
 
         const hasFork = data.longForkedPlayers.includes(data.me);
         const hasCompressed = data.longCompressedPlayers.includes(data.me);
-        const hasBomb = data.longBombPlayers.includes(data.me);
+        const hasFirstBomb = data.firstLongBombPlayers.includes(data.me);
+        const hasSecondBomb = data.secondLongBombPlayers.includes(data.me);
+        const isBombTrue = hasFirstBomb ? is1stTrue : is2ndTrue;
 
         const hasSpread = (hasFork && isLongTrue) || (hasCompressed && !isLongTrue);
         const hasStack = (hasFork && !isLongTrue) || (hasCompressed && isLongTrue);
+        const hasBomb = hasFirstBomb || hasSecondBomb;
 
         // Handle 2 Mechs
         if (hasSpread && hasBomb)
           return {
             [severity]: output.forkBomb!({
               mech1: output.spread!(),
-              mech2: is2ndTrue ? output.bomb!() : output.fakeBomb!(),
+              mech2: isBombTrue ? output.bomb!() : output.fakeBomb!(),
             }),
           };
         if (hasStack && hasBomb)
           return {
             [severity]: output.compressedBomb!({
               mech1: output.stack!(),
-              mech2: is2ndTrue ? output.bomb!() : output.fakeBomb!(),
+              mech2: isBombTrue ? output.bomb!() : output.fakeBomb!(),
             }),
           };
         if (hasSpread)
@@ -4972,7 +5011,7 @@ const triggerSet: TriggerSet<Data> = {
         if (hasBomb)
           return {
             [severity]: output.bombStack!({
-              mech1: is2ndTrue ? output.bomb!() : output.fakeBomb!(),
+              mech1: isBombTrue ? output.bomb!() : output.fakeBomb!(),
               mech2: output.stack!(),
             }),
           };

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -867,23 +867,36 @@ const triggerSet: TriggerSet<Data> = {
         // P4 Only
         // 5CA Mana Charged falls off ~5.4s prior to startsUsing
         // 5CD Thunder Charged and 5CC Blizzard Charged fall off after subsequent
-        // Thrumming Thunder III and Blizzard III Blowout startsUsing
+        // This will need to be done while stacking donuts if Dynamic Fluid is true
         if (id === 'BAA5' && data.isIceTrue !== undefined && data.isThunderTrue !== undefined) {
           const isThunderCharged = data.isThunderChargedTrue;
           const isBlizzardCharged = data.isBlizzardChargedTrue;
+          const isFluidTrue = data.isFluidTrue;
           const trueThunder = (isThunderCharged && data.isThunderTrue) ||
             (!isThunderCharged && !data.isThunderTrue);
           const trueIce = (isBlizzardCharged && data.isIceTrue) ||
             (!isBlizzardCharged && !data.isIceTrue);
 
           if (trueThunder) {
-            return trueIce
+            const tells = trueIce
               ? output.trueIceTrueThunder!()
               : output.fakeIceTrueThunder!();
+            return isFluidTrue
+              ? output.tellsDonut!({
+                tells: tells,
+                donut: output.inDonut!(),
+              })
+              : tells;
           }
-          return trueIce
+          const tells = trueIce
             ? output.trueIceFakeThunder!()
             : output.fakeIceFakeThunder!();
+          return isFluidTrue
+            ? output.tellsDonut!({
+              tells: tells,
+              donut: output.inDonut!(),
+            })
+            : tells;
         }
       },
       outputStrings: {
@@ -1034,6 +1047,12 @@ const triggerSet: TriggerSet<Data> = {
           cn: '面对神像',
           ko: '시선 바라보기',
           tc: '面對神像',
+        },
+        inDonut: {
+          en: 'In Donut',
+        },
+        tellsDonut: {
+          en: '${tells} + ${donut}',
         },
       },
     },

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -84,6 +84,8 @@ export interface Data extends RaidbossData {
   isDynamicFluidTrue?: boolean;
   deathOrField?: 'death' | 'field';
   wound?: 'white' | 'black';
+  isThunderChargedTrue?: boolean;
+  isBlizzardChargedTrue?: boolean;
 }
 
 const headMarkerData = {
@@ -4551,6 +4553,19 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: mysteryMagicOutputStrings,
     },
     {
+      id: 'DMU P4 Mana Charge Collect',
+      // 5CD Thunder Charged: Store the value of isThunderTrue for later
+      // 5CC Blizzard Charged: Store the value of isIceTrue for later
+      type: 'GainsEffect',
+      netRegex: { effectId: ['5CD', '5CC'], capture: false },
+      run: (data, matches) => {
+        if (matches.effectId === '5CD')
+          data.isThunderChargedTrue = data.isThunderTrue;
+        else
+          data.isBlizzardChargedTrue = data.isIceTrue;
+      },
+    },
+    {
       id: 'DMU P4 First Cursed Shriek',
       // TODO: Merge this with Mana Charge (stored fake/real thunder)
       type: 'GainsEffect',
@@ -4755,6 +4770,14 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: mysteryMagicOutputStrings,
     },
     {
+      id: 'DMU P4 Blizzard Charge Collect',
+      // Store the value of the isIceTrue for later
+      type: 'StartsUsing',
+      netRegex: { id: 'BA95', source: 'Kefka', capture: false },
+      condition: (data) => data.grandCrossCount === 3,
+      run: (data) => data.chargeBlizzardTrue = data.isIceTrue,
+    },
+    {
       id: 'DMU P4 Second Cursed Shriek',
       type: 'GainsEffect',
       netRegex: { effectId: '15A7', capture: true },
@@ -4836,7 +4859,6 @@ const triggerSet: TriggerSet<Data> = {
         puddles: Outputs.baitPuddles,
       },
     },
-    {
       id: 'DMU P4 Mana Release',
       // 5CA Mana Charged falls off ~5.4s prior to startsUsing
       // 5CD Thunder Charged and 5CC Blizzard Charged fall off after subsequent
@@ -4847,12 +4869,19 @@ const triggerSet: TriggerSet<Data> = {
         return data.isIceTrue !== undefined && data.isThunderTrue !== undefined;
       },
       infoText: (data, _matches, output) => {
-        if (data.isThunderTrue) {
-          return data.isIceTrue
+        const isThunderCharged = data.isThunderChargedTrue;
+        const isBlizzardCharged = data.isBlizzardChargedTrue;
+        const trueThunder = (isThunderCharged && data.isThunderTrue) ||
+          (!isThunderCharged && !data.isThunderTrue);
+        const trueIce = (isBlizzardCharged && data.isIceTrue) ||
+          (!isBlizzardCharged && !data.isIceTrue);
+
+        if (trueThunder) {
+          return trueIce
             ? output.trueIceTrueThunder!()
             : output.fakeIceTrueThunder!();
         }
-        return data.isIceTrue
+        return trueIce
           ? output.trueIceFakeThunder!()
           : output.fakeIceFakeThunder!();
       },

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -122,7 +122,7 @@ export interface Data extends RaidbossData {
   deathOrField?: 'death' | 'field';
   wound?: 'white' | 'black';
   isThunderChargedTrue?: boolean;
-  isBlizzardChargedTrue?: boolean;main
+  isBlizzardChargedTrue?: boolean;
 }
 
 const headMarkerData = {

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4169,7 +4169,6 @@ const triggerSet: TriggerSet<Data> = {
           : data.longForkedPlayers.includes(data.me);
         const hasBomb = data.longBombPlayers.includes(data.me);
 
-
         // Shriek players always are short bomb
         // This will be two players
         if (hasShreik)

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -80,9 +80,11 @@ export interface Data extends RaidbossData {
   shortBombPlayers: string[];
   longBombPlayers: string[];
   areFirstDebuffsTrue?: boolean;
-  isEntropyTrue?: boolean;
   areSecondDebuffsTrue?: boolean;
-  isDynamicFluidTrue?: boolean;
+  areThirdDebuffsTrue?: boolean;
+  areFourthDebuffsTrue?: boolean;
+  isEntropyTrue?: boolean;
+  isFluidTrue?: boolean;
   deathOrField?: 'death' | 'field';
   wound?: 'white' | 'black';
   isThunderChargedTrue?: boolean;
@@ -4025,12 +4027,12 @@ const triggerSet: TriggerSet<Data> = {
         // These always come out in order
         if (data.areFirstDebuffsTrue === undefined)
           data.areFirstDebuffsTrue = isTrue;
-        else if (data.isEntropyTrue === undefined)
-          data.isDynamicFluidTrue = isTrue;
         else if (data.areSecondDebuffsTrue === undefined)
           data.areSecondDebuffsTrue = isTrue;
-        else if (data.isDynamicFluidTrue === undefined)
-          data.isEntropyTrue = isTrue;
+        else if (data.areThirdDebuffsTrue === undefined)
+          data.areThirdDebuffsTrue = isTrue;
+        else if (data.areFourthDebuffsTrue === undefined)
+          data.areFourthDebuffsTrue = isTrue;
         // Last two are not needed as the next is a double negative and last
         // has unique cast ids for true/fake
       },
@@ -4067,14 +4069,14 @@ const triggerSet: TriggerSet<Data> = {
       // 15A9 Compressed Water x2 76s or 51s              => 13:19.578          13:44.672
       // 15AA Acceleration Bomb (2 Long 76s, 2 Short 51s) => 13:19.672          13:44.672
       // Chaos Debuffs 1: (12:34.341)
-      // 15AC Dynamic Fluid x8 84s                        => 13:48.672
+      // 15AC Dynamic Fluid x8 84s or 15AB Entropy x8 60s => 13:58.341          13:35.485
       // Neo Exdeath Debuffs Cast 2: (12:43.578)
       // 15A8 Forked Lightning x2 36s or 61s              => 13:19.578          13.44.578
       // 15A7 Cursed Shriek x2 69s                        => 13:52.578
       // 15A9 Compressed Water x2 36s or 61s              => 13:19.578          13.44.578
       // 15AA Acceleration Bomb (2 Long 61s, 2 Short 36s) => 13:19.578          13:44.578
       // Chaos Debuffs 2: 12:50.485
-      // 15AB Entroy x8 45s                               => 13:35.485
+      // 15AB Entropy x8 45s or 15AC Dynamic Fluid 8x 69s => 13:35.485          13:58.341
       // Neo Exdeath Debuffs Cast 3: (13:00.002)
       // 15A5 White Wound or 1317 (Fake)
       // 15A6 Black Wound or 1318 (Fake)
@@ -4095,7 +4097,7 @@ const triggerSet: TriggerSet<Data> = {
       // For 3rd set of debuffs we do not need to know real/fake:
       // Allagan Field players swap their color by getting hit with opposite color Angilight
       // Beyond Death field players keep their color by getting hit with same colore Antilight
-      // Entropy and Dynamic Fluids will be handled seperately
+      // Entropy and Dynamic Fluids debuffs can be 2nd or 4rth, but resolution is at same time
       type: 'GainsEffect',
       netRegex: {
         effectId: [
@@ -4256,30 +4258,62 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'DMU P4 Entropy (Early)',
+      id: 'DMU P4 Entropy/Dynamic Fluid Collect',
+      // Separate trigger as we only need to capture one
+      // 15AB Entropy
+      // 15AC Dynamic Fluid
       type: 'GainsEffect',
-      netRegex: { effectId: '15AB', capture: false },
+      netRegex: { effectId: ['15AB', '15AC'], capture: true },
+      condition: Conditions.targetIsYou(),
+      run: (data, matches) => {
+        const duration = parseFloat(matches.duration);
+        // These could be undefined if the true/false trigger fails to collect
+        // Checking for undefined should be handled in an output trigger
+
+        if (matches.effectId === '15AB') {
+          data.isEntropyTrue = duration > 46
+            ? data.areSecondDebuffsTrue
+            : data.areFourthDebuffsTrue;
+          return;
+        }
+        data.isFluidTrue = duration > 83
+          ? data.areSecondDebuffsTrue
+          : data.areFourthDebuffsTrue;
+      },
+    },
+    {
+      id: 'DMU P4 Second Debuffs (Early)',
+      type: 'GainsEffect',
+      netRegex: { effectId: ['15AB', '15AC'], capture: true },
+      condition: (data) => data.grandCrossCount === 1,
       delaySeconds: 0.1,
       suppressSeconds: 99999,
-      infoText: (data, _matches, output) => {
-        const isEntropyTrue = data.isEntropyTrue;
-        if (isEntropyTrue === undefined)
+      infoText: (data, matches, output) => {
+        const areSecondDebuffsTrue = data.areSecondDebuffsTrue;
+        if (areSecondDebuffsTrue === undefined)
           return;
-        return isEntropyTrue
-          ? output.puddlesFirst!()
-          : output.donutsFirst!();
+        const isEntropy = matches.id === '15AB';
+        if (isEntropy)
+          return areSecondDebuffsTrue ? output.puddlesFirst!() : output.donutsFirst!();
+        return areSecondDebuffsTrue ? output.donutsSecond!() : output.puddlesSecond!();
       },
       outputStrings: {
         puddlesFirst: {
           en: 'Puddles First',
         },
+        puddlesSecond: {
+          en: 'Puddles Second',
+        },
         donutsFirst: {
           en: 'Donuts First',
+        },
+        donutsSecond: {
+          en: 'Donuts Second',
         },
       },
     },
     {
-      id: 'DMU P4 Second Debuffs (Early)',
+      id: 'DMU P4 Third Debuffs (Early)',
       // Cast 2:
       // 15A8 Forked Lightning x2 36s or 61s
       // 15A7 Cursed Shriek x2 69s
@@ -4293,7 +4327,7 @@ const triggerSet: TriggerSet<Data> = {
       delaySeconds: 0.1,
       suppressSeconds: 99999,
       infoText: (data, _matches, output) => {
-        const isTrue = data.areSecondDebuffsTrue;
+        const isTrue = data.areThirdDebuffsTrue;
         const isShort = data.isFirstDebuffShort;
         if (isTrue === undefined || isShort === undefined)
           return;
@@ -4376,22 +4410,30 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'DMU P4 Dynamic Fluid (Early)',
+      id: 'DMU P4 Fourth Debuffs (Early)',
       type: 'GainsEffect',
-      netRegex: { effectId: '15AC', capture: false },
+      netRegex: { effectId: ['15AB', '15AC'], capture: true },
+      condition: (data) => data.grandCrossCount === 2,
       delaySeconds: 0.1,
       suppressSeconds: 99999,
-      infoText: (data, _matches, output) => {
-        const isFluidTrue = data.isDynamicFluidTrue;
-        if (isFluidTrue === undefined)
+      infoText: (data, matches, output) => {
+        const areFourthDebuffsTrue = data.areFourthDebuffsTrue;
+        if (areFourthDebuffsTrue === undefined)
           return;
-        return isFluidTrue
-          ? output.donutsSecond!()
-          : output.puddlesSecond!();
+        const isEntropy = matches.id === '15AB';
+        if (isEntropy)
+          return areFourthDebuffsTrue ? output.puddlesFirst!() : output.donutsFirst!();
+        return areFourthDebuffsTrue ? output.donutsSecond!() : output.puddlesSecond!();
       },
       outputStrings: {
+        puddlesFirst: {
+          en: 'Puddles First',
+        },
         puddlesSecond: {
           en: 'Puddles Second',
+        },
+        donutsFirst: {
+          en: 'Donuts First',
         },
         donutsSecond: {
           en: 'Donuts Second',
@@ -4473,7 +4515,7 @@ const triggerSet: TriggerSet<Data> = {
         });
 
         const is1stTrue = data.areFirstDebuffsTrue;
-        const is2ndTrue = data.areSecondDebuffsTrue;
+        const is2ndTrue = data.areThirdDebuffsTrue;
         const isFirstShort = data.isFirstDebuffShort;
         if (is1stTrue === undefined || is2ndTrue === undefined || isFirstShort === undefined)
           return laser;
@@ -4569,7 +4611,7 @@ const triggerSet: TriggerSet<Data> = {
       suppressSeconds: 99999,
       alertText: (data, _matches, output) => {
         const is1stTrue = data.areFirstDebuffsTrue;
-        const is2ndTrue = data.areSecondDebuffsTrue;
+        const is2ndTrue = data.areThirdDebuffsTrue;
         const isFirstShort = data.isFirstDebuffShort;
         if (is1stTrue === undefined || is2ndTrue === undefined || isFirstShort === undefined)
           return;
@@ -4678,7 +4720,7 @@ const triggerSet: TriggerSet<Data> = {
         const isFirstDebuff = duration > 75 || (duration < 52 && duration > 50);
         const isTrue = isFirstDebuff
           ? data.areFirstDebuffsTrue
-          : data.areSecondDebuffsTrue;
+          : data.areThirdDebuffsTrue;
         return isTrue ? output.stopEverything!() : output.keepMoving!();
       },
       outputStrings: {
@@ -4714,7 +4756,7 @@ const triggerSet: TriggerSet<Data> = {
       suppressSeconds: 1,
       infoText: (data, matches, output) => {
         const isShortDebuffs = parseFloat(matches.duration) < 61;
-        const isTrue = isShortDebuffs ? data.areFirstDebuffsTrue : data.areSecondDebuffsTrue;
+        const isTrue = isShortDebuffs ? data.areFirstDebuffsTrue : data.areThirdDebuffsTrue;
         if (isTrue === undefined)
           return;
 
@@ -4864,7 +4906,7 @@ const triggerSet: TriggerSet<Data> = {
       suppressSeconds: 99999,
       alertText: (data, _matches, output) => {
         const is1stTrue = data.areFirstDebuffsTrue;
-        const is2ndTrue = data.areSecondDebuffsTrue;
+        const is2ndTrue = data.areThirdDebuffsTrue;
         const isFirstShort = data.isFirstDebuffShort;
         if (is1stTrue === undefined || is2ndTrue === undefined || isFirstShort === undefined)
           return;
@@ -4968,7 +5010,7 @@ const triggerSet: TriggerSet<Data> = {
       durationSeconds: 3,
       suppressSeconds: 99999,
       alertText: (data, _matches, output) => {
-        const is2ndTrue = data.areSecondDebuffsTrue;
+        const is2ndTrue = data.areThirdDebuffsTrue;
         if (is2ndTrue === undefined)
           return;
 
@@ -5008,7 +5050,7 @@ const triggerSet: TriggerSet<Data> = {
       durationSeconds: 6.9, // Time until Stray Spray
       suppressSeconds: 99999,
       alertText: (data, _matches, output) => {
-        const isFluidTrue = data.isDynamicFluidTrue;
+        const isFluidTrue = data.isFluidTrue;
         if (isFluidTrue === undefined)
           return;
 

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -79,6 +79,10 @@ export interface Data extends RaidbossData {
   longCompressedPlayers: string[];
   shortBombPlayers: string[];
   longBombPlayers: string[];
+  areFirstDebuffsTrue?: boolean;
+  isEntropyTrue?: boolean;
+  areSecondDebuffsTrue?: boolean;
+  isDynamicFluidTrue?: boolean;
   deathOrField?: 'death' | 'field';
   wound?: 'white' | 'black';
 }
@@ -3872,6 +3876,15 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.aoe(),
     },
     {
+      id: 'DMU P4 Tsunami/Inferno',
+      // BB14 Grand Cross AoE also happens ~4s after this cast starts
+      // BB20 Inferno / BB21 Tsunami are 9s castTime
+      type: 'StartsUsing',
+      netRegex: { id: ['BB20', 'BB21'], source: 'Chaos', capture: true },
+      delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 6,
+      response: Responses.aoe(),
+    },
+    {
       id: 'DMU P4 Grand Cross Counter',
       type: 'StartsUsing',
       netRegex: { id: 'BB14', source: 'Neo Exdeath', capture: false },
@@ -3984,7 +3997,6 @@ const triggerSet: TriggerSet<Data> = {
       // 15A8 Forked Lightning x2 76s
       // 15A9 Compressed Water x2 76s
       // 15AA Acceleration Bomb (2 Long 76s, 2 Short 51s)
-      // TODO: Detect if fake
       type: 'GainsEffect',
       netRegex: { effectId: ['15A7', '15A8', '15A9', '15AA'], capture: true },
       condition: Conditions.targetIsYou(),
@@ -3995,22 +4007,28 @@ const triggerSet: TriggerSet<Data> = {
         const hasFork = data.longForkedPlayers.includes(data.me);
         const hasCompressed = data.longCompressedPlayers.includes(data.me);
         const hasBomb = data.longBombPlayers.includes(data.me);
+        const isTrue = data.areFirstDebuffsTrue;
+
+        if (isTrue === undefined)
+          return;
 
         // Shriek players always are short bomb
         // This will be two players
         if (hasShreik)
           return output.firstGazeAndBomb!({
-            gaze: output.gaze!(),
-            bomb: output.bomb!(),
+            gaze: isTrue ? output.gaze!() : output.fakeGaze!(),
+            bomb: isTrue ? output.bomb!() : output.fakeBomb!(),
           });
 
         // Remaing 6 players will get one debuff
-        if (hasFork)
+        if ((hasFork && isTrue) || (hasCompressed && !isTrue))
           return output.spreadSecond!({ mech: output.spread!() });
-        if (hasCompressed)
+        if ((hasFork && !isTrue) || (hasCompressed && isTrue))
           return output.stackSecond!({ mech: output.stack!() });
         if (hasBomb)
-          return output.bombSecond!({ mech: output.bomb!() });
+          return output.bombSecond!({
+            mech: isTrue ? output.bomb!() : output.fakeBomb!(),
+          });
       },
       outputStrings: {
         firstGazeAndBomb: {
@@ -4032,9 +4050,7 @@ const triggerSet: TriggerSet<Data> = {
           en: '${mech} on YOU Second',
         },
         stack: Outputs.stackMarker,
-        fakeStack: Outputs.spread,
         spread: Outputs.spread,
-        fakeSpread: Outputs.stackMarker,
         bomb: {
           en: 'Stillness',
         },
@@ -4045,15 +4061,24 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'DMU P4 Dynamic Fluid (Early)',
-      // TODO: Detect if fake
       type: 'GainsEffect',
       netRegex: { effectId: '15AC', capture: false },
       delaySeconds: 0.1,
       suppressSeconds: 99999,
-      infoText: (_data, _matches, output) => output.text!(),
+      infoText: (data, _matches, output) => {
+        const isFluidTrue = data.isDynamicFluidTrue;
+        if (isFluidTrue === undefined)
+          return;
+        return isFluidTrue
+          ? output.donutsSecond!()
+          : output.twistersSecond!();
+      },
       outputStrings: {
-        text: {
-          en: 'Donuts or Twisters (later)',
+        twistersSecond: {
+          en: 'Twisters Second',
+        },
+        donutsSecond: {
+          en: 'Donuts Second',
         },
       },
     },
@@ -4064,7 +4089,6 @@ const triggerSet: TriggerSet<Data> = {
       // 15A7 Cursed Shriek x2 69s
       // 15A9 Compressed Water x2 36s
       // 15AA Acceleration Bomb (2 Long 61s, 2 Short 36s)
-      // TODO: Detect if fake
       type: 'GainsEffect',
       netRegex: { effectId: ['15A7', '15A8', '15A9', '15AA'], capture: true },
       condition: (data, matches) => {
@@ -4077,22 +4101,28 @@ const triggerSet: TriggerSet<Data> = {
         const hasFork = data.shortForkedPlayers.includes(data.me);
         const hasCompressed = data.shortCompressedPlayers.includes(data.me);
         const hasBomb = data.shortBombPlayers.includes(data.me);
+        const isTrue = data.areSecondDebuffsTrue;
+
+        if (isTrue === undefined)
+          return;
 
         // Shriek players always are short bomb
         // This will be two players
         if (hasShreik)
           return output.secondGazeAndBomb!({
-            gaze: output.gaze!(),
-            bomb: output.bomb!(),
+            gaze: isTrue ? output.gaze!() : output.fakeGaze!(),
+            bomb: isTrue ? output.bomb!() : output.fakeBomb!(),
           });
 
         // Remaing 6 players will get one debuff
-        if (hasFork)
+        if ((hasFork && isTrue) || (hasCompressed && !isTrue))
           return output.spreadFirst!({ mech: output.spread!() });
-        if (hasCompressed)
+        if ((hasFork && !isTrue) || (hasCompressed && isTrue))
           return output.stackFirst!({ mech: output.stack!() });
         if (hasBomb)
-          return output.bombFirst!({ mech: output.bomb!() });
+          return output.bombFirst!({
+            mech: isTrue ? output.bomb!() : output.fakeBomb!(),
+          });
       },
       outputStrings: {
         secondGazeAndBomb: {
@@ -4114,9 +4144,7 @@ const triggerSet: TriggerSet<Data> = {
           en: '${mech} on YOU First',
         },
         stack: Outputs.stackMarker,
-        fakeStack: Outputs.spread,
         spread: Outputs.spread,
-        fakeSpread: Outputs.stackMarker,
         bomb: {
           en: 'Stillness',
         },
@@ -4127,15 +4155,24 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'DMU P4 Entropy (Early)',
-      // TODO: Detect if fake
       type: 'GainsEffect',
       netRegex: { effectId: '15AB', capture: false },
       delaySeconds: 0.1,
       suppressSeconds: 99999,
-      infoText: (_data, _matches, output) => output.text!(),
+      infoText: (data, _matches, output) => {
+        const isEntropyTrue = data.isEntropyTrue;
+        if (isEntropyTrue === undefined)
+          return;
+        return isEntropyTrue
+          ? output.twistersFirst!()
+          : output.donutsFirst!();
+      },
       outputStrings: {
-        text: {
-          en: 'Twisters or Donuts (later)',
+        twistersFirst: {
+          en: 'Twisters First',
+        },
+        donutsFirst: {
+          en: 'Donuts First',
         },
       },
     },
@@ -4146,7 +4183,6 @@ const triggerSet: TriggerSet<Data> = {
       // 1318 Black Wound
       // 1558 Beyond Death x4 15s
       // 1C6 Allagan Field x4 15s
-      // TODO: Detect if short debuffs fake
       type: 'GainsEffect',
       netRegex: { effectId: ['1317', '1318', '1558', '1C6'], capture: true },
       condition: Conditions.targetIsYou(),
@@ -4170,26 +4206,33 @@ const triggerSet: TriggerSet<Data> = {
         const hasFork = data.shortForkedPlayers.includes(data.me);
         const hasCompressed = data.shortCompressedPlayers.includes(data.me);
         const hasBomb = data.shortBombPlayers.includes(data.me);
+        const isTrue = data.areSecondDebuffsTrue;
+
+        if (isTrue === undefined)
+          return laser;
+
+        const isSpread = (hasFork && isTrue) || (hasCompressed && !isTrue);
+        const isStack = (hasFork && !isTrue) || (hasCompressed && isTrue);
 
         // Handle 2 Mechs
-        if (hasFork && hasBomb)
+        if (isSpread && hasBomb)
           return output.laserThenForkBomb!({
             mech1: laser,
             mech2: output.spread!(),
-            mech3: output.bomb!(),
+            mech3: isTrue ? output.bomb!() : output.fakeBomb!(),
           });
-        if (hasCompressed && hasBomb)
+        if (isStack && hasBomb)
           return output.laserThenCompressedBomb!({
             mech1: laser,
             mech2: output.stack!(),
-            mech3: output.bomb!(),
+            mech3: isTrue ? output.bomb!() : output.fakeBomb!(),
           });
-        if (hasFork)
+        if (isSpread)
           return output.laserThenSpread!({
             mech1: laser,
             mech2: output.spread!(),
           });
-        if (hasCompressed)
+        if (isStack)
           return output.laserThenStack!({
             mech1: laser,
             mech2: output.stack!(),
@@ -4197,7 +4240,7 @@ const triggerSet: TriggerSet<Data> = {
         if (hasBomb)
           return output.laserThenBomb!({
             mech1: laser,
-            mech2: output.bomb!(),
+            mech2: isTrue ? output.bomb!() : output.fakeBomb!(),
             mech3: output.stack!(),
           });
       },
@@ -4230,9 +4273,7 @@ const triggerSet: TriggerSet<Data> = {
           en: '${mech1} => ${mech2} + ${mech3}',
         },
         stack: Outputs.stackMarker,
-        fakeStack: Outputs.spread,
         spread: Outputs.spread,
-        fakeSpread: Outputs.stackMarker,
         bomb: {
           en: 'Stillness',
         },
@@ -4247,7 +4288,6 @@ const triggerSet: TriggerSet<Data> = {
       // 1558 Beyond Death x4 15s
       // 1C6 Allagan Field x4 15s
       // The spells/abilities or losesEffect could be triggered from early deaths
-      // TODO: Detect if short debuffs fake
       type: 'GainsEffect',
       netRegex: { effectId: ['1558', '1C6'], capture: true },
       delaySeconds: (_data, matches) => parseFloat(matches.duration),
@@ -4256,6 +4296,11 @@ const triggerSet: TriggerSet<Data> = {
         const hasFork = data.shortForkedPlayers.includes(data.me);
         const hasCompressed = data.shortCompressedPlayers.includes(data.me);
         const hasBomb = data.shortBombPlayers.includes(data.me);
+        const is2ndTrue = data.areSecondDebuffsTrue;
+        const is1stTrue = data.areFirstDebuffsTrue;
+
+        if (is2ndTrue === undefined || is1stTrue === undefined)
+          return;
 
         const players = data.shortShriekPlayers.map(
           (player) => {
@@ -4266,34 +4311,40 @@ const triggerSet: TriggerSet<Data> = {
         );
         const msg = players?.join(', ');
 
+        const gaze = is1stTrue
+          ? output.lookAwayFromPlayers!({ players: msg })
+          : output.lookAtPlayers!({ players: msg });
+        const isSpread = (hasFork && is2ndTrue) || (hasCompressed && !is2ndTrue);
+        const isStack = (hasFork && !is2ndTrue) || (hasCompressed && is2ndTrue);
+
         // Handle 2 Mechs
-        if (hasFork && hasBomb)
+        if (isSpread && hasBomb)
           return output.forkBombThenGaze!({
             mech1: output.spread!(),
-            mech2: output.bomb!(),
-            mech3: output.lookAwayFromPlayers!({ players: msg }),
+            mech2: is2ndTrue ? output.bomb!() : output.fakeBomb!(),
+            mech3: gaze,
           });
-        if (hasCompressed && hasBomb)
+        if (isStack && hasBomb)
           return output.compressedBombThenGaze!({
             mech1: output.stack!(),
-            mech2: output.bomb!(),
-            mech3: output.lookAwayFromPlayers!({ players: msg }),
+            mech2: is2ndTrue ? output.bomb!() : output.fakeBomb!(),
+            mech3: gaze,
           });
-        if (hasFork)
+        if (isSpread)
           return output.spreadThenGaze!({
             mech1: output.spread!(),
-            mech2: output.lookAwayFromPlayers!({ players: msg }),
+            mech2: gaze,
           });
-        if (hasCompressed)
+        if (isStack)
           return output.stackThenGaze!({
             mech1: output.stack!(),
-            mech2: output.lookAwayFromPlayers!({ players: msg }),
+            mech2: gaze,
           });
         if (hasBomb)
           return output.bombThenGaze!({
-            mech1: output.bomb!(),
+            mech1: is2ndTrue ? output.bomb!() : output.fakeBomb!(),
             mech2: output.stack!(),
-            mech3: output.lookAwayFromPlayers!({ players: msg }),
+            mech3: gaze,
           });
       },
       outputStrings: {
@@ -4316,9 +4367,7 @@ const triggerSet: TriggerSet<Data> = {
           en: '${mech1} + ${mech2} => ${mech3}',
         },
         stack: Outputs.stackMarker,
-        fakeStack: Outputs.spread,
         spread: Outputs.spread,
-        fakeSpread: Outputs.stackMarker,
         bomb: {
           en: 'Stillness',
         },
@@ -4335,7 +4384,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'DMU P4 First Cursed Shriek',
-      // TODO: Detect if short debuffs fake
       // TODO: Merge this with Mana Charge (stored fake/real thunder)
       type: 'GainsEffect',
       netRegex: { effectId: '15A7', capture: true },
@@ -4343,6 +4391,12 @@ const triggerSet: TriggerSet<Data> = {
       delaySeconds: (_data, matches) => parseFloat(matches.duration) - 6,
       suppressSeconds: 99999,
       infoText: (data, _matches, output) => {
+        const is1stTrue = data.areFirstDebuffsTrue;
+        const isEntropyTrue = data.isEntropyTrue;
+
+        if (is1stTrue === undefined || isEntropyTrue === undefined)
+          return;
+
         const players = data.shortShriekPlayers.map(
           (player) => {
             if (player === data.me)
@@ -4353,8 +4407,10 @@ const triggerSet: TriggerSet<Data> = {
         const msg = players?.join(', ');
 
         return output.shriekThenEntropy!({
-          mech1: msg,
-          mech2: output.twistersOrDonuts!(),
+          mech1: is1stTrue
+            ? output.lookAwayFromPlayers!({ players: msg })
+            : output.lookAtPlayers!({ players: msg }),
+          mech2: isEntropyTrue ? output.twisters!() : output.donuts!(),
         });
       },
       outputStrings: {
@@ -4370,8 +4426,22 @@ const triggerSet: TriggerSet<Data> = {
         lookAwayFromPlayers: {
           en: 'Look Away from ${players}',
         },
-        twistersOrDonuts: {
-          en: 'Twisters or Donuts',
+        donuts: {
+          en: 'Stack for Donuts',
+          de: 'Für Donuts sammeln',
+          fr: 'Packez-vous pour les donuts',
+          cn: '集合放月环',
+          ko: '모여서 도넛장판 피하기',
+          tc: '集合放月環',
+        },
+        twisters: {
+          en: 'Twisters',
+          de: 'Wirbelstürme',
+          fr: 'Tornades',
+          ja: '大竜巻',
+          cn: '旋风',
+          ko: '회오리',
+          tc: '旋風',
         },
       },
     },
@@ -4379,17 +4449,36 @@ const triggerSet: TriggerSet<Data> = {
       id: 'DMU P4 Entropy',
       // Using the following as possible matches:
       // 15A7 Cursed Shriek x2 60s
-      // TODO: Detect if shriek debuffs fake
       // TODO: Merge this with Mana Charge (stored fake/real thunder)
       type: 'GainsEffect',
       netRegex: { effectId: '15A7', capture: true },
       condition: (_data, matches) => parseFloat(matches.duration) < 61,
       delaySeconds: (_data, matches) => parseFloat(matches.duration),
       suppressSeconds: 99999,
-      alertText: (_data, _matches, output) => output.twistersOrDonuts!(),
+      alertText: (data, _matches, output) => {
+        const isEntropyTrue = data.isEntropyTrue;
+        if (isEntropyTrue === undefined)
+          return;
+
+        return isEntropyTrue ? output.twisters!() : output.donuts!();
+      },
       outputStrings: {
-        twistersOrDonuts: {
-          en: 'Twisters or Donuts',
+        donuts: {
+          en: 'Stack for Donuts',
+          de: 'Für Donuts sammeln',
+          fr: 'Packez-vous pour les donuts',
+          cn: '集合放月环',
+          ko: '모여서 도넛장판 피하기',
+          tc: '集合放月環',
+        },
+        twisters: {
+          en: 'Twisters',
+          de: 'Wirbelstürme',
+          fr: 'Tornades',
+          ja: '大竜巻',
+          cn: '旋风',
+          ko: '회오리',
+          tc: '旋風',
         },
       },
     },
@@ -4405,7 +4494,6 @@ const triggerSet: TriggerSet<Data> = {
       // 15A8 Forked Lightning x2 76s
       // 15A9 Compressed Water x2 76s
       // 15AA Acceleration Bomb (2 Long 76s)
-      // TODO: Detect if long debuffs fake
       type: 'GainsEffect',
       netRegex: { effectId: ['15A8', '15A9', '15AA'], capture: true },
       condition: (_data, matches) => parseFloat(matches.duration) > 75,
@@ -4415,6 +4503,11 @@ const triggerSet: TriggerSet<Data> = {
         const hasFork = data.longForkedPlayers.includes(data.me);
         const hasCompressed = data.longCompressedPlayers.includes(data.me);
         const hasBomb = data.longBombPlayers.includes(data.me);
+        const is1stTrue = data.areFirstDebuffsTrue;
+        const is2ndTrue = data.areSecondDebuffsTrue;
+
+        if (is2ndTrue === undefined || is1stTrue === undefined)
+          return;
 
         const players = data.longShriekPlayers.map(
           (player) => {
@@ -4425,34 +4518,40 @@ const triggerSet: TriggerSet<Data> = {
         );
         const msg = players?.join(', ');
 
+        const gaze = is2ndTrue
+          ? output.lookAwayFromPlayers!({ players: msg })
+          : output.lookAtPlayers!({ players: msg });
+        const isSpread = (hasFork && is1stTrue) || (hasCompressed && !is1stTrue);
+        const isStack = (hasFork && !is1stTrue) || (hasCompressed && is1stTrue);
+
         // Handle 2 Mechs
-        if (hasFork && hasBomb)
+        if (isSpread && hasBomb)
           return output.forkBombThenGaze!({
             mech1: output.spread!(),
-            mech2: output.bomb!(),
-            mech3: output.lookAwayFromPlayers!({ players: msg }),
+            mech2: is1stTrue ? output.bomb!() : output.fakeBomb!(),
+            mech3: gaze,
           });
-        if (hasCompressed && hasBomb)
+        if (isStack && hasBomb)
           return output.compressedBombThenGaze!({
             mech1: output.stack!(),
-            mech2: output.bomb!(),
-            mech3: output.lookAwayFromPlayers!({ players: msg }),
+            mech2: is1stTrue ? output.bomb!() : output.fakeBomb!(),
+            mech3: gaze,
           });
-        if (hasFork)
+        if (isSpread)
           return output.spreadThenGaze!({
             mech1: output.spread!(),
-            mech2: output.lookAwayFromPlayers!({ players: msg }),
+            mech2: gaze,
           });
-        if (hasCompressed)
+        if (isStack)
           return output.stackThenGaze!({
             mech1: output.stack!(),
-            mech2: output.lookAwayFromPlayers!({ players: msg }),
+            mech2: gaze,
           });
         if (hasBomb)
           return output.bombThenGaze!({
-            mech1: output.bomb!(),
+            mech1: is1stTrue ? output.bomb!() : output.fakeBomb!(),
             mech2: output.stack!(),
-            mech3: output.lookAwayFromPlayers!({ players: msg }),
+            mech3: gaze,
           });
       },
       outputStrings: {
@@ -4475,9 +4574,7 @@ const triggerSet: TriggerSet<Data> = {
           en: '${mech1} + ${mech2} => ${mech3}',
         },
         stack: Outputs.stackMarker,
-        fakeStack: Outputs.spread,
         spread: Outputs.spread,
-        fakeSpread: Outputs.stackMarker,
         bomb: {
           en: 'Stillness',
         },
@@ -4489,6 +4586,104 @@ const triggerSet: TriggerSet<Data> = {
         },
         lookAwayFromPlayers: {
           en: 'Look Away from ${players}',
+        },
+      },
+    },
+    {
+      id: 'DMU P4 Second Cursed Shriek',
+      type: 'GainsEffect',
+      netRegex: { effectId: '15A7', capture: true },
+      condition: (_data, matches) => parseFloat(matches.duration) > 68,
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 6,
+      suppressSeconds: 99999,
+      infoText: (data, _matches, output) => {
+        const is2ndTrue = data.areSecondDebuffsTrue;
+        const isFluidTrue = data.isDynamicFluidTrue;
+
+        if (is2ndTrue === undefined || isFluidTrue === undefined)
+          return;
+
+        const players = data.shortShriekPlayers.map(
+          (player) => {
+            if (player === data.me)
+              return output.you!();
+            return data.party.member(player);
+          },
+        );
+        const msg = players?.join(', ');
+
+        return output.shriekThenFluid!({
+          mech1: is2ndTrue
+            ? output.lookAwayFromPlayers!({ players: msg })
+            : output.lookAtPlayers!({ players: msg }),
+          mech2: isFluidTrue ? output.donuts!() : output.twisters!(),
+        });
+      },
+      outputStrings: {
+        you: {
+          en: 'YOU',
+        },
+        shriekThenFluid: {
+          en: '${mech1} => ${mech2}',
+        },
+        lookAtPlayers: {
+          en: 'Face ${players}',
+        },
+        lookAwayFromPlayers: {
+          en: 'Look Away from ${players}',
+        },
+        donuts: {
+          en: 'Stack for Donuts',
+          de: 'Für Donuts sammeln',
+          fr: 'Packez-vous pour les donuts',
+          cn: '集合放月环',
+          ko: '모여서 도넛장판 피하기',
+          tc: '集合放月環',
+        },
+        twisters: {
+          en: 'Twisters',
+          de: 'Wirbelstürme',
+          fr: 'Tornades',
+          ja: '大竜巻',
+          cn: '旋风',
+          ko: '회오리',
+          tc: '旋風',
+        },
+      },
+    },
+    {
+      id: 'DMU P4 Dynamic Fluid',
+      // Using the following as possible matches:
+      // 15A7 Cursed Shriek x2 69s
+      type: 'GainsEffect',
+      netRegex: { effectId: '15A7', capture: true },
+      condition: (_data, matches) => parseFloat(matches.duration) > 68,
+      delaySeconds: (_data, matches) => parseFloat(matches.duration),
+      suppressSeconds: 99999,
+      alertText: (data, _matches, output) => {
+        const isFluidTrue = data.isDynamicFluidTrue;
+        if (isFluidTrue === undefined)
+          return;
+
+        return isFluidTrue ? output.donuts!() : output.twisters!();
+      },
+      outputStrings: {
+        donuts: {
+          en: 'Stack for Donuts',
+          de: 'Für Donuts sammeln',
+          fr: 'Packez-vous pour les donuts',
+          cn: '集合放月环',
+          ko: '모여서 도넛장판 피하기',
+          tc: '集合放月環',
+        },
+        twisters: {
+          en: 'Twisters',
+          de: 'Wirbelstürme',
+          fr: 'Tornades',
+          ja: '大竜巻',
+          cn: '旋风',
+          ko: '회오리',
+          tc: '旋風',
         },
       },
     },

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4110,15 +4110,16 @@ const triggerSet: TriggerSet<Data> = {
           // Forked Lightning
           if (duration < 52) { // Capture both 51s and 36s
             if (data.isFirstDebuffShort === undefined)
-              data.isFirstDebuffShort = duration > 37 ? true : false;
+              data.isFirstDebuffShort = true;
             data.shortForkedPlayers.push(target);
-          } else
+          } else {
+            if (data.isFirstDebuffShort === undefined)
+              data.isFirstDebuffShort = false;
             data.longForkedPlayers.push(target);
+          }
         } else if (id === '15A9') {
           // Compressed Water
           if (duration < 52) { // Capture both 51s and 36s
-            if (data.isFirstDebuffShort === undefined)
-              data.isFirstDebuffShort = duration > 37 ? true : false;
             data.shortCompressedPlayers.push(target);
           } else
             data.longCompressedPlayers.push(target);

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -3876,15 +3876,6 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.aoe(),
     },
     {
-      id: 'DMU P4 Tsunami/Inferno',
-      // BB14 Grand Cross AoE also happens ~4s after this cast starts
-      // BB20 Inferno / BB21 Tsunami are 9s castTime
-      type: 'StartsUsing',
-      netRegex: { id: ['BB20', 'BB21'], source: 'Chaos', capture: true },
-      delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 6,
-      response: Responses.aoe(),
-    },
-    {
       id: 'DMU P4 Grand Cross Counter',
       type: 'StartsUsing',
       netRegex: { id: 'BB14', source: 'Neo Exdeath', capture: false },

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -3896,7 +3896,7 @@ const triggerSet: TriggerSet<Data> = {
       // Neo Exdeath Debuffs Cast 3: (13:00.002)
       // 15A5 White Wound or 1317 (Fake)
       // 15A6 Black Wound or 1318 (Fake)
-      // 1558 Beyond Death or 556 (Fake) x4 15s           => 13:15.002
+      // 1558 Beyond Death (Fake) or 566 x4 15s           => 13:15.002
       // 1C6 Allagan Field x4 15s                         => 13:15.002
       // Neo Exdeath Final: (13:11.383)
       // 1317 White Wound (Fake) or 15A5 White Wound
@@ -4163,7 +4163,7 @@ const triggerSet: TriggerSet<Data> = {
       // Neo Exdeath Debuffs Cast 3
       // 1317 White Wound (Fake) or 15A5 White Wound
       // 1318 Black Wound (Fake) or 15A6 Black Wound
-      // 566 Beyond Death (Fake) or 1558 Beyond Death
+      // 1558 Beyond Death (Fake) or 566 Beyond Death
       // 1C6 Allagan Field
       type: 'GainsEffect',
       netRegex: {
@@ -4275,7 +4275,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'DMU P4 Short Debuffs',
       // Using the following as possible matches:
-      // 566 Beyond Death (Fake) or 1558 Beyond Death
+      // 1558 Beyond Death (Fake) or 566 Beyond Death
       // 1C6 Allagan Field
       // The spells/abilities or losesEffect could be triggered from early deaths
       type: 'GainsEffect',

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -110,157 +110,6 @@ const headMarkerData = {
   'spreadPath': '02CC', // When standing in Path of Light tower, causes BAC1 Spellscatter (small aoe on the player)
 } as const;
 
-const mysteryMagicOutputStrings: OutputStrings = {
-  puddle: {
-    en: 'Bait Puddle',
-    de: 'Fläche ködern',
-    fr: 'Déposez',
-    ja: 'AOE誘導',
-    cn: '诱导AOE',
-    ko: '장판 유도',
-    tc: '誘導AOE',
-  },
-  spread: Outputs.spread,
-  middle: Outputs.goIntoMiddle,
-  stack: {
-    en: 'Stack',
-    de: 'Stacken',
-    fr: 'Packez-vous',
-    ja: 'スタック',
-    cn: '分摊',
-    ko: '쉐어',
-    tc: '集合',
-  },
-  trueThunder: {
-    en: 'Avoid Tell',
-    cn: '躲避直线',
-    ko: '예고 피하기',
-  },
-  fakeThunder: {
-    en: 'In Line',
-    cn: '进入直线',
-    ko: '직선 안으로',
-  },
-  trueIce: {
-    en: 'Avoid Tell',
-    cn: '躲避扇形',
-    ko: '예고 피하기',
-  },
-  fakeIce: {
-    en: 'In Cone',
-    cn: '进入扇形',
-    ko: '부채꼴 안으로',
-  },
-  trueIcePuddle: {
-    en: '${mech1} + ${mech2} => ${mech3}',
-    cn: '${mech1} + ${mech2} => ${mech3}',
-    ko: '${mech1} + ${mech2} => ${mech3}',
-  },
-  fakeIcePuddle: {
-    en: '${mech1} + ${mech2} => ${mech3}',
-    cn: '${mech1} + ${mech2} => ${mech3}',
-    ko: '${mech1} + ${mech2} => ${mech3}',
-  },
-  stackTrueIce: {
-    en: '${mech} + ${ice}',
-    cn: '${mech} + ${ice}',
-    ko: '${mech} + ${ice}',
-  },
-  stackFakeIce: {
-    en: '${mech} + ${ice}',
-    cn: '${mech} + ${ice}',
-    ko: '${mech} + ${ice}',
-  },
-  spreadTrueIce: {
-    en: '${mech} + ${ice}',
-    cn: '${mech} + ${ice}',
-    ko: '${mech} + ${ice}',
-  },
-  spreadFakeIce: {
-    en: '${mech} + ${ice}',
-    cn: '${mech} + ${ice}',
-    ko: '${mech} + ${ice}',
-  },
-  trueIceTrueThunder: {
-    en: 'Avoid Tells',
-    cn: '躲避扇形+直线',
-    ko: '예고 다 피하기',
-  },
-  fakeIceTrueThunder: {
-    en: 'Cone (only)',
-    cn: '仅扇形',
-    ko: '부채꼴만',
-  },
-  trueIceFakeThunder: {
-    en: 'Line (only)',
-    cn: '仅直线',
-    ko: '직선만',
-  },
-  fakeIceFakeThunder: {
-    en: 'Cone + Line',
-    cn: '扇形+直线',
-    ko: '부채꼴 + 직선',
-  },
-  stackTrueThunderLook: {
-    en: '${mech} + ${thunder} + ${look}',
-    cn: '${mech} + ${thunder} + ${look}',
-    ko: '${mech} + ${thunder} + ${look}',
-  },
-  stackFakeThunderLook: {
-    en: '${mech} + ${thunder} + ${look}',
-    cn: '${mech} + ${thunder} + ${look}',
-    ko: '${mech} + ${thunder} + ${look}',
-  },
-  spreadTrueThunderLook: {
-    en: '${mech} + ${thunder} + ${look}',
-    cn: '${mech} + ${thunder} + ${look}',
-    ko: '${mech} + ${thunder} + ${look}',
-  },
-  spreadFakeThunderLook: {
-    en: '${mech} + ${thunder} + ${look}',
-    cn: '${mech} + ${thunder} + ${look}',
-    ko: '${mech} + ${thunder} + ${look}',
-  },
-  stackTrueThunder: {
-    en: '${mech} + ${thunder}',
-    cn: '${mech} + ${thunder}',
-    ko: '${mech} + ${thunder}',
-  },
-  stackFakeThunder: {
-    en: '${mech} + ${thunder}',
-    cn: '${mech} + ${thunder}',
-    ko: '${mech} + ${thunder}',
-  },
-  spreadTrueThunder: {
-    en: '${mech} + ${thunder}',
-    cn: '${mech} + ${thunder}',
-    ko: '${mech} + ${thunder}',
-  },
-  spreadFakeThunder: {
-    en: '${mech} + ${thunder}',
-    cn: '${mech} + ${thunder}',
-    ko: '${mech} + ${thunder}',
-  },
-  lookAway: {
-    en: 'Look Away From Statue',
-    de: 'Von Statue wegschauen',
-    fr: 'Ne regardez pas la statue',
-    ja: '塔を見ない！',
-    cn: '背对神像',
-    ko: '시선 피하기',
-    tc: '背對神像',
-  },
-  lookAt: {
-    en: 'Look At Statue',
-    de: 'Statue anschauen',
-    fr: 'Regardez la statue',
-    ja: '像を見る！',
-    cn: '面对神像',
-    ko: '시선 바라보기',
-    tc: '面對神像',
-  },
-};
-
 const trapOutputStrings: OutputStrings = {
   you: {
     en: 'YOU',
@@ -886,33 +735,300 @@ const triggerSet: TriggerSet<Data> = {
       run: (data, matches) => data.fireMarker = matches.id,
     },
     {
-      id: 'DMU P1 Mystery Magic Ice and Fire',
-      // Set 1: Only Ice and Fire should be set
+      id: 'DMU P1 and P4 Mystery Magic',
+      // BA94 Myster Magic
+      // BA95 Blizzard III Blowout
+      // C5DE Thrumming Thunder III
+      // BAA5 Mana Release
       type: 'StartsUsing',
-      netRegex: { id: 'BA94', source: 'Kefka', capture: false },
-      condition: (data) => {
-        return data.isIceTrue !== undefined && data.isFireTrue !== undefined;
-      },
-      infoText: (data, _matches, output) => {
-        const fireMarker = data.fireMarker;
-        if (
-          (fireMarker === headMarkerData['dorito'] && data.isFireTrue) ||
-          (fireMarker === headMarkerData['stack'] && !data.isFireTrue)
-        )
-          return data.isIceTrue
-            ? output.spreadTrueIce!({ mech: output.spread!(), ice: output.trueIce!() })
-            : output.spreadFakeIce!({ mech: output.spread!(), ice: output.fakeIce!() });
+      netRegex: { id: ['BA94', 'BA95', 'C5DE', 'BAA5'], source: 'Kefka', capture: true },
+      infoText: (data, matches, output) => {
+        const id = matches.id;
+        if (id === 'BA94') {
+          // Set 1: P1 Ice and Fire
+          if (data.isIceTrue !== undefined && data.isFireTrue !== undefined) {
+            const fireMarker = data.fireMarker;
+            if (
+              (fireMarker === headMarkerData['dorito'] && data.isFireTrue) ||
+              (fireMarker === headMarkerData['stack'] && !data.isFireTrue)
+            )
+              return data.isIceTrue
+                ? output.spreadTrueIce!({ mech: output.spread!(), ice: output.trueIce!() })
+                : output.spreadFakeIce!({ mech: output.spread!(), ice: output.fakeIce!() });
 
-        if (
-          (fireMarker === headMarkerData['dorito'] && !data.isFireTrue) ||
-          (fireMarker === headMarkerData['stack'] && data.isFireTrue)
-        ) {
-          return data.isIceTrue
-            ? output.stackTrueIce!({ mech: output.stack!(), ice: output.trueIce!() })
-            : output.stackFakeIce!({ mech: output.stack!(), ice: output.fakeIce!() });
+            if (
+              (fireMarker === headMarkerData['dorito'] && !data.isFireTrue) ||
+              (fireMarker === headMarkerData['stack'] && data.isFireTrue)
+            ) {
+              return data.isIceTrue
+                ? output.stackTrueIce!({ mech: output.stack!(), ice: output.trueIce!() })
+                : output.stackFakeIce!({ mech: output.stack!(), ice: output.fakeIce!() });
+            }
+          }
+
+          // Set 2 and P4: Ice and Thunder
+          if (data.isIceTrue !== undefined && data.isThunderTrue !== undefined) {
+            if (data.isThunderTrue) {
+              return data.isIceTrue
+                ? output.trueIceTrueThunder!()
+                : output.fakeIceTrueThunder!();
+            }
+            return data.isIceTrue
+              ? output.trueIceFakeThunder!()
+              : output.fakeIceFakeThunder!();
+          }
+
+          // Set 4: P1 Fire and Thunder
+          if (
+            data.isFireTrue !== undefined &&
+            data.isThunderTrue !== undefined &&
+            data.phase === 'p1'
+          ) {
+            const fireMarker = data.fireMarker;
+            const look = data.isTowerLookAway ? output.lookAway!() : output.lookAt!();
+            if (
+              (fireMarker === headMarkerData['dorito'] && data.isFireTrue) ||
+              (fireMarker === headMarkerData['stack'] && !data.isFireTrue)
+            )
+              return data.isThunderTrue
+                ? output.spreadTrueThunderLook!({
+                  mech: output.spread!(),
+                  thunder: output.trueThunder!(),
+                  look: look,
+                })
+                : output.spreadFakeThunderLook!({
+                  mech: output.spread!(),
+                  thunder: output.fakeThunder!(),
+                  look: look,
+                });
+
+            if (
+              (fireMarker === headMarkerData['dorito'] && !data.isFireTrue) ||
+              (fireMarker === headMarkerData['stack'] && data.isFireTrue)
+            ) {
+              return data.isThunderTrue
+                ? output.stackTrueThunderLook!({
+                  mech: output.stack!(),
+                  thunder: output.trueThunder!(),
+                  look: look,
+                })
+                : output.stackFakeThunderLook!({
+                  mech: output.stack!(),
+                  thunder: output.fakeThunder!(),
+                  look: look,
+                });
+            }
+          }
+        }
+
+        if (id === 'BA95') {
+          // Set 3: P1 Ice Only, and Gravitas and Vitrophyre Tethers
+          // Occurs between Graven Image Set 2 and Set 3
+          if (
+            data.isIceTrue !== undefined &&
+            data.isThunderTrue === undefined &&
+            data.isFireTrue === undefined
+          ) {
+            const hasVitrophyre = data.gravenImageTether === 'vitrophyre';
+            return data.isIceTrue
+              ? output.trueIcePuddle!({
+                mech1: output.trueIce!(),
+                mech2: output.puddle!(),
+                mech3: hasVitrophyre ? output.spread!() : output.middle!(),
+              })
+              : output.fakeIcePuddle!({
+                mech1: output.fakeIce!(),
+                mech2: output.puddle!(),
+                mech3: hasVitrophyre ? output.spread!() : output.middle!(),
+              });
+          }
+
+          // P4 Only
+          // BAA4 Mana Charge signifies that the true/fake will be stored for later
+          // Indicated with boss buff 5CA Mana Charged and 5CC Blizzard Charged
+          // Prevent triggering on earlier P1 or P4 triggers
+          if (data.grandCrossCount === 3)
+            return data.isIceTrue ? output.trueIce!() : output.fakeIce!();
+        }
+
+        // P4 Only
+        // BAA4 Mana Charge signifies that the true/fake will be stored for later
+        // Indicated with boss buff 5CA Mana Charged and 5CD Thunder Charged
+        if (id === 'C5DE')
+          return data.isThunderTrue ? output.trueThunder!() : output.fakeThunder!();
+
+        // P4 Only
+        // 5CA Mana Charged falls off ~5.4s prior to startsUsing
+        // 5CD Thunder Charged and 5CC Blizzard Charged fall off after subsequent
+        // Thrumming Thunder III and Blizzard III Blowout startsUsing
+        if (id === 'BAA5' && data.isIceTrue !== undefined && data.isThunderTrue !== undefined) {
+          const isThunderCharged = data.isThunderChargedTrue;
+          const isBlizzardCharged = data.isBlizzardChargedTrue;
+          const trueThunder = (isThunderCharged && data.isThunderTrue) ||
+            (!isThunderCharged && !data.isThunderTrue);
+          const trueIce = (isBlizzardCharged && data.isIceTrue) ||
+            (!isBlizzardCharged && !data.isIceTrue);
+
+          if (trueThunder) {
+            return trueIce
+              ? output.trueIceTrueThunder!()
+              : output.fakeIceTrueThunder!();
+          }
+          return trueIce
+            ? output.trueIceFakeThunder!()
+            : output.fakeIceFakeThunder!();
         }
       },
-      outputStrings: mysteryMagicOutputStrings,
+      outputStrings: {
+        puddle: {
+          en: 'Bait Puddle',
+          de: 'Fläche ködern',
+          fr: 'Déposez',
+          ja: 'AOE誘導',
+          cn: '诱导AOE',
+          ko: '장판 유도',
+          tc: '誘導AOE',
+        },
+        spread: Outputs.spread,
+        middle: Outputs.goIntoMiddle,
+        stack: {
+          en: 'Stack',
+          de: 'Stacken',
+          fr: 'Packez-vous',
+          ja: 'スタック',
+          cn: '分摊',
+          ko: '쉐어',
+          tc: '集合',
+        },
+        trueThunder: {
+          en: 'Avoid Tell',
+          cn: '躲避直线',
+          ko: '예고 피하기',
+        },
+        fakeThunder: {
+          en: 'In Line',
+          cn: '进入直线',
+          ko: '직선 안으로',
+        },
+        trueIce: {
+          en: 'Avoid Tell',
+          cn: '躲避扇形',
+          ko: '예고 피하기',
+        },
+        fakeIce: {
+          en: 'In Cone',
+          cn: '进入扇形',
+          ko: '부채꼴 안으로',
+        },
+        trueIcePuddle: {
+          en: '${mech1} + ${mech2} => ${mech3}',
+          cn: '${mech1} + ${mech2} => ${mech3}',
+          ko: '${mech1} + ${mech2} => ${mech3}',
+        },
+        fakeIcePuddle: {
+          en: '${mech1} + ${mech2} => ${mech3}',
+          cn: '${mech1} + ${mech2} => ${mech3}',
+          ko: '${mech1} + ${mech2} => ${mech3}',
+        },
+        stackTrueIce: {
+          en: '${mech} + ${ice}',
+          cn: '${mech} + ${ice}',
+          ko: '${mech} + ${ice}',
+        },
+        stackFakeIce: {
+          en: '${mech} + ${ice}',
+          cn: '${mech} + ${ice}',
+          ko: '${mech} + ${ice}',
+        },
+        spreadTrueIce: {
+          en: '${mech} + ${ice}',
+          cn: '${mech} + ${ice}',
+          ko: '${mech} + ${ice}',
+        },
+        spreadFakeIce: {
+          en: '${mech} + ${ice}',
+          cn: '${mech} + ${ice}',
+          ko: '${mech} + ${ice}',
+        },
+        trueIceTrueThunder: {
+          en: 'Avoid Tells',
+          cn: '躲避扇形+直线',
+          ko: '예고 다 피하기',
+        },
+        fakeIceTrueThunder: {
+          en: 'Cone (only)',
+          cn: '仅扇形',
+          ko: '부채꼴만',
+        },
+        trueIceFakeThunder: {
+          en: 'Line (only)',
+          cn: '仅直线',
+          ko: '직선만',
+        },
+        fakeIceFakeThunder: {
+          en: 'Cone + Line',
+          cn: '扇形+直线',
+          ko: '부채꼴 + 직선',
+        },
+        stackTrueThunderLook: {
+          en: '${mech} + ${thunder} + ${look}',
+          cn: '${mech} + ${thunder} + ${look}',
+          ko: '${mech} + ${thunder} + ${look}',
+        },
+        stackFakeThunderLook: {
+          en: '${mech} + ${thunder} + ${look}',
+          cn: '${mech} + ${thunder} + ${look}',
+          ko: '${mech} + ${thunder} + ${look}',
+        },
+        spreadTrueThunderLook: {
+          en: '${mech} + ${thunder} + ${look}',
+          cn: '${mech} + ${thunder} + ${look}',
+          ko: '${mech} + ${thunder} + ${look}',
+        },
+        spreadFakeThunderLook: {
+          en: '${mech} + ${thunder} + ${look}',
+          cn: '${mech} + ${thunder} + ${look}',
+          ko: '${mech} + ${thunder} + ${look}',
+        },
+        stackTrueThunder: {
+          en: '${mech} + ${thunder}',
+          cn: '${mech} + ${thunder}',
+          ko: '${mech} + ${thunder}',
+        },
+        stackFakeThunder: {
+          en: '${mech} + ${thunder}',
+          cn: '${mech} + ${thunder}',
+          ko: '${mech} + ${thunder}',
+        },
+        spreadTrueThunder: {
+          en: '${mech} + ${thunder}',
+          cn: '${mech} + ${thunder}',
+          ko: '${mech} + ${thunder}',
+        },
+        spreadFakeThunder: {
+          en: '${mech} + ${thunder}',
+          cn: '${mech} + ${thunder}',
+          ko: '${mech} + ${thunder}',
+        },
+        lookAway: {
+          en: 'Look Away From Statue',
+          de: 'Von Statue wegschauen',
+          fr: 'Ne regardez pas la statue',
+          ja: '塔を見ない！',
+          cn: '背对神像',
+          ko: '시선 피하기',
+          tc: '背對神像',
+        },
+        lookAt: {
+          en: 'Look At Statue',
+          de: 'Statue anschauen',
+          fr: 'Regardez la statue',
+          ja: '像を見る！',
+          cn: '面对神像',
+          ko: '시선 바라보기',
+          tc: '面對神像',
+        },
+      },
     },
     {
       id: 'DMU P1 Graven Image Tether Cleanup',
@@ -1134,26 +1250,6 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: trapOutputStrings,
     },
     {
-      id: 'DMU P1 and P4 Mystery Magic Ice and Thunder',
-      // Set 2: Only Ice and Thunder should be set
-      type: 'StartsUsing',
-      netRegex: { id: 'BA94', source: 'Kefka', capture: false },
-      condition: (data) => {
-        return data.isIceTrue !== undefined && data.isThunderTrue !== undefined;
-      },
-      infoText: (data, _matches, output) => {
-        if (data.isThunderTrue) {
-          return data.isIceTrue
-            ? output.trueIceTrueThunder!()
-            : output.fakeIceTrueThunder!();
-        }
-        return data.isIceTrue
-          ? output.trueIceFakeThunder!()
-          : output.fakeIceFakeThunder!();
-      },
-      outputStrings: mysteryMagicOutputStrings,
-    },
-    {
       id: 'DMU P1 Light of Judgment',
       type: 'StartsUsing',
       netRegex: { id: 'C622', source: 'Kefka', capture: false },
@@ -1167,37 +1263,6 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { id: 'C622', source: 'Kefka', capture: true },
       delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 2, // Result in ~5.1s warning
       response: Responses.tankBuster(),
-    },
-    {
-      id: 'DMU P1 Mystery Magic Ice, and Gravitas and Vitrophyre Tethers 1',
-      // Occurs between Graven Image Set 2 and Set 3
-      // BA95 Blizzard III Blowout cast
-      type: 'StartsUsing',
-      netRegex: { id: 'BA95', source: 'Kefka', capture: false },
-      condition: (data) => {
-        if (
-          data.isIceTrue !== undefined &&
-          data.isThunderTrue === undefined &&
-          data.isFireTrue === undefined
-        )
-          return true;
-        return false;
-      },
-      infoText: (data, _matches, output) => {
-        const hasVitrophyre = data.gravenImageTether === 'vitrophyre';
-        return data.isIceTrue
-          ? output.trueIcePuddle!({
-            mech1: output.trueIce!(),
-            mech2: output.puddle!(),
-            mech3: hasVitrophyre ? output.spread!() : output.middle!(),
-          })
-          : output.fakeIcePuddle!({
-            mech1: output.fakeIce!(),
-            mech2: output.puddle!(),
-            mech3: hasVitrophyre ? output.spread!() : output.middle!(),
-          });
-      },
-      outputStrings: mysteryMagicOutputStrings,
     },
     {
       id: 'DMU P1 Vitrophyre',
@@ -1815,58 +1880,6 @@ const triggerSet: TriggerSet<Data> = {
           ko: '시선 피하기 (나중에)',
         },
       },
-    },
-    {
-      id: 'DMU P1 Mystery Magic Fire and Thunder',
-      // Set 3: Only Fire and Thunder should be set
-      type: 'StartsUsing',
-      netRegex: { id: 'BA94', source: 'Kefka', capture: false },
-      condition: (data) => {
-        if (
-          data.isFireTrue !== undefined &&
-          data.isThunderTrue !== undefined &&
-          data.phase === 'p1'
-        )
-          return true;
-        return false;
-      },
-      infoText: (data, _matches, output) => {
-        const fireMarker = data.fireMarker;
-        const look = data.isTowerLookAway ? output.lookAway!() : output.lookAt!();
-        if (
-          (fireMarker === headMarkerData['dorito'] && data.isFireTrue) ||
-          (fireMarker === headMarkerData['stack'] && !data.isFireTrue)
-        )
-          return data.isThunderTrue
-            ? output.spreadTrueThunderLook!({
-              mech: output.spread!(),
-              thunder: output.trueThunder!(),
-              look: look,
-            })
-            : output.spreadFakeThunderLook!({
-              mech: output.spread!(),
-              thunder: output.fakeThunder!(),
-              look: look,
-            });
-
-        if (
-          (fireMarker === headMarkerData['dorito'] && !data.isFireTrue) ||
-          (fireMarker === headMarkerData['stack'] && data.isFireTrue)
-        ) {
-          return data.isThunderTrue
-            ? output.stackTrueThunderLook!({
-              mech: output.stack!(),
-              thunder: output.trueThunder!(),
-              look: look,
-            })
-            : output.stackFakeThunderLook!({
-              mech: output.stack!(),
-              thunder: output.fakeThunder!(),
-              look: look,
-            });
-        }
-      },
-      outputStrings: mysteryMagicOutputStrings,
     },
     {
       id: 'DMU P1 and P4 Mystery Magic Cleanup',
@@ -4697,17 +4710,6 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'DMU P4 Thrumming Thunder III',
-      // BAA4 Mana Charge signifies that the true/fake will be stored for later
-      // Indicated with boss buff 5CA Mana Charged and 5CD Thunder Charged
-      type: 'StartsUsing',
-      netRegex: { id: 'C5DE', source: 'Kefka', capture: false },
-      infoText: (data, _matches, output) => {
-        return data.isThunderTrue ? output.trueThunder!() : output.fakeThunder!();
-      },
-      outputStrings: mysteryMagicOutputStrings,
-    },
-    {
       id: 'DMU P4 First Cursed Shriek',
       type: 'GainsEffect',
       netRegex: { effectId: '15A7', capture: true },
@@ -4895,19 +4897,6 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'DMU P4 Blizzard III Blowout',
-      // BAA4 Mana Charge signifies that the true/fake will be stored for later
-      // Indicated with boss buff 5CA Mana Charged and 5CC Blizzard Charged
-      type: 'StartsUsing',
-      netRegex: { id: 'BA95', source: 'Kefka', capture: false },
-      // Prevent triggering on earlier P1 or P4 triggers
-      condition: (data) => data.grandCrossCount === 3,
-      infoText: (data, _matches, output) => {
-        return data.isIceTrue ? output.trueIce!() : output.fakeIce!();
-      },
-      outputStrings: mysteryMagicOutputStrings,
-    },
-    {
       id: 'DMU P4 Second Cursed Shriek',
       type: 'GainsEffect',
       netRegex: { effectId: '15A7', capture: true },
@@ -4973,35 +4962,6 @@ const triggerSet: TriggerSet<Data> = {
         },
         puddles: Outputs.baitPuddles,
       },
-    },
-    {
-      id: 'DMU P4 Mana Release',
-      // 5CA Mana Charged falls off ~5.4s prior to startsUsing
-      // 5CD Thunder Charged and 5CC Blizzard Charged fall off after subsequent
-      // Thrumming Thunder III and Blizzard III Blowout startsUsing
-      type: 'StartsUsing',
-      netRegex: { id: 'BAA5', source: 'Kefka', capture: false },
-      condition: (data) => {
-        return data.isIceTrue !== undefined && data.isThunderTrue !== undefined;
-      },
-      infoText: (data, _matches, output) => {
-        const isThunderCharged = data.isThunderChargedTrue;
-        const isBlizzardCharged = data.isBlizzardChargedTrue;
-        const trueThunder = (isThunderCharged && data.isThunderTrue) ||
-          (!isThunderCharged && !data.isThunderTrue);
-        const trueIce = (isBlizzardCharged && data.isIceTrue) ||
-          (!isBlizzardCharged && !data.isIceTrue);
-
-        if (trueThunder) {
-          return trueIce
-            ? output.trueIceTrueThunder!()
-            : output.fakeIceTrueThunder!();
-        }
-        return trueIce
-          ? output.trueIceFakeThunder!()
-          : output.fakeIceFakeThunder!();
-      },
-      outputStrings: mysteryMagicOutputStrings,
     },
     {
       id: 'DMU P4 Fake Stray Spray',

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4644,6 +4644,44 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
+      id: 'DMU P4 Acceleration Bomb Reminder',
+      // Shorts are 51 (First), 36 (Second)
+      // Longs are 76 (First), 61 (Second)
+      type: 'GainsEffect',
+      netRegex: { effectId: '15AA', capture: true },
+      condition: Conditions.targetIsYou(),
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 3,
+      durationSeconds: 3,
+      alertText: (data, matches, output) => {
+        const duration = parseFloat(matches.duration);
+        const isFirstDebuff = duration > 75 || (duration < 52 && duration > 50);
+        const isTrue = isFirstDebuff
+          ? data.areFirstDebuffsTrue
+          : data.areSecondDebuffsTrue;
+        return isTrue ? output.stopEverything!() : output.keepMoving!();
+      },
+      outputStrings: {
+        keepMoving: {
+          en: 'Keep Moving',
+          de: 'weiter bewegen',
+          fr: 'Continuez à bouger',
+          ja: '最後は動く',
+          cn: '后行动',
+          ko: '마지막엔 움직이기',
+          tc: '後行動',
+        },
+        stopEverything: {
+          en: 'Stop Everything',
+          de: 'Alles stoppen',
+          fr: 'Arrêtez tout',
+          ja: '最後は止まる',
+          cn: '后静止',
+          ko: '마지막엔 멈추기',
+          tc: '後靜止',
+        },
+      },
+    },
+    {
       id: 'DMU P4 Mana Charge Collect',
       // 5CD Thunder Charged: Store the value of isThunderTrue for later
       // 5CC Blizzard Charged: Store the value of isIceTrue for later
@@ -4670,17 +4708,15 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'DMU P4 First Cursed Shriek',
-      // TODO: Merge this with Mana Charge (stored fake/real thunder)
       type: 'GainsEffect',
       netRegex: { effectId: '15A7', capture: true },
       condition: (_data, matches) => parseFloat(matches.duration) < 61,
-      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 6,
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 3,
+      durationSeconds: 3,
       suppressSeconds: 99999,
-      infoText: (data, _matches, output) => {
+      alertText: (data, _matches, output) => {
         const is1stTrue = data.areFirstDebuffsTrue;
-        const isEntropyTrue = data.isEntropyTrue;
-
-        if (is1stTrue === undefined || isEntropyTrue === undefined)
+        if (is1stTrue === undefined)
           return;
 
         const players = data.shortShriekPlayers.map(
@@ -4692,19 +4728,13 @@ const triggerSet: TriggerSet<Data> = {
         );
         const msg = players?.join(', ');
 
-        return output.shriekThenEntropy!({
-          mech1: is1stTrue
-            ? output.lookAwayFromPlayers!({ players: msg })
-            : output.lookAtPlayers!({ players: msg }),
-          mech2: isEntropyTrue ? output.puddles!() : output.donuts!(),
-        });
+        return is1stTrue
+          ? output.lookAwayFromPlayers!({ players: msg })
+          : output.lookAtPlayers!({ players: msg });
       },
       outputStrings: {
         you: {
           en: 'YOU',
-        },
-        shriekThenEntropy: {
-          en: '${mech1} => ${mech2}',
         },
         lookAtPlayers: {
           en: 'Face ${players}',
@@ -4712,15 +4742,6 @@ const triggerSet: TriggerSet<Data> = {
         lookAwayFromPlayers: {
           en: 'Look Away from ${players}',
         },
-        donuts: {
-          en: 'Stack for Donuts',
-          de: 'Für Donuts sammeln',
-          fr: 'Packez-vous pour les donuts',
-          cn: '集合放月环',
-          ko: '모여서 도넛장판 피하기',
-          tc: '集合放月環',
-        },
-        puddles: Outputs.baitPuddles,
       },
     },
     {
@@ -4885,13 +4906,12 @@ const triggerSet: TriggerSet<Data> = {
       type: 'GainsEffect',
       netRegex: { effectId: '15A7', capture: true },
       condition: (_data, matches) => parseFloat(matches.duration) > 68,
-      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 6,
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 3,
+      durationSeconds: 3,
       suppressSeconds: 99999,
-      infoText: (data, _matches, output) => {
+      alertText: (data, _matches, output) => {
         const is2ndTrue = data.areSecondDebuffsTrue;
-        const isFluidTrue = data.isDynamicFluidTrue;
-
-        if (is2ndTrue === undefined || isFluidTrue === undefined)
+        if (is2ndTrue === undefined)
           return;
 
         const players = data.longShriekPlayers.map(
@@ -4903,19 +4923,13 @@ const triggerSet: TriggerSet<Data> = {
         );
         const msg = players?.join(', ');
 
-        return output.shriekThenFluid!({
-          mech1: is2ndTrue
-            ? output.lookAwayFromPlayers!({ players: msg })
-            : output.lookAtPlayers!({ players: msg }),
-          mech2: isFluidTrue ? output.donuts!() : output.puddles!(),
-        });
+        return is2ndTrue
+          ? output.lookAwayFromPlayers!({ players: msg })
+          : output.lookAtPlayers!({ players: msg });
       },
       outputStrings: {
         you: {
           en: 'YOU',
-        },
-        shriekThenFluid: {
-          en: '${mech1} => ${mech2}',
         },
         lookAtPlayers: {
           en: 'Face ${players}',
@@ -4923,15 +4937,6 @@ const triggerSet: TriggerSet<Data> = {
         lookAwayFromPlayers: {
           en: 'Look Away from ${players}',
         },
-        donuts: {
-          en: 'Stack for Donuts',
-          de: 'Für Donuts sammeln',
-          fr: 'Packez-vous pour les donuts',
-          cn: '集合放月环',
-          ko: '모여서 도넛장판 피하기',
-          tc: '集合放月環',
-        },
-        puddles: Outputs.baitPuddles,
       },
     },
     {

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4671,6 +4671,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { effectId: '15A7', capture: true },
       condition: (_data, matches) => parseFloat(matches.duration) < 61,
       delaySeconds: (_data, matches) => parseFloat(matches.duration),
+      durationSeconds: 6.9, // Time until Stray Flames
       suppressSeconds: 99999,
       alertText: (data, _matches, output) => {
         const isEntropyTrue = data.isEntropyTrue;
@@ -4698,15 +4699,115 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.bigAoe(),
     },
     {
-      id: 'DMU P4 Long Debuffs',
-      // Using the following as possible matches:
+      id: 'DMU P4 Stray Flames and Long Debuffs',
+      // Puddles have been baited, these will be going off next:
       // 15A8 Forked Lightning x2 76s
       // 15A9 Compressed Water x2 76s
       // 15AA Acceleration Bomb (2 Long 76s)
-      type: 'GainsEffect',
-      netRegex: { effectId: ['15A8', '15A9', '15AA'], capture: true },
-      condition: (_data, matches) => parseFloat(matches.duration) > 75,
-      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 6,
+      type: 'StartsUsing',
+      netRegex: { id: 'BB22', source: 'Chaos', capture: false },
+      durationSeconds: 9, // Time until debuffs expire
+      suppressSeconds: 99999,
+      alertText: (data, _matches, output) => {
+        const hasFork = data.longForkedPlayers.includes(data.me);
+        const hasCompressed = data.longCompressedPlayers.includes(data.me);
+        const hasBomb = data.longBombPlayers.includes(data.me);
+        const is1stTrue = data.areFirstDebuffsTrue;
+        const is2ndTrue = data.areSecondDebuffsTrue;
+
+        if (is2ndTrue === undefined || is1stTrue === undefined)
+          return;
+
+        const players = data.longShriekPlayers.map(
+          (player) => {
+            if (player === data.me)
+              return output.you!();
+            return data.party.member(player);
+          },
+        );
+        const msg = players?.join(', ');
+
+        const gaze = is2ndTrue
+          ? output.lookAwayFromPlayers!({ players: msg })
+          : output.lookAtPlayers!({ players: msg });
+        const hasSpread = (hasFork && is1stTrue) || (hasCompressed && !is1stTrue);
+        const hasStack = (hasFork && !is1stTrue) || (hasCompressed && is1stTrue);
+
+        // Handle 2 Mechs
+        if (hasSpread && hasBomb)
+          return output.forkBombThenGaze!({
+            mech1: output.spread!(),
+            mech2: is1stTrue ? output.bomb!() : output.fakeBomb!(),
+            mech3: gaze,
+          });
+        if (hasStack && hasBomb)
+          return output.compressedBombThenGaze!({
+            mech1: output.stack!(),
+            mech2: is1stTrue ? output.bomb!() : output.fakeBomb!(),
+            mech3: gaze,
+          });
+        if (hasSpread)
+          return output.spreadThenGaze!({
+            mech1: output.spread!(),
+            mech2: gaze,
+          });
+        if (hasStack)
+          return output.stackThenGaze!({
+            mech1: output.stack!(),
+            mech2: gaze,
+          });
+        if (hasBomb)
+          return output.bombThenGaze!({
+            mech1: is1stTrue ? output.bomb!() : output.fakeBomb!(),
+            mech2: output.stack!(),
+            mech3: gaze,
+          });
+      },
+      outputStrings: {
+        you: {
+          en: 'YOU',
+        },
+        spreadThenGaze: {
+          en: '${mech1} => ${mech2}',
+        },
+        stackThenGaze: {
+          en: '${mech1} => ${mech2}',
+        },
+        bombThenGaze: {
+          en: '${mech1} + ${mech2} => ${mech3}',
+        },
+        forkBombThenGaze: {
+          en: '${mech1} + ${mech2} => ${mech3}',
+        },
+        compressedBombThenGaze: {
+          en: '${mech1} + ${mech2} => ${mech3}',
+        },
+        stack: Outputs.stackMarker,
+        spread: Outputs.spread,
+        bomb: {
+          en: 'Stillness',
+        },
+        fakeBomb: {
+          en: 'Motion',
+        },
+        lookAtPlayers: {
+          en: 'Face ${players}',
+        },
+        lookAwayFromPlayers: {
+          en: 'Look Away from ${players}',
+        },
+      },
+    },
+    {
+      id: 'DMU P4 Fake Stray Flames and Long Debuffs',
+      // Need to wait for the donut then these will be going off next:
+      // 15A8 Forked Lightning x2 76s
+      // 15A9 Compressed Water x2 76s
+      // 15AA Acceleration Bomb (2 Long 76s)
+      type: 'StartsUsing',
+      netRegex: { id: 'BB23', source: 'Chaos', capture: true },
+      delaySeconds: (_data, matches) => parseFloat(matches.castTime), // 4.7s
+      durationSeconds: (_data, matches) => 9 - parseFloat(matches.castTime),
       suppressSeconds: 99999,
       alertText: (data, _matches, output) => {
         const hasFork = data.longForkedPlayers.includes(data.me);
@@ -4873,6 +4974,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { effectId: '15A7', capture: true },
       condition: (_data, matches) => parseFloat(matches.duration) > 68,
       delaySeconds: (_data, matches) => parseFloat(matches.duration),
+      durationSeconds: 6.9, // Time until Stray Spray
       suppressSeconds: 99999,
       alertText: (data, _matches, output) => {
         const isFluidTrue = data.isDynamicFluidTrue;
@@ -4921,6 +5023,14 @@ const triggerSet: TriggerSet<Data> = {
           : output.fakeIceFakeThunder!();
       },
       outputStrings: mysteryMagicOutputStrings,
+    },
+    {
+      id: 'DMU P4 Fake Stray Spray',
+      // Puddles have been baited, need to move away
+      type: 'StartsUsing',
+      netRegex: { id: 'BB25', source: 'Chaos', capture: false },
+      suppressSeconds: 99999,
+      response: Responses.moveAway('alert'),
     },
   ],
   timelineReplace: [

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4388,9 +4388,9 @@ const triggerSet: TriggerSet<Data> = {
             ? output.black!()
             : output.white!(),
           dir: (keep && wound === 'white' && isBlueLeft) ||
-            (keep && wound === 'black' && !isBlueLeft) ||
-            (!keep && wound === 'white' && !isBlueLeft) ||
-            (!keep && wound === 'black' && isBlueLeft)
+              (keep && wound === 'black' && !isBlueLeft) ||
+              (!keep && wound === 'white' && !isBlueLeft) ||
+              (!keep && wound === 'black' && isBlueLeft)
             ? output.right!()
             : output.left!(),
         });

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -7,7 +7,6 @@ import { RaidbossData } from '../../../../../types/data';
 import { OutputStrings, TriggerSet } from '../../../../../types/trigger';
 
 // TODO: P2 Old AAAABBBB plan was found at https://raidplan.io/plan/kj2d734d36es2ugs, would like to find replacement
-// TODO: P4 Add detection for Fake Chaos and Fake Neo Exdeath debuffs
 // TODO: Earlier phase tracking for P5 (counting the jumps to middle?)
 
 type Phase = 'p1' | 'p2' | 'p3' | 'p4' | 'p5';
@@ -3864,6 +3863,32 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Get Behind ${target}',
           ko: '${target} 뒤로',
         },
+      },
+    },
+    {
+      id: 'DMU P4 Chaos and Neo Exdeath Debuff Collect',
+      // In the count field of Effect 808, the bosses receive these values:
+      // Fake Chaos: 45F
+      // True Chaos: 460
+      // Fake Neo Exdeath: 461
+      // True Neo Exdeath: 462
+      type: 'GainsEffect',
+      netRegex: { effectId: '808', source: ['Chaos', 'Neo Exdeath'], capture: true },
+      run: (data, matches) => {
+        const count = matches.count;
+        const grandCrossCount = data.grandCrossCount;
+        const isTrue = count === '460' || (count === '462')
+          ? true
+          : false;
+        if (grandCrossCount === 0)
+          data.areFirstDebuffsTrue = isTrue;
+        else if (grandCrossCount === 1)
+          data.isEntropyTrue = isTrue;
+        else if (grandCrossCount === 2)
+          data.areSecondDebuffsTrue = isTrue;
+        else if (grandCrossCount === 3)
+          data.isDynamicFluidTrue = isTrue;
+        // Last set has a double negative, so only tracking debuffs
       },
     },
     {

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4853,6 +4853,11 @@ const triggerSet: TriggerSet<Data> = {
             mech2: output.stack!(),
             mech3: gaze,
           });
+        // Has nothing
+        return output.stackThenGaze!({
+          mech1: output.stack!(),
+          mech2: gaze,
+        });
       },
       outputStrings: {
         you: {

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4012,7 +4012,8 @@ const triggerSet: TriggerSet<Data> = {
           data.areSecondDebuffsTrue = isTrue;
         else if (data.isDynamicFluidTrue === undefined)
           data.isDynamicFluidTrue = isTrue;
-        // Last set has a double negative, so only tracking debuffs
+        // Last two are not needed as the next is a double negative and last
+        // has unique cast ids for true/fake
       },
     },
     {
@@ -4333,20 +4334,65 @@ const triggerSet: TriggerSet<Data> = {
       },
       condition: Conditions.targetIsYou(),
       delaySeconds: 0.1,
-      durationSeconds: 9,
       suppressSeconds: 99999,
       infoText: (data, _matches, output) => {
+        const wound = data.wound;
+        const deathOrField = data.deathOrField;
+        if (wound === undefined || deathOrField === undefined)
+          return;
+
+        return output.debuffsOnYou!({
+          wound: output[wound]!(),
+          deathOrField: output[deathOrField]!(),
+        });
+      },
+      outputStrings: {
+        death: {
+          en: 'Death',
+        },
+        field: {
+          en: 'Field',
+        },
+        white: {
+          en: 'Purple Debuff',
+        },
+        black: {
+          en: 'Blue Debuff',
+        },
+        debuffsOnYou: {
+          en: '${wound} + ${deathOrField} on YOU',
+        },
+      },
+    },
+    {
+      id: 'DMU P4 Flood of Naught',
+      type: 'StartsUsing',
+      netRegex: { id: ['C392', 'C393', 'C3A1', 'C3A2'], source: 'Neo Exdeath', capture: true },
+      alertText: (data, matches, output) => {
         const wound = data.wound;
         const deathOrField = data.deathOrField;
 
         if (wound === undefined || deathOrField === undefined)
           return;
+
+        const id = matches.id;
+        const isFloodTrue = id === 'C392' || id === 'C393';
+        const isBlueLeft = id === 'C3A1' || id === 'C393'; // Our left
+        const keep = (deathOrField === 'death' && isFloodTrue) ||
+          (deathOrField === 'field' && !isFloodTrue);
+
         const laser = output[deathOrField]!({
-          color: deathOrField === 'death'
+          color: keep
             ? output[wound]!()
             : wound === 'white'
             ? output.black!()
             : output.white!(),
+          dir: (keep && wound === 'white' && isBlueLeft) ||
+            (keep && wound === 'black' && !isBlueLeft) ||
+            (!keep && wound === 'white' && !isBlueLeft) ||
+            (!keep && wound === 'black' && isBlueLeft)
+            ? output.right!()
+            : output.left!(),
         });
 
         const hasFork = data.shortForkedPlayers.includes(data.me);
@@ -4397,10 +4443,10 @@ const triggerSet: TriggerSet<Data> = {
       },
       outputStrings: {
         death: {
-          en: 'Stand in ${color}',
+          en: 'Stand in ${color} (${dir})',
         },
         field: {
-          en: 'Stand in ${color}',
+          en: 'Stand in ${color} (${dir})',
         },
         white: {
           en: 'Purple',
@@ -4408,6 +4454,8 @@ const triggerSet: TriggerSet<Data> = {
         black: {
           en: 'Blue',
         },
+        left: Outputs.left,
+        right: Outputs.right,
         laserThenSpread: {
           en: '${mech1} => ${mech2}',
         },
@@ -4431,20 +4479,13 @@ const triggerSet: TriggerSet<Data> = {
         fakeBomb: {
           en: 'Motion',
         },
-        text: {
-          en: 'unknown',
-        },
       },
     },
     {
       id: 'DMU P4 Short Debuffs',
-      // Using the following as possible matches:
-      // 1558 Beyond Death (Fake) or 566 Beyond Death
-      // 1C6 Allagan Field
-      // The spells/abilities or losesEffect could be triggered from early deaths
-      type: 'GainsEffect',
-      netRegex: { effectId: ['566', '1558', '1C6'], capture: true },
-      delaySeconds: (_data, matches) => parseFloat(matches.duration),
+      // Once hit by C394 White Antilight or C395 Black Antilight, it is safe to move
+      type: 'Ability',
+      netRegex: { id: ['C394', 'C395'], source: 'Neo Exdeath', capture: false },
       suppressSeconds: 99999,
       alertText: (data, _matches, output) => {
         const hasFork = data.shortForkedPlayers.includes(data.me);

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -3839,17 +3839,17 @@ const triggerSet: TriggerSet<Data> = {
       },
       run: (data, matches) => {
         const count = matches.count;
-        const grandCrossCount = data.grandCrossCount;
         const isTrue = count === '460' || (count === '462')
           ? true
           : false;
-        if (grandCrossCount === 0)
+        // These always come out in order
+        if (data.areFirstDebuffsTrue === undefined)
           data.areFirstDebuffsTrue = isTrue;
-        else if (grandCrossCount === 1)
+        else if (data.isEntropyTrue === undefined)
           data.isEntropyTrue = isTrue;
-        else if (grandCrossCount === 2)
+        else if (data.areSecondDebuffsTrue === undefined)
           data.areSecondDebuffsTrue = isTrue;
-        else if (grandCrossCount === 3)
+        else if (data.isDynamicFluidTrue === undefined)
           data.isDynamicFluidTrue = isTrue;
         // Last set has a double negative, so only tracking debuffs
       },
@@ -3857,10 +3857,10 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'DMU P4 Tsunami/Inferno',
       // BB14 Grand Cross AoE also happens ~4s after this cast starts
-      // BB20 Inferno / BB21 Tsunami are 9s castTime
+      // BB20 Inferno / BB21 Tsunami are 8.7s castTime
       type: 'StartsUsing',
       netRegex: { id: ['BB20', 'BB21'], source: 'Chaos', capture: true },
-      delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 6,
+      delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 5,
       response: Responses.aoe(),
     },
     {
@@ -3871,10 +3871,10 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'DMU P4 Grand Cross',
-      // 9s castTime
+      // 8.7s castTime
       type: 'StartsUsing',
       netRegex: { id: 'BB14', source: 'Neo Exdeath', capture: true },
-      delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 6,
+      delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 5,
       response: Responses.aoe(),
     },
     {
@@ -3894,13 +3894,13 @@ const triggerSet: TriggerSet<Data> = {
       // Chaos Debuffs 2: 12:50.485
       // 15AB Entroy x8 45s                               => 13:35.485
       // Neo Exdeath Debuffs Cast 3: (13:00.002)
-      // 1317 White Wound
-      // 1318 Black Wound
-      // 1558 Beyond Death x4 15s                         => 13:15.002
+      // 15A5 White Wound or 1317 (Fake)
+      // 15A6 Black Wound or 1318 (Fake)
+      // 1558 Beyond Death or 556 (Fake) x4 15s           => 13:15.002
       // 1C6 Allagan Field x4 15s                         => 13:15.002
       // Neo Exdeath Final: (13:11.383)
-      // 1317 or 15A5 White Wound
-      // 1318 or 15A6 Black Wound
+      // 1317 White Wound (Fake) or 15A5 White Wound
+      // 1318 Black Wound (Fake) or 15A6 Black Wound
       //
       // For Neo Exdeath, after the second Grand Cross cast there will be:
       // 1 Support, 1 DPS with Short 3-Person Stack (Compressed Water and/or Fake Forked Lightning)
@@ -3916,6 +3916,8 @@ const triggerSet: TriggerSet<Data> = {
       type: 'GainsEffect',
       netRegex: {
         effectId: [
+          '15A5',
+          '15A6',
           '15A7',
           '15A8',
           '15A9',
@@ -3923,6 +3925,7 @@ const triggerSet: TriggerSet<Data> = {
           '1317',
           '1318',
           '1558',
+          '566',
           '1C6',
         ],
         capture: true,
@@ -3958,7 +3961,7 @@ const triggerSet: TriggerSet<Data> = {
             data.longBombPlayers.push(target);
         } else if (data.me === target) {
           // Cast 5 / 6 Debuffs
-          if (id === '1558')
+          if (id === '1558' || id === '566')
             data.deathOrField = 'death';
           else if (id === '1C6')
             data.deathOrField = 'field';
@@ -4039,25 +4042,25 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'DMU P4 Dynamic Fluid (Early)',
+      id: 'DMU P4 Entropy (Early)',
       type: 'GainsEffect',
-      netRegex: { effectId: '15AC', capture: false },
+      netRegex: { effectId: '15AB', capture: false },
       delaySeconds: 0.1,
       suppressSeconds: 99999,
       infoText: (data, _matches, output) => {
-        const isFluidTrue = data.isDynamicFluidTrue;
-        if (isFluidTrue === undefined)
+        const isEntropyTrue = data.isEntropyTrue;
+        if (isEntropyTrue === undefined)
           return;
-        return isFluidTrue
-          ? output.donutsSecond!()
-          : output.twistersSecond!();
+        return isEntropyTrue
+          ? output.twistersFirst!()
+          : output.donutsFirst!();
       },
       outputStrings: {
-        twistersSecond: {
-          en: 'Twisters Second',
+        twistersFirst: {
+          en: 'Twisters First',
         },
-        donutsSecond: {
-          en: 'Donuts Second',
+        donutsFirst: {
+          en: 'Donuts First',
         },
       },
     },
@@ -4133,25 +4136,25 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'DMU P4 Entropy (Early)',
+      id: 'DMU P4 Dynamic Fluid (Early)',
       type: 'GainsEffect',
-      netRegex: { effectId: '15AB', capture: false },
+      netRegex: { effectId: '15AC', capture: false },
       delaySeconds: 0.1,
       suppressSeconds: 99999,
       infoText: (data, _matches, output) => {
-        const isEntropyTrue = data.isEntropyTrue;
-        if (isEntropyTrue === undefined)
+        const isFluidTrue = data.isDynamicFluidTrue;
+        if (isFluidTrue === undefined)
           return;
-        return isEntropyTrue
-          ? output.twistersFirst!()
-          : output.donutsFirst!();
+        return isFluidTrue
+          ? output.donutsSecond!()
+          : output.twistersSecond!();
       },
       outputStrings: {
-        twistersFirst: {
-          en: 'Twisters First',
+        twistersSecond: {
+          en: 'Twisters Second',
         },
-        donutsFirst: {
-          en: 'Donuts First',
+        donutsSecond: {
+          en: 'Donuts Second',
         },
       },
     },

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -744,7 +744,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { id: ['BA94', 'BA95', 'C5DE', 'BAA5'], source: 'Kefka', capture: true },
       delaySeconds: (_data, matches) => {
         if (matches.id === 'BAA5')
-          return parseFloat(matches.castTime) + 0.4;
+          return parseFloat(matches.castTime) + 0.3;
         return 0;
       },
       infoText: (data, matches, output) => {

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4584,8 +4584,8 @@ const triggerSet: TriggerSet<Data> = {
         const msg = players?.join(', ');
 
         const gaze = is1stTrue
-          ? output.lookAwayFromPlayers!({ players: msg })
-          : output.lookAtPlayers!({ players: msg });
+          ? output.fakeCursedShriekOnPlayers!({ players: msg })
+          : output.cursedShriekOnPlayers!({ players: msg });
         const hasSpread = (hasFork && isShortTrue) || (hasCompressed && !isShortTrue);
         const hasStack = (hasFork && !isShortTrue) || (hasCompressed && isShortTrue);
 
@@ -4651,10 +4651,10 @@ const triggerSet: TriggerSet<Data> = {
         fakeBomb: {
           en: 'Motion',
         },
-        lookAtPlayers: {
+        cursedShriekOnPlayers: {
           en: 'Face ${players}',
         },
-        lookAwayFromPlayers: {
+        fakeCursedShriekOnPlayers: {
           en: 'Look Away from ${players}',
         },
       },
@@ -4726,27 +4726,27 @@ const triggerSet: TriggerSet<Data> = {
         // Seperate configurable output if you have it
         if (shriekPlayers.includes(data.me)) {
           return isTrue
-            ? output.lookAwayFromPlayerYou!({ players: msg })
-            : output.lookAtPlayerYou!({ players: msg });
+            ? output.fakeCursedShriekOnYou!({ players: msg })
+            : output.cursedShriekOnYou!({ players: msg });
         }
         return isTrue
-          ? output.lookAwayFromPlayers!({ players: msg })
-          : output.lookAtPlayers!({ players: msg });
+          ? output.fakeCursedShriekOnPlayers!({ players: msg })
+          : output.cursedShriekOnPlayers!({ players: msg });
       },
       outputStrings: {
         you: {
           en: 'YOU',
         },
-        lookAtPlayers: {
+        cursedShriekOnPlayers: {
           en: 'Face ${players} (later)',
         },
-        lookAwayFromPlayers: {
+        fakeCursedShriekOnPlayers: {
           en: 'Look Away from ${players} (later)',
         },
-        lookAtPlayerYou: {
+        cursedShriekOnYou: {
           en: 'Face ${players} (later)',
         },
-        lookAwayFromPlayerYou: {
+        fakeCursedShriekOnYou: {
           en: 'Look Away from ${players} (later)',
         },
       },
@@ -4757,7 +4757,7 @@ const triggerSet: TriggerSet<Data> = {
       // 5CC Blizzard Charged: Store the value of isIceTrue for later
       type: 'GainsEffect',
       netRegex: { effectId: ['5CD', '5CC'], capture: true },
-      delaySeconds: 0.2, // Delay for headmarker collect
+      delaySeconds: 0.1, // Delay for headmarker collect
       run: (data, matches) => {
         if (matches.effectId === '5CD')
           data.isThunderChargedTrue = data.isThunderTrue;
@@ -4788,17 +4788,17 @@ const triggerSet: TriggerSet<Data> = {
         const msg = players?.join(', ');
 
         return is1stTrue
-          ? output.lookAwayFromPlayers!({ players: msg })
-          : output.lookAtPlayers!({ players: msg });
+          ? output.fakeCursedShriekOnPlayers!({ players: msg })
+          : output.cursedShriekOnPlayers!({ players: msg });
       },
       outputStrings: {
         you: {
           en: 'YOU',
         },
-        lookAtPlayers: {
+        cursedShriekOnPlayers: {
           en: 'Face ${players}',
         },
-        lookAwayFromPlayers: {
+        fakeCursedShriekOnPlayers: {
           en: 'Look Away from ${players}',
         },
       },
@@ -4879,8 +4879,8 @@ const triggerSet: TriggerSet<Data> = {
         const msg = players?.join(', ');
 
         const gaze = is2ndTrue
-          ? output.lookAwayFromPlayers!({ players: msg })
-          : output.lookAtPlayers!({ players: msg });
+          ? output.fakeCursedShriekOnPlayers!({ players: msg })
+          : output.cursedShriekOnPlayers!({ players: msg });
         const hasSpread = (hasFork && isLongTrue) || (hasCompressed && !isLongTrue);
         const hasStack = (hasFork && !isLongTrue) || (hasCompressed && isLongTrue);
 
@@ -4946,10 +4946,10 @@ const triggerSet: TriggerSet<Data> = {
         fakeBomb: {
           en: 'Motion',
         },
-        lookAtPlayers: {
+        cursedShriekOnPlayers: {
           en: 'Face ${players}',
         },
-        lookAwayFromPlayers: {
+        fakeCursedShriekOnPlayers: {
           en: 'Look Away from ${players}',
         },
       },
@@ -4977,17 +4977,17 @@ const triggerSet: TriggerSet<Data> = {
         const msg = players?.join(', ');
 
         return is2ndTrue
-          ? output.lookAwayFromPlayers!({ players: msg })
-          : output.lookAtPlayers!({ players: msg });
+          ? output.fakeCursedShriekOnPlayers!({ players: msg })
+          : output.cursedShriekOnPlayers!({ players: msg });
       },
       outputStrings: {
         you: {
           en: 'YOU',
         },
-        lookAtPlayers: {
+        cursedShriekOnPlayers: {
           en: 'Face ${players}',
         },
-        lookAwayFromPlayers: {
+        fakeCursedShriekOnPlayers: {
           en: 'Look Away from ${players}',
         },
       },

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4052,12 +4052,12 @@ const triggerSet: TriggerSet<Data> = {
         if (isEntropyTrue === undefined)
           return;
         return isEntropyTrue
-          ? output.twistersFirst!()
+          ? output.puddlesFirst!()
           : output.donutsFirst!();
       },
       outputStrings: {
-        twistersFirst: {
-          en: 'Twisters First',
+        puddlesFirst: {
+          en: 'Puddles First',
         },
         donutsFirst: {
           en: 'Donuts First',
@@ -4147,11 +4147,11 @@ const triggerSet: TriggerSet<Data> = {
           return;
         return isFluidTrue
           ? output.donutsSecond!()
-          : output.twistersSecond!();
+          : output.puddlesSecond!();
       },
       outputStrings: {
-        twistersSecond: {
-          en: 'Twisters Second',
+        puddlesSecond: {
+          en: 'Puddles Second',
         },
         donutsSecond: {
           en: 'Donuts Second',
@@ -4269,6 +4269,9 @@ const triggerSet: TriggerSet<Data> = {
         },
         fakeBomb: {
           en: 'Motion',
+        },
+        text: {
+          en: 'unknown',
         },
       },
     },
@@ -4416,7 +4419,7 @@ const triggerSet: TriggerSet<Data> = {
           mech1: is1stTrue
             ? output.lookAwayFromPlayers!({ players: msg })
             : output.lookAtPlayers!({ players: msg }),
-          mech2: isEntropyTrue ? output.twisters!() : output.donuts!(),
+          mech2: isEntropyTrue ? output.puddles!() : output.donuts!(),
         });
       },
       outputStrings: {
@@ -4440,15 +4443,7 @@ const triggerSet: TriggerSet<Data> = {
           ko: '모여서 도넛장판 피하기',
           tc: '集合放月環',
         },
-        twisters: {
-          en: 'Twisters',
-          de: 'Wirbelstürme',
-          fr: 'Tornades',
-          ja: '大竜巻',
-          cn: '旋风',
-          ko: '회오리',
-          tc: '旋風',
-        },
+        puddles: Outputs.baitPuddles,
       },
     },
     {
@@ -4466,7 +4461,7 @@ const triggerSet: TriggerSet<Data> = {
         if (isEntropyTrue === undefined)
           return;
 
-        return isEntropyTrue ? output.twisters!() : output.donuts!();
+        return isEntropyTrue ? output.puddles!() : output.donuts!();
       },
       outputStrings: {
         donuts: {
@@ -4477,15 +4472,7 @@ const triggerSet: TriggerSet<Data> = {
           ko: '모여서 도넛장판 피하기',
           tc: '集合放月環',
         },
-        twisters: {
-          en: 'Twisters',
-          de: 'Wirbelstürme',
-          fr: 'Tornades',
-          ja: '大竜巻',
-          cn: '旋风',
-          ko: '회오리',
-          tc: '旋風',
-        },
+        puddles: Outputs.baitPuddles,
       },
     },
     {
@@ -4635,7 +4622,7 @@ const triggerSet: TriggerSet<Data> = {
           mech1: is2ndTrue
             ? output.lookAwayFromPlayers!({ players: msg })
             : output.lookAtPlayers!({ players: msg }),
-          mech2: isFluidTrue ? output.donuts!() : output.twisters!(),
+          mech2: isFluidTrue ? output.donuts!() : output.puddles!(),
         });
       },
       outputStrings: {
@@ -4659,15 +4646,7 @@ const triggerSet: TriggerSet<Data> = {
           ko: '모여서 도넛장판 피하기',
           tc: '集合放月環',
         },
-        twisters: {
-          en: 'Twisters',
-          de: 'Wirbelstürme',
-          fr: 'Tornades',
-          ja: '大竜巻',
-          cn: '旋风',
-          ko: '회오리',
-          tc: '旋風',
-        },
+        puddles: Outputs.baitPuddles,
       },
     },
     {
@@ -4684,7 +4663,7 @@ const triggerSet: TriggerSet<Data> = {
         if (isFluidTrue === undefined)
           return;
 
-        return isFluidTrue ? output.donuts!() : output.twisters!();
+        return isFluidTrue ? output.donuts!() : output.puddles!();
       },
       outputStrings: {
         donuts: {
@@ -4695,15 +4674,7 @@ const triggerSet: TriggerSet<Data> = {
           ko: '모여서 도넛장판 피하기',
           tc: '集合放月環',
         },
-        twisters: {
-          en: 'Twisters',
-          de: 'Wirbelstürme',
-          fr: 'Tornades',
-          ja: '大竜巻',
-          cn: '旋风',
-          ko: '회오리',
-          tc: '旋風',
-        },
+        puddles: Outputs.baitPuddles,
       },
     },
     {

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -4870,27 +4870,58 @@ const triggerSet: TriggerSet<Data> = {
       id: 'DMU P4 Stray Flames and Long Debuffs',
       // BB22 Stray Flames: Puddles have been baited, these will be going off next
       // BB23 Fake Stray Flames: Wait until Donuts happen
+      // These have a 4.7s castTime, using GainsEffect from 15AB Entropy to prevent early triggers
       // 15A8 Forked Lightning x2 76s
       // 15A9 Compressed Water x2 76s
       // 15AA Acceleration Bomb (2 Long 76s)
-      // Thes have a 4.7s castTime
-      type: 'StartsUsing',
-      netRegex: { id: ['BB22', 'BB23'], source: 'Chaos', capture: true },
-      delaySeconds: (_data, matches) => {
-        return matches.id === 'BB23' ? parseFloat(matches.castTime) : 0;
+      type: 'GainsEffect',
+      netRegex: { effectId: '15AB', capture: true },
+      delaySeconds: (data, matches) => {
+        const duration = parseFloat(matches.duration);
+        return (data.isEntropyTrue || data.isEntropyTrue === undefined)
+          ? duration
+          : duration + 4.7;
       },
-      durationSeconds: (_data, matches) => {
-        // Time until debuffs expire
-        return matches.id === 'BB22' ? 9 : 9 - parseFloat(matches.castTime);
+      durationSeconds: (data) => {
+        // Time until 15A8, 15A9, 15AA debuffs expire
+        return (data.isEntropyTrue || data.isEntropyTrue === undefined) ? 9.1 : 4.4;
       },
       suppressSeconds: 99999,
-      alertText: (data, _matches, output) => {
+      response: (data, _matches, output) => {
+        // cactbot-builtin-response
+        output.responseOutputStrings = {
+          you: {
+            en: 'YOU',
+          },
+          bombStack: {
+            en: '${mech1} + ${mech2}',
+          },
+          forkBomb: {
+            en: '${mech1} + ${mech2}',
+          },
+          compressedBomb: {
+            en: '${mech1} + ${mech2}',
+          },
+          noDebuff: Outputs.stackMarker,
+          stack: Outputs.stackMarker,
+          spread: Outputs.spread,
+          bomb: {
+            en: 'Stillness',
+          },
+          fakeBomb: {
+            en: 'Motion',
+          },
+        };
+
         const is1stTrue = data.areFirstDebuffsTrue;
         const is2ndTrue = data.areThirdDebuffsTrue;
         const isFirstShort = data.isFirstDebuffShort;
         if (is1stTrue === undefined || is2ndTrue === undefined || isFirstShort === undefined)
           return;
         const isLongTrue = isFirstShort ? is2ndTrue : is1stTrue;
+
+        // Drop severity if fail to get true/false for Entropy as we default to end of debuffs
+        const severity = data.isEntropyTrue === undefined ? 'infoText' : 'alertText';
 
         const hasFork = data.longForkedPlayers.includes(data.me);
         const hasCompressed = data.longCompressedPlayers.includes(data.me);
@@ -4901,49 +4932,32 @@ const triggerSet: TriggerSet<Data> = {
 
         // Handle 2 Mechs
         if (hasSpread && hasBomb)
-          return output.forkBomb!({
-            mech1: output.spread!(),
-            mech2: isLongTrue ? output.bomb!() : output.fakeBomb!(),
-          });
+          return {
+            [severity]: output.forkBomb!({
+              mech1: output.spread!(),
+              mech2: isLongTrue ? output.bomb!() : output.fakeBomb!(),
+            }),
+          };
         if (hasStack && hasBomb)
-          return output.compressedBomb!({
-            mech1: output.stack!(),
-            mech2: isLongTrue ? output.bomb!() : output.fakeBomb!(),
-          });
+          return {
+            [severity]: output.compressedBomb!({
+              mech1: output.stack!(),
+              mech2: isLongTrue ? output.bomb!() : output.fakeBomb!(),
+            }),
+          };
         if (hasSpread)
-          return output.spread!();
+          return { [severity]: output.spread!() };
         if (hasStack)
-          return output.stack!();
+          return { [severity]: output.stack!() };
         if (hasBomb)
-          return output.bombStack!({
-            mech1: isLongTrue ? output.bomb!() : output.fakeBomb!(),
-            mech2: output.stack!(),
-          });
+          return {
+            [severity]: output.bombStack!({
+              mech1: isLongTrue ? output.bomb!() : output.fakeBomb!(),
+              mech2: output.stack!(),
+            }),
+          };
         // Has nothing
-        return output.noDebuff!();
-      },
-      outputStrings: {
-        you: {
-          en: 'YOU',
-        },
-        bombStack: {
-          en: '${mech1} + ${mech2}',
-        },
-        forkBomb: {
-          en: '${mech1} + ${mech2}',
-        },
-        compressedBomb: {
-          en: '${mech1} + ${mech2}',
-        },
-        noDebuff: Outputs.stackMarker,
-        stack: Outputs.stackMarker,
-        spread: Outputs.spread,
-        bomb: {
-          en: 'Stillness',
-        },
-        fakeBomb: {
-          en: 'Motion',
-        },
+        return { [severity]: output.noDebuff!() };
       },
     },
     {
@@ -5027,8 +5041,11 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'DMU P4 Fake Stray Spray',
       // Puddles have been baited, need to move away
-      type: 'StartsUsing',
-      netRegex: { id: 'BB25', source: 'Chaos', capture: false },
+      // Using GainsEffect of 15AC Dynamic Fluid prevents early trigger
+      type: 'GainsEffect',
+      netRegex: { effectId: '15AC', capture: true },
+      condition: (data) => !data.isFluidTrue,
+      delaySeconds: (_data, matches) => parseFloat(matches.duration),
       suppressSeconds: 99999,
       response: Responses.moveAway('alert'),
     },

--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -742,6 +742,11 @@ const triggerSet: TriggerSet<Data> = {
       // BAA5 Mana Release
       type: 'StartsUsing',
       netRegex: { id: ['BA94', 'BA95', 'C5DE', 'BAA5'], source: 'Kefka', capture: true },
+      delaySeconds: (_data, matches) => {
+        if (matches.id === 'BAA5')
+          return parseFloat(matches.castTime); // Mana Release happens before the tells
+        return 0;
+      },
       infoText: (data, matches, output) => {
         const id = matches.id;
         if (id === 'BA94') {
@@ -4584,8 +4589,8 @@ const triggerSet: TriggerSet<Data> = {
         const msg = players?.join(', ');
 
         const gaze = is1stTrue
-          ? output.fakeCursedShriekOnPlayers!({ players: msg })
-          : output.cursedShriekOnPlayers!({ players: msg });
+          ? output.fakeGazeOnPlayers!({ players: msg })
+          : output.gazeOnPlayers!({ players: msg });
         const hasSpread = (hasFork && isShortTrue) || (hasCompressed && !isShortTrue);
         const hasStack = (hasFork && !isShortTrue) || (hasCompressed && isShortTrue);
 
@@ -4651,10 +4656,10 @@ const triggerSet: TriggerSet<Data> = {
         fakeBomb: {
           en: 'Motion',
         },
-        cursedShriekOnPlayers: {
+        gazeOnPlayers: {
           en: 'Face ${players}',
         },
-        fakeCursedShriekOnPlayers: {
+        fakeGazeOnPlayers: {
           en: 'Look Away from ${players}',
         },
       },
@@ -4726,27 +4731,27 @@ const triggerSet: TriggerSet<Data> = {
         // Seperate configurable output if you have it
         if (shriekPlayers.includes(data.me)) {
           return isTrue
-            ? output.fakeCursedShriekOnYou!({ players: msg })
-            : output.cursedShriekOnYou!({ players: msg });
+            ? output.fakeGazeOnYou!({ players: msg })
+            : output.gazeOnYou!({ players: msg });
         }
         return isTrue
-          ? output.fakeCursedShriekOnPlayers!({ players: msg })
-          : output.cursedShriekOnPlayers!({ players: msg });
+          ? output.fakeGazeOnPlayers!({ players: msg })
+          : output.gazeOnPlayers!({ players: msg });
       },
       outputStrings: {
         you: {
           en: 'YOU',
         },
-        cursedShriekOnPlayers: {
+        gazeOnPlayers: {
           en: 'Face ${players} (later)',
         },
-        fakeCursedShriekOnPlayers: {
+        fakeGazeOnPlayers: {
           en: 'Look Away from ${players} (later)',
         },
-        cursedShriekOnYou: {
+        gazeOnYou: {
           en: 'Face ${players} (later)',
         },
-        fakeCursedShriekOnYou: {
+        fakeGazeOnYou: {
           en: 'Look Away from ${players} (later)',
         },
       },
@@ -4788,17 +4793,17 @@ const triggerSet: TriggerSet<Data> = {
         const msg = players?.join(', ');
 
         return is1stTrue
-          ? output.fakeCursedShriekOnPlayers!({ players: msg })
-          : output.cursedShriekOnPlayers!({ players: msg });
+          ? output.fakeGazeOnPlayers!({ players: msg })
+          : output.gazeOnPlayers!({ players: msg });
       },
       outputStrings: {
         you: {
           en: 'YOU',
         },
-        cursedShriekOnPlayers: {
+        gazeOnPlayers: {
           en: 'Face ${players}',
         },
-        fakeCursedShriekOnPlayers: {
+        fakeGazeOnPlayers: {
           en: 'Look Away from ${players}',
         },
       },
@@ -4879,8 +4884,8 @@ const triggerSet: TriggerSet<Data> = {
         const msg = players?.join(', ');
 
         const gaze = is2ndTrue
-          ? output.fakeCursedShriekOnPlayers!({ players: msg })
-          : output.cursedShriekOnPlayers!({ players: msg });
+          ? output.fakeGazeOnPlayers!({ players: msg })
+          : output.gazeOnPlayers!({ players: msg });
         const hasSpread = (hasFork && isLongTrue) || (hasCompressed && !isLongTrue);
         const hasStack = (hasFork && !isLongTrue) || (hasCompressed && isLongTrue);
 
@@ -4946,10 +4951,10 @@ const triggerSet: TriggerSet<Data> = {
         fakeBomb: {
           en: 'Motion',
         },
-        cursedShriekOnPlayers: {
+        gazeOnPlayers: {
           en: 'Face ${players}',
         },
-        fakeCursedShriekOnPlayers: {
+        fakeGazeOnPlayers: {
           en: 'Look Away from ${players}',
         },
       },
@@ -4977,17 +4982,17 @@ const triggerSet: TriggerSet<Data> = {
         const msg = players?.join(', ');
 
         return is2ndTrue
-          ? output.fakeCursedShriekOnPlayers!({ players: msg })
-          : output.cursedShriekOnPlayers!({ players: msg });
+          ? output.fakeGazeOnPlayers!({ players: msg })
+          : output.gazeOnPlayers!({ players: msg });
       },
       outputStrings: {
         you: {
           en: 'YOU',
         },
-        cursedShriekOnPlayers: {
+        gazeOnPlayers: {
           en: 'Face ${players}',
         },
-        fakeCursedShriekOnPlayers: {
+        fakeGazeOnPlayers: {
           en: 'Look Away from ${players}',
         },
       },


### PR DESCRIPTION
This is a short phase and is mostly debuff vomit.

~~This PR also reduces the Mystery Magic trigger count. Now all the ones with output are 1 trigger so there is less places players have to go to alter the outputs.~~ Reduces output strings for the Mystery Magic triggers. P1 and P4 Ice/Thunder are merged.