### PR TITLE
config: Make the config headers sticky

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ quote_type = single
 
 [*.py]
 indent_size = 4
+
+[*.css]
+indent_size = 2

--- a/ui/config/config.css
+++ b/ui/config/config.css
@@ -73,7 +73,7 @@ html {
   grid-template-columns: repeat(1, auto 1fr);
   justify-items: left;
   align-items: center;
-
+  /* sticky top-level headers */
   position: sticky;
   top: 0;
 }

--- a/ui/config/config.css
+++ b/ui/config/config.css
@@ -73,6 +73,7 @@ html {
   grid-template-columns: repeat(1, auto 1fr);
   justify-items: left;
   align-items: center;
+
   /* sticky top-level headers */
   position: sticky;
   top: 0;

--- a/ui/config/config.css
+++ b/ui/config/config.css
@@ -73,6 +73,9 @@ html {
   grid-template-columns: repeat(1, auto 1fr);
   justify-items: left;
   align-items: center;
+
+  position: sticky;
+  top: 0;
 }
 
 .overlay-header::before {


### PR DESCRIPTION
<img width="1326" height="617" alt="image" src="https://github.com/user-attachments/assets/77c6ee3f-4e05-48c2-869e-d639449ac64a" />

Makes the top-level headers sticky so that you can easily see if you're looking at the oopsy section instead of the raidboss section.

Also adds .editorconfig directive for 2-space indentation in CSS files since that seems to be what the files are already using.