### PR TITLE
ci: update action.yml

### DIFF
--- a/.github/actions/setup-js-env/action.yml
+++ b/.github/actions/setup-js-env/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: actions/setup-node@v6
       with:
-        node-version: '>=24.18.0'
+        node-version: '>=24.18.0 <25'
         cache: 'npm'
         cache-dependency-path: 'package-lock.json'
 

--- a/.github/actions/setup-js-env/action.yml
+++ b/.github/actions/setup-js-env/action.yml
@@ -5,6 +5,9 @@ runs:
   steps:
     - uses: actions/setup-node@v6
       with:
+        # 24.17 has a bug that breaks our workflows
+        # 26 introduces changes that break our workflows
+        # @TODO: remove upper restriction once dependencies no longer fail on 26
         node-version: '>=24.18.0 <25'
         cache: 'npm'
         cache-dependency-path: 'package-lock.json'


### PR DESCRIPTION
Follow-up to #1100 : further restrict Node to the 24 LTS branch.  Node 26 may have breaking changes (cf: https://github.com/OverlayPlugin/cactbot/pull/1100#issuecomment-4861721184).