### PR TITLE
ci: bump `actions/setup-node` version to avoid regression

### DIFF
--- a/.github/actions/setup-js-env/action.yml
+++ b/.github/actions/setup-js-env/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: actions/setup-node@v6
       with:
-        node-version: '24'
+        node-version: '>=24.18.0'
         cache: 'npm'
         cache-dependency-path: 'package-lock.json'
 

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -8,7 +8,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Force checkout the main repo (base branch) so that repo secrets
           # are not available to unexpected/malicious PR code.


### PR DESCRIPTION
- Require `actions/setup-node` to use Node version >=24.18.0 to avoid a bug introduced in 24.17 (nodejs/node#63989)
- `lint-pr-title` updated to use `actions/checkout@v6` (missed in #1057)