### PR TITLE
test: Make `compile test` more sane

### DIFF
--- a/test/unittests/compile_test.ts
+++ b/test/unittests/compile_test.ts
@@ -15,26 +15,20 @@ describe('compile test', () => {
   it('npm package should compile successfully', async function() {
     // eslint-disable-next-line @typescript-eslint/no-invalid-this
     this.timeout(30000); // allow a 30s timeout
-    let execError = false;
     let output = '';
+    let exitCode = -1;
     try {
       process.chdir(projectRoot);
       fs.rmSync('dist', { recursive: true, force: true });
-      await exec('npx tsc --declaration', [], {
+      exitCode = await exec('npx tsc --declaration', [], {
         listeners: {
           stdout: (data) => output += data.toString(),
-          stderr: (data) => {
-            execError = true;
-            output += data.toString();
-          },
+          stderr: (data) => output += data.toString(),
         },
       });
-      if (execError)
-        throw output;
     } catch (err) {
       console.error(err);
-      execError = true;
     }
-    assert(execError === false, output);
+    assert(exitCode === 0, output);
   });
 });


### PR DESCRIPTION
`npm@11.18.0` and `npm@12.0.0` include a breaking change (for us) which causes `npx <foo>` to print the remapped node command out to stderr, which triggers the error logic that was originally written for this test.

Instead of treating anything printed to stderr, capture the exit code of the subprocess and treat a non-zero exit code as an error.