### PR TITLE
raidemulator: fix source name parsing in LineEvent0x17

### DIFF
--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x17.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x17.ts
@@ -19,7 +19,7 @@ export class LineEvent0x17 extends LineEvent implements LineEventSource, LineEve
     super(repo, line, parts);
 
     this.id = parts[fields.sourceId]?.toUpperCase() ?? '';
-    this.name = parts[fields.name] ?? '';
+    this.name = parts[fields.source] ?? '';
     this.abilityId = parseInt(parts[fields.id]?.toUpperCase() ?? '', 16);
     this.abilityName = parts[fields.name] ?? '';
     this.reason = parts[fields.reason] ?? '';


### PR DESCRIPTION
The `name` should be `playerName`, not `AbilityName`.