### PR TITLE
raidboss: DMU P3 Tankbuster remove boss outputString

### DIFF
--- a/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
+++ b/ui/raidboss/data/07-dt/ultimate/dancing_mad.ts
@@ -5202,16 +5202,12 @@ const triggerSet: TriggerSet<Data> = {
         // cactbot-builtin-response
         output.responseOutputStrings = {
           avoid: {
-            en: '${boss}${cleaves}',
+            en: '${boss}: ${cleaves}',
             ko: '${boss}: ${cleaves}',
           },
           tankCleaveNearThenSwap: {
-            en: 'Near ${boss}${cleave} => ${swap}',
+            en: 'Near ${boss}: ${cleave} => ${swap}',
             ko: '${boss} 근처: ${cleave} => ${swap}',
-          },
-          boss: {
-            en: '${boss}: ',
-            ko: '${boss}',
           },
           tankCleave: Outputs.tankCleave,
           avoidTankCleaves: Outputs.avoidTankCleaves,
@@ -5221,7 +5217,7 @@ const triggerSet: TriggerSet<Data> = {
         const severity = data.role === 'tank' || data.role === 'healer'
           ? 'alertText'
           : 'infoText';
-        const boss = output.boss!({ boss: matches.source });
+        const boss = matches.source;
 
         if (data.role === 'tank')
           return {


### PR DESCRIPTION
The boss outputString can be replaced with directly referencing the source. The configuration is still there in the main outputStrings.

This also addresses a note in previous PR #1118 about the colon being in different place.