### PR TITLE
raidboss: DMU remove unused variables, rename collector

### DIFF
--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -953,8 +953,6 @@ const triggerSet: TriggerSet<Data> = {
       windCrystalNext: false,
       fireElementPlayers: [],
       waterElementPlayers: [],
-      firstBlaster: [],
-      firstBlaster2: [],
       inLine: {},
       hadAccretion: false,
       blackHoleIdDirNums: {},
@@ -1117,7 +1115,7 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'DMU P1 Mystery Magic Collect',
+      id: 'DMU P1 and P4 Mystery Magic Collect',
       type: 'HeadMarker',
       netRegex: {
         id: [


### PR DESCRIPTION
I noticed I missed these lines in the P3/P4 PRs. These changes are minor and don't have an impact on output.